### PR TITLE
feat(2024): Add 2024 Monsters

### DIFF
--- a/src/2024/en/5e-SRD-Monsters-New.json
+++ b/src/2024/en/5e-SRD-Monsters-New.json
@@ -1,0 +1,24510 @@
+[
+  {
+    "name": "Aboleth",
+    "size": "Large",
+    "type": "aberration",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 150,
+    "hit_dice": "20d10",
+    "speed": {
+      "walk": "10 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 21,
+    "dexterity": 9,
+    "constitution": 15,
+    "intelligence": 18,
+    "wisdom": 15,
+    "charisma": 18,
+    "perception": 10,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 20
+    },
+    "languages": "Deep Speech; telepathy 120 ft.",
+    "challenge_rating": "10",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The aboleth can breathe air and water."
+      },
+      {
+        "name": "Eldritch Restoration",
+        "desc": "If destroyed, the aboleth gains a new body in 5d10 days, reviving with all its Hit Points in the Far Realm or another location chosen by the GM."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the aboleth fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Mucus Cloud",
+        "desc": "While underwater, the aboleth is surrounded by mucus. Constitution Saving Throw: DC 14, each creature in a 5-foot Emanation originating from the aboleth at the end of the aboleth’s turn. Failure: The target is cursed. Until the curse ends, the target’s skin becomes slimy, the target can breathe air and water, and it can’t regain Hit Points unless it is underwater. While the cursed creature is outside a body of water, the creature takes 6 (1d12) Acid damage at the end of every 10 minutes unless moisture is applied to its skin before those minutes have passed."
+      },
+      {
+        "name": "Probing Telepathy",
+        "desc": "If a creature the aboleth can see communicates telepathically with the aboleth, the aboleth learns the creature’s greatest desires."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The aboleth makes two Tentacle attacks and uses either Consume Memories or Dominate Mind if available."
+      },
+      {
+        "name": "Tentacle",
+        "desc": "Melee Attack Roll: +9, reach 15 ft. Hit: 12 (2d6 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of four tentacles.",
+        "damage_dice": "2d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Consume Memories",
+        "desc": "Intelligence Saving Throw: DC 16, one creature within 30 feet that is Charmed or Grappled by the aboleth. Failure: 10 (3d6) Psychic damage. Success: Half damage. Failure or Success: The aboleth gains the target’s memories if the target is a Humanoid and is reduced to 0 Hit Points by this action.",
+        "damage_dice": "3d6"
+      },
+      {
+        "name": "Dominate Mind (2/Day)",
+        "desc": "Wisdom Saving Throw: DC 16, one creature the aboleth can see within 30 feet. Failure: The target has the Charmed condition until the aboleth dies or is on a different plane of existence from the target. While Charmed, the target acts as an ally to the aboleth and is under its control while within 60 feet of it. In addition, the aboleth and the target can communicate telepathically with each other over any distance. The target repeats the save whenever it takes damage as well as after every 24 hours it spends at least 1 mile away from the aboleth, ending the effect on itself on a success."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Lash",
+        "desc": "The aboleth makes one Tentacle attack."
+      },
+      {
+        "name": "Psychic Drain",
+        "desc": "If the aboleth has at least one creature Charmed or Grappled, it uses Consume Memories and regains 5 (1d10) Hit Points."
+      }
+    ],
+    "index": "aboleth",
+    "url": "/api/2024/monsters/aboleth",
+    "image": "/api/images/monsters/aboleth.png",
+    "hit_points_roll": "20d10 + 40",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 20"
+  },
+  {
+    "name": "Air Elemental",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 90,
+    "hit_dice": "12d10",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "90 ft.",
+      "hover": true
+    },
+    "strength": 14,
+    "dexterity": 20,
+    "constitution": 14,
+    "intelligence": 6,
+    "wisdom": 10,
+    "charisma": 6,
+    "damage_resistances": [
+      "bludgeoning",
+      "lightning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison",
+      "thunder"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "prone",
+      "restrained",
+      "unconscious"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Primordial (Auran)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Air Form",
+        "desc": "The elemental can enter a creature’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The elemental makes two Thunderous Slam attacks."
+      },
+      {
+        "name": "Thunderous Slam",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 14 (2d8 + 5) Thunder damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Whirlwind (Recharge 4–6)",
+        "desc": "Strength Saving Throw: DC 13, one Medium or smaller creature in the elemental’s space. Failure: 24 (4d10 + 2) Thunder damage, and the target is pushed up to 20 feet straight away from the elemental and has the Prone condition. Success: Half damage only. Animated Objects",
+        "damage_dice": "4d10",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "air-elemental",
+    "url": "/api/2024/monsters/air-elemental",
+    "image": "/api/images/monsters/air-elemental.png",
+    "hit_points_roll": "12d10 + 24",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Animated Armor",
+    "size": "Medium",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 33,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "25 ft."
+    },
+    "strength": 14,
+    "dexterity": 11,
+    "constitution": 13,
+    "intelligence": 1,
+    "wisdom": 3,
+    "charisma": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "deafened",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 6
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The armor makes two Slam attacks."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "animated-armor",
+    "url": "/api/2024/monsters/animated-armor",
+    "image": "/api/images/monsters/animated-armor.png",
+    "hit_points_roll": "6d8 + 6",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 6"
+  },
+  {
+    "name": "Animated Flying Sword",
+    "size": "Small",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 14,
+    "hit_dice": "4d6",
+    "speed": {
+      "walk": "5 ft.",
+      "fly": "50 ft.",
+      "hover": true
+    },
+    "strength": 12,
+    "dexterity": 15,
+    "constitution": 11,
+    "intelligence": 1,
+    "wisdom": 5,
+    "charisma": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "deafened",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 7
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Slash",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "animated-flying-sword",
+    "url": "/api/2024/monsters/animated-flying-sword",
+    "image": "/api/images/monsters/animated-flying-sword.png",
+    "hit_points_roll": "4d6",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 7"
+  },
+  {
+    "name": "Animated Rug of Smothering",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 27,
+    "hit_dice": "5d10",
+    "speed": {
+      "walk": "10 ft."
+    },
+    "strength": 17,
+    "dexterity": 14,
+    "constitution": 10,
+    "intelligence": 1,
+    "wisdom": 3,
+    "charisma": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "deafened",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 6
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Smother",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, the rug can give it the Grappled condition (escape DC 13) instead of dealing damage. Until the grapple ends, the target has the Blinded and Restrained conditions, is suffocating, and takes 10 (2d6 + 3) Bludgeoning damage at the start of each of its turns. The rug can smother only one creature at a time. While grappling the target, the rug can’t take this action, the rug halves the damage it takes (round down), and the target takes the same amount of damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "animated-rug-of-smothering",
+    "url": "/api/2024/monsters/animated-rug-of-smothering",
+    "image": "/api/images/monsters/animated-rug-of-smothering.png",
+    "hit_points_roll": "5d10",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 6"
+  },
+  {
+    "name": "Ankheg",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 45,
+    "hit_dice": "6d10",
+    "speed": {
+      "walk": "30 ft.",
+      "burrow": "10 ft."
+    },
+    "strength": 17,
+    "dexterity": 11,
+    "constitution": 14,
+    "intelligence": 1,
+    "wisdom": 13,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft., Tremorsense 60 ft."
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Tunneler",
+        "desc": "The ankheg can burrow through solid rock at half its Burrow Speed and leaves a 10-foot-diameter tunnel in its wake."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the ankheg), reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage plus 3 (1d6) Acid damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13).",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Acid Spray (Recharge 6)",
+        "desc": "Dexterity Saving Throw: DC 12, each creature in a 30-foot-long, 5-foot-wide Line. Failure: 14 (4d6) Acid damage. Success: Half damage.",
+        "damage_dice": "4d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ankheg",
+    "url": "/api/2024/monsters/ankheg",
+    "image": "/api/images/monsters/ankheg.png",
+    "hit_points_roll": "6d10 + 12",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft., Tremorsense 60 ft.;"
+  },
+  {
+    "name": "Assassin",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 97,
+    "hit_dice": "15d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 11,
+    "dexterity": 18,
+    "constitution": 14,
+    "intelligence": 16,
+    "wisdom": 11,
+    "charisma": 10,
+    "perception": 6,
+    "damage_resistances": [
+      "poison"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 16
+    },
+    "languages": "Common, Thieves’ Cant",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Evasion",
+        "desc": "If the assassin is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the assassin instead takes no damage if it succeeds on the save and only half damage if it fails. It can’t use this trait if it has the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The assassin makes three attacks, using Shortsword or Light Crossbow in any combination."
+      },
+      {
+        "name": "Shortsword",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 7 (1d6 + 4) Piercing damage plus 17 (5d6) Poison damage, and the target has the Poisoned condition until the start of the assassin’s next turn.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Light Crossbow",
+        "desc": "Ranged Attack Roll: +7, range 80/320 ft. Hit: 8 (1d8 + 4) Piercing damage plus 21 (6d6) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Cunning Action",
+        "desc": "The assassin takes the Dash, Disengage, or Hide action. Awakened Plants"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "assassin",
+    "url": "/api/2024/monsters/assassin",
+    "image": "/api/images/monsters/assassin.png",
+    "hit_points_roll": "15d8 + 30",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 16"
+  },
+  {
+    "name": "Awakened Shrub",
+    "size": "Small",
+    "type": "plant",
+    "alignment": "neutral",
+    "armor_class": 9,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 10,
+    "hit_dice": "3d6",
+    "speed": {
+      "walk": "20 ft."
+    },
+    "strength": 3,
+    "dexterity": 8,
+    "constitution": 11,
+    "intelligence": 10,
+    "wisdom": 10,
+    "charisma": 6,
+    "damage_resistances": [
+      "piercing"
+    ],
+    "damage_vulnerabilities": [
+      "fire"
+    ],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rake",
+        "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 Slashing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "awakened-shrub",
+    "url": "/api/2024/monsters/awakened-shrub",
+    "image": "/api/images/monsters/awakened-shrub.png",
+    "hit_points_roll": "3d6",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Awakened Tree",
+    "size": "Huge",
+    "type": "plant",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 59,
+    "hit_dice": "7d12",
+    "speed": {
+      "walk": "20 ft."
+    },
+    "strength": 19,
+    "dexterity": 6,
+    "constitution": 15,
+    "intelligence": 10,
+    "wisdom": 10,
+    "charisma": 7,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing"
+    ],
+    "damage_vulnerabilities": [
+      "fire"
+    ],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 14 (3d6 + 4) Bludgeoning damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "awakened-tree",
+    "url": "/api/2024/monsters/awakened-tree",
+    "image": "/api/images/monsters/awakened-tree.png",
+    "hit_points_roll": "7d12 + 14",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Axe Beak",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 14,
+    "dexterity": 12,
+    "constitution": 12,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage. Azer",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "axe-beak",
+    "url": "/api/2024/monsters/axe-beak",
+    "image": "/api/images/monsters/axe-beak.png",
+    "hit_points_roll": "3d10 + 3",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Azer Sentinel",
+    "size": "Medium",
+    "type": "elemental",
+    "alignment": "lawful neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 39,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 17,
+    "dexterity": 12,
+    "constitution": 15,
+    "intelligence": 12,
+    "wisdom": 13,
+    "charisma": 10,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "passive_perception": 11
+    },
+    "languages": "Primordial (Ignan)",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Fire Aura",
+        "desc": "At the end of each of the azer’s turns, each creature of the azer’s choice in a 5-foot Emanation originating from the azer takes 5 (1d10) Fire damage unless the azer has the Incapacitated condition."
+      },
+      {
+        "name": "Illumination",
+        "desc": "The azer sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Burning Hammer",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Bludgeoning damage plus 3 (1d6) Fire damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "azer-sentinel",
+    "url": "/api/2024/monsters/azer-sentinel",
+    "image": "/api/images/monsters/azer-sentinel.png",
+    "hit_points_roll": "6d8 + 12",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 11"
+  },
+  {
+    "name": "Balor",
+    "size": "Huge",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 287,
+    "hit_dice": "23d12",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 26,
+    "dexterity": 15,
+    "constitution": 22,
+    "intelligence": 20,
+    "wisdom": 16,
+    "charisma": 22,
+    "perception": 9,
+    "damage_resistances": [
+      "cold",
+      "lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "frightened",
+      "poisoned"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 19
+    },
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "19",
+    "special_abilities": [
+      {
+        "name": "Death Throes",
+        "desc": "The balor explodes when it dies. Dexterity Saving Throw: DC 20, each creature in a 30-foot"
+      },
+      {
+        "name": "Emanation originating from the balor",
+        "desc": "Failure: 31 (9d6) Fire damage plus 31 (9d6) Force damage. Success: Half damage. Failure or Success: If the balor dies outside the Abyss, it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Fire Aura",
+        "desc": "At the end of each of the balor’s turns, each creature in a 5-foot Emanation originating from the balor takes 13 (3d8) Fire damage."
+      },
+      {
+        "name": "Legendary Resistance (3/Day)",
+        "desc": "If the balor fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The balor has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The balor makes one Flame Whip attack and one Lightning Blade attack."
+      },
+      {
+        "name": "Flame Whip",
+        "desc": "Melee Attack Roll: +14, reach 30 ft. Hit: 18 (3d6 + 8) Force damage plus 17 (5d6) Fire damage. If the target is a Huge or smaller creature, the balor pulls the target up to 25 feet straight toward itself, and the target has the Prone condition.",
+        "damage_dice": "3d6",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Lightning Blade",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 21 (3d8 + 8) Force damage plus 22 (4d10) Lightning damage, and the target can’t take Reactions until the start of the balor’s next turn.",
+        "damage_dice": "3d8",
+        "damage_bonus": 8
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Teleport",
+        "desc": "The balor teleports itself or a willing demon within 10 feet of itself up to 60 feet to an unoccupied space the balor can see. Bandits"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "balor",
+    "url": "/api/2024/monsters/balor",
+    "image": "/api/images/monsters/balor.png",
+    "hit_points_roll": "23d12 + 138",
+    "proficiencies": [
+      {
+        "value": 12,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 19"
+  },
+  {
+    "name": "Bandit",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 11,
+    "dexterity": 12,
+    "constitution": 12,
+    "intelligence": 10,
+    "wisdom": 10,
+    "charisma": 10,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common, Thieves’ Cant",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Scimitar",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Light Crossbow",
+        "desc": "Ranged Attack Roll: +3, range 80/320 ft. Hit: 5 (1d8 + 1) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "bandit",
+    "url": "/api/2024/monsters/bandit",
+    "image": "/api/images/monsters/bandit.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Bandit Captain",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 52,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 16,
+    "constitution": 14,
+    "intelligence": 14,
+    "wisdom": 11,
+    "charisma": 14,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common, Thieves’ Cant",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bandit makes two attacks, using Scimitar and Pistol in any combination."
+      },
+      {
+        "name": "Scimitar",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Pistol",
+        "desc": "Ranged Attack Roll: +5, range 30/90 ft. Hit: 8 (1d10 + 3) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The bandit is hit by a melee attack roll while holding a weapon. Response: The bandit adds 2 to its AC against that attack, possibly causing it to miss."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "bandit-captain",
+    "url": "/api/2024/monsters/bandit-captain",
+    "image": "/api/images/monsters/bandit-captain.png",
+    "hit_points_roll": "8d8 + 16",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Barbed Devil",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 110,
+    "hit_dice": "13d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 17,
+    "constitution": 18,
+    "intelligence": 12,
+    "wisdom": 14,
+    "charisma": 14,
+    "perception": 8,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft. (unimpeded by magical"
+    },
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Barbed Hide",
+        "desc": "At the start of each of its turns, the devil deals 5 (1d10) Piercing damage to any creature it is grappling or any creature grappling it."
+      },
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes one Claws attack and one Tail attack, or it makes two Hurl Flame attacks."
+      },
+      {
+        "name": "Claws",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13) from both claws.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 14 (2d10 + 3) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Hurl Flame",
+        "desc": "Ranged Attack Roll: +5, range 150 ft. Hit: 17 (5d6) Fire damage. If the target is a flammable object that isn’t being worn or carried, it starts burning.",
+        "damage_dice": "5d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "barbed-devil",
+    "url": "/api/2024/monsters/barbed-devil",
+    "image": "/api/images/monsters/barbed-devil.png",
+    "hit_points_roll": "13d8 + 52",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft. (unimpeded by magical"
+  },
+  {
+    "name": "Basilisk",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 52,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "20 ft."
+    },
+    "strength": 16,
+    "dexterity": 8,
+    "constitution": 15,
+    "intelligence": 2,
+    "wisdom": 8,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Petrifying Gaze (Recharge 4–6)",
+        "desc": "Constitution Saving Throw: DC 12, each creature in a 30-foot Cone. If the basilisk sees its reflection in the Cone, the basilisk must make this save. First Failure: The target has the Restrained condition and repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition instead of the Restrained condition."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "basilisk",
+    "url": "/api/2024/monsters/basilisk",
+    "image": "/api/images/monsters/basilisk.png",
+    "hit_points_roll": "8d8 + 16",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Bearded Devil",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 58,
+    "hit_dice": "9d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 15,
+    "constitution": 15,
+    "intelligence": 9,
+    "wisdom": 11,
+    "charisma": 14,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "frightened",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft. (unimpeded by magical"
+    },
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes one Beard attack and one Infernal Glaive attack."
+      },
+      {
+        "name": "Beard",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage, and the target has the Poisoned condition until the start of the devil’s next turn. Until this poison ends, the target can’t regain Hit Points.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Infernal Glaive",
+        "desc": "Melee Attack Roll: +5, reach 10 ft. Hit: 8 (1d10 + 3) Slashing damage. If the target is a creature and doesn’t already have an infernal wound, it is subjected to the following effect. Constitution Saving Throw: DC 12. Failure: The target receives an infernal wound. While wounded, the target loses 5 (1d10) Hit",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Points at the start of each of its turns",
+        "desc": "The wound closes after 1 minute, after a spell restores Hit Points to the target, or after the target or a creature within 5 feet of it takes an action to stanch the wound, doing so by succeeding on a DC 12 Wisdom (Medicine) check."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "bearded-devil",
+    "url": "/api/2024/monsters/bearded-devil",
+    "image": "/api/images/monsters/bearded-devil.png",
+    "hit_points_roll": "9d8 + 18",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft. (unimpeded by magical"
+  },
+  {
+    "name": "Behir",
+    "size": "Huge",
+    "type": "monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 168,
+    "hit_dice": "16d12",
+    "speed": {
+      "walk": "50 ft.",
+      "climb": "50 ft."
+    },
+    "strength": 23,
+    "dexterity": 16,
+    "constitution": 18,
+    "intelligence": 7,
+    "wisdom": 14,
+    "charisma": 12,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "90 ft.",
+      "passive_perception": 16
+    },
+    "languages": "Draconic",
+    "challenge_rating": "11",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The behir makes one Bite attack and uses Constrict."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 19 (2d12 + 6) Piercing damage plus 11 (2d10) Lightning damage.",
+        "damage_dice": "2d12",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 18, one Large or smaller creature the behir can see within 5 feet. Failure: 28 (5d8 + 6) Bludgeoning damage. The target has the Grappled condition (escape DC 16), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "5d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 16, each creature in a 90-foot-long, 5-footwide Line. Failure: 66 (12d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "12d10"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Swallow",
+        "desc": "Dexterity Saving Throw: DC 18, one Large or smaller creature Grappled by the behir (the behir can have only one creature swallowed at a time). Failure: The behir swallows the target, which is no longer Grappled. While swallowed, a creature has the Blinded and Restrained conditions, has Total Cover against attacks and other effects outside the behir, and takes 21 (6d6) Acid damage at the start of each of the behir’s turns. If the behir takes 30 damage or more on a single turn from the swallowed creature, the behir must succeed on a DC 14 Constitution saving throw at the end of that turn or regurgitate the creature, which falls in a space within 10 feet of the behir and has the Prone condition. If the behir dies, a swallowed creature is no longer Restrained and can escape from the corpse by using 15 feet of movement, exiting Prone."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "behir",
+    "url": "/api/2024/monsters/behir",
+    "image": "/api/images/monsters/behir.png",
+    "hit_points_roll": "16d12 + 64",
+    "proficiencies": [],
+    "old_senses": "Darkvision 90 ft.; Passive Perception 16"
+  },
+  {
+    "name": "Berserker",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 67,
+    "hit_dice": "9d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 12,
+    "constitution": 17,
+    "intelligence": 9,
+    "wisdom": 11,
+    "charisma": 9,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Bloodied Frenzy",
+        "desc": "While Bloodied, the berserker has Advantage on attack rolls and saving throws."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Greataxe",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 9 (1d12 + 3) Slashing damage. Black Dragons",
+        "damage_dice": "1d12",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "berserker",
+    "url": "/api/2024/monsters/berserker",
+    "image": "/api/images/monsters/berserker.png",
+    "hit_points_roll": "9d8 + 27",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Black Dragon Wyrmling",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 33,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 14,
+    "constitution": 13,
+    "intelligence": 10,
+    "wisdom": 11,
+    "charisma": 13,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Draconic",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage plus 2 (1d4) Acid damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 11, each creature in a 15-foot-long, 5-footwide Line. Failure: 22 (5d8) Acid damage. Success: Half damage.",
+        "damage_dice": "5d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "black-dragon-wyrmling",
+    "url": "/api/2024/monsters/black-dragon-wyrmling",
+    "image": "/api/images/monsters/black-dragon-wyrmling.png",
+    "hit_points_roll": "6d8 + 6",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Young Black Dragon",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 127,
+    "hit_dice": "15d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 19,
+    "dexterity": 14,
+    "constitution": 17,
+    "intelligence": 12,
+    "wisdom": 11,
+    "charisma": 15,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "7",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 9 (2d4 + 4) Slashing damage plus 3 (1d6) Acid damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 14, each creature in a 30-foot-long, 5-footwide Line. Failure: 49 (14d6) Acid damage. Success: Half damage.",
+        "damage_dice": "14d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "young-black-dragon",
+    "url": "/api/2024/monsters/young-black-dragon",
+    "image": "/api/images/monsters/young-black-dragon.png",
+    "hit_points_roll": "15d10 + 45",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Adult Black Dragon",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 12,
+    "hit_points": 195,
+    "hit_dice": "17d12",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 23,
+    "dexterity": 14,
+    "constitution": 21,
+    "intelligence": 14,
+    "wisdom": 13,
+    "charisma": 19,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "14",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Acid Arrow (level 3 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 4 (1d8) Acid damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 18, each creature in a 60-foot-long, 5-footwide Line. Failure: 54 (12d8) Acid damage. Success: Half damage.",
+        "damage_dice": "12d8"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17, +9 to hit with spell attacks):",
+        "attack_bonus": 9
+      },
+      {
+        "name": "At Will",
+        "desc": "Acid Arrow (level 3 version), Detect Magic, Fear"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Speak with Dead, Vitriolic Sphere"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Cloud of Insects",
+        "desc": "Dexterity Saving Throw: DC 17, one creature the dragon can see within 120 feet. Failure: 22 (4d10) Poison damage, and the target has Disadvantage on saving throws to maintain Concentration until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "4d10"
+      },
+      {
+        "name": "Frightful Presence",
+        "desc": "The dragon uses Spellcasting to cast"
+      },
+      {
+        "name": "Fear",
+        "desc": "The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "adult-black-dragon",
+    "url": "/api/2024/monsters/adult-black-dragon",
+    "image": "/api/images/monsters/adult-black-dragon.png",
+    "hit_points_roll": "17d12 + 85",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Ancient Black Dragon",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 16,
+    "hit_points": 367,
+    "hit_dice": "21d20",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 27,
+    "dexterity": 14,
+    "constitution": 25,
+    "intelligence": 16,
+    "wisdom": 15,
+    "charisma": 22,
+    "perception": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "21",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Acid Arrow (level 4 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +15, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 9 (2d8) Acid damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 22, each creature in a 90-foot-long, 10-footwide Line. Failure: 67 (15d8) Acid damage. Success: Half damage.",
+        "damage_dice": "15d8"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks):",
+        "attack_bonus": 13
+      },
+      {
+        "name": "At Will",
+        "desc": "Acid Arrow (level 4 version), Detect Magic, Fear"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Create Undead, Speak with Dead, Vitriolic Sphere (level 5 version)"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Cloud of Insects",
+        "desc": "Dexterity Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 33 (6d10) Poison damage, and the target has Disadvantage on saving throws to maintain Concentration until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "6d10"
+      },
+      {
+        "name": "Frightful Presence",
+        "desc": "The dragon uses Spellcasting to cast"
+      },
+      {
+        "name": "Fear",
+        "desc": "The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "ancient-black-dragon",
+    "url": "/api/2024/monsters/ancient-black-dragon",
+    "image": "/api/images/monsters/ancient-black-dragon.png",
+    "hit_points_roll": "21d20 + 147",
+    "proficiencies": [
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Black Pudding",
+    "size": "Large",
+    "type": "ooze",
+    "alignment": "unaligned",
+    "armor_class": 7,
+    "armor_desc": "",
+    "initiative": -3,
+    "hit_points": 68,
+    "hit_dice": "8d10",
+    "speed": {
+      "walk": "20 ft.",
+      "climb": "20 ft."
+    },
+    "strength": 16,
+    "dexterity": 5,
+    "constitution": 16,
+    "intelligence": 1,
+    "wisdom": 6,
+    "charisma": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid",
+      "cold",
+      "lightning",
+      "slashing"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "deafened",
+      "exhaustion",
+      "frightened",
+      "grappled",
+      "prone",
+      "restrained"
+    ],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 8
+    },
+    "languages": "None",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Amorphous",
+        "desc": "The pudding can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Corrosive Form",
+        "desc": "A creature that hits the pudding with a melee attack roll takes 4 (1d8) Acid damage. Nonmagical ammunition is destroyed immediately after hitting the pudding and dealing any damage. Any nonmagical weapon takes a cumulative −1 penalty to attack rolls immediately after dealing damage to the pudding and coming into contact with it. The weapon is destroyed if the penalty reaches −5. The penalty can be removed by casting the Mending spell on the weapon. In 1 minute, the pudding can eat through 2 feet of nonmagical wood or metal."
+      },
+      {
+        "name": "Spider Climb",
+        "desc": "The pudding can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Dissolving Pseudopod",
+        "desc": "Melee Attack Roll: +5, reach 10 ft. Hit: 17 (4d6 + 3) Acid damage. Nonmagical armor worn by the target takes a −1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10. The penalty can be removed by casting the Mending spell on the armor.",
+        "damage_dice": "4d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Split",
+        "desc": "Trigger: While the pudding is Large or Medium and has 10+ Hit Points, it becomes Bloodied or is subjected to Lightning or Slashing damage. Response: The pudding splits into two new Black Puddings. Each new pudding is one size smaller than the original pudding and acts on its Initiative. The original pudding’s Hit Points are divided evenly between the new puddings (round down)."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "black-pudding",
+    "url": "/api/2024/monsters/black-pudding",
+    "image": "/api/images/monsters/black-pudding.png",
+    "hit_points_roll": "8d10 + 24",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Blink Dog",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "lawful good",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 22,
+    "hit_dice": "4d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 12,
+    "dexterity": 17,
+    "constitution": 12,
+    "intelligence": 10,
+    "wisdom": 13,
+    "charisma": 11,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "Blink Dog; understands Elvish and Sylvan but",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Teleport (Recharge 4–6)",
+        "desc": "The dog teleports up to 40 feet to an unoccupied space it can see. Blue Dragons"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "blink-dog",
+    "url": "/api/2024/monsters/blink-dog",
+    "image": "/api/images/monsters/blink-dog.png",
+    "hit_points_roll": "4d8 + 4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Blue Dragon Wyrmling",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 65,
+    "hit_dice": "10d8",
+    "speed": {
+      "walk": "30 ft.",
+      "burrow": "15 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 17,
+    "dexterity": 10,
+    "constitution": 15,
+    "intelligence": 12,
+    "wisdom": 11,
+    "charisma": 15,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Draconic",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage plus 3 (1d6) Lightning damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 12, each creature in a 30-foot-long, 5-footwide Line. Failure: 21 (6d6) Lightning damage. Success: Half damage.",
+        "damage_dice": "6d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "blue-dragon-wyrmling",
+    "url": "/api/2024/monsters/blue-dragon-wyrmling",
+    "image": "/api/images/monsters/blue-dragon-wyrmling.png",
+    "hit_points_roll": "10d8 + 20",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Young Blue Dragon",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 152,
+    "hit_dice": "16d10",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "20 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 21,
+    "dexterity": 10,
+    "constitution": 19,
+    "intelligence": 14,
+    "wisdom": 13,
+    "charisma": 17,
+    "perception": 9,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "9",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 12 (2d6 + 5) Slashing damage plus 5 (1d10) Lightning damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 16, each creature in a 60-foot-long, 5-footwide Line. Failure: 55 (10d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "10d10"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "young-blue-dragon",
+    "url": "/api/2024/monsters/young-blue-dragon",
+    "image": "/api/images/monsters/young-blue-dragon.png",
+    "hit_points_roll": "16d10 + 64",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Adult Blue Dragon",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 212,
+    "hit_dice": "17d12",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "30 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 25,
+    "dexterity": 10,
+    "constitution": 23,
+    "intelligence": 16,
+    "wisdom": 15,
+    "charisma": 20,
+    "perception": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "16",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Shatter."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 16 (2d8 + 7) Slashing damage plus 5 (1d10) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 19, each creature in a 90-foot-long, 5-footwide Line. Failure: 60 (11d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "11d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Invisibility, Mage Hand, Shatter"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Scrying, Sending"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Cloaked Flight",
+        "desc": "The dragon uses Spellcasting to cast Invisibility on itself, and it can fly up to half its Fly Speed. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Sonic Boom",
+        "desc": "The dragon uses Spellcasting to cast Shatter. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Tail Swipe",
+        "desc": "The dragon makes one Rend attack."
+      }
+    ],
+    "index": "adult-blue-dragon",
+    "url": "/api/2024/monsters/adult-blue-dragon",
+    "image": "/api/images/monsters/adult-blue-dragon.png",
+    "hit_points_roll": "17d12 + 102",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Ancient Blue Dragon",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 481,
+    "hit_dice": "26d20",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 29,
+    "dexterity": 10,
+    "constitution": 27,
+    "intelligence": 18,
+    "wisdom": 17,
+    "charisma": 25,
+    "perception": 17,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "23",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Shatter (level 3 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +16, reach 15 ft. Hit: 18 (2d8 + 9) Slashing damage plus 11 (2d10) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 23, each creature in a 120-foot-long, 10-foot-wide Line. Failure: 88 (16d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "16d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Invisibility, Mage Hand, Shatter (level 3 version)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Scrying, Sending"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Cloaked Flight",
+        "desc": "The dragon uses Spellcasting to cast Invisibility on itself, and it can fly up to half its Fly Speed. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Sonic Boom",
+        "desc": "The dragon uses Spellcasting to cast Shatter (level 3 version). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Tail Swipe",
+        "desc": "The dragon makes one Rend attack."
+      }
+    ],
+    "index": "ancient-blue-dragon",
+    "url": "/api/2024/monsters/ancient-blue-dragon",
+    "image": "/api/images/monsters/ancient-blue-dragon.png",
+    "hit_points_roll": "26d20 + 208",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Bone Devil",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 161,
+    "hit_dice": "17d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 16,
+    "constitution": 18,
+    "intelligence": 13,
+    "wisdom": 14,
+    "charisma": 16,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft. (unimpeded by magical"
+    },
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "9",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes two Claw attacks and one Infernal Sting attack."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 13 (2d8 + 4) Slashing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Infernal Sting",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 15 (2d10 + 4) Piercing damage plus 18 (4d8) Poison damage, and the target has the Poisoned condition until the start of the devil’s next turn. While Poisoned, the target can’t regain Hit Points. Brass Dragons",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "bone-devil",
+    "url": "/api/2024/monsters/bone-devil",
+    "image": "/api/images/monsters/bone-devil.png",
+    "hit_points_roll": "17d10 + 68",
+    "proficiencies": [
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft. (unimpeded by magical"
+  },
+  {
+    "name": "Brass Dragon Wyrmling",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "4d8",
+    "speed": {
+      "walk": "30 ft.",
+      "burrow": "15 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 15,
+    "dexterity": 10,
+    "constitution": 13,
+    "intelligence": 10,
+    "wisdom": 11,
+    "charisma": 13,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Draconic",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 11, each creature in a 20-foot-long, 5-footwide Line. Failure: 14 (4d6) Fire damage. Success: Half damage.",
+        "damage_dice": "4d6"
+      },
+      {
+        "name": "Sleep Breath",
+        "desc": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 1 minute. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "brass-dragon-wyrmling",
+    "url": "/api/2024/monsters/brass-dragon-wyrmling",
+    "image": "/api/images/monsters/brass-dragon-wyrmling.png",
+    "hit_points_roll": "4d8 + 4",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Young Brass Dragon",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 110,
+    "hit_dice": "13d10",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "20 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 19,
+    "dexterity": 10,
+    "constitution": 17,
+    "intelligence": 12,
+    "wisdom": 11,
+    "charisma": 15,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace two attacks with a use of Sleep Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 15 (2d10 + 4) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 14, each creature in a 40-foot-long, 5-footwide Line. Failure: 38 (11d6) Fire damage. Success: Half damage.",
+        "damage_dice": "11d6"
+      },
+      {
+        "name": "Sleep Breath",
+        "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 1 minute. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "young-brass-dragon",
+    "url": "/api/2024/monsters/young-brass-dragon",
+    "image": "/api/images/monsters/young-brass-dragon.png",
+    "hit_points_roll": "13d10 + 39",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Adult Brass Dragon",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 172,
+    "hit_dice": "15d12",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "30 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 23,
+    "dexterity": 10,
+    "constitution": 21,
+    "intelligence": 14,
+    "wisdom": 13,
+    "charisma": 17,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Sleep Breath or (B) Spellcasting to cast Scorching Ray."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage plus 4 (1d8) Fire damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 18, each creature in a 60-foot-long, 5-footwide Line. Failure: 45 (10d8) Fire damage. Success: Half damage.",
+        "damage_dice": "10d8"
+      },
+      {
+        "name": "Sleep Breath",
+        "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 10 minutes. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Minor Illusion, Scorching Ray, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Detect Thoughts, Control Weather"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Blazing Light",
+        "desc": "The dragon uses Spellcasting to cast Scorching Ray."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      },
+      {
+        "name": "Scorching Sands",
+        "desc": "Dexterity Saving Throw: DC 16, one creature the dragon can see within 120 feet. Failure: 27 (6d8) Fire damage, and the target’s Speed is halved until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "6d8"
+      }
+    ],
+    "index": "adult-brass-dragon",
+    "url": "/api/2024/monsters/adult-brass-dragon",
+    "image": "/api/images/monsters/adult-brass-dragon.png",
+    "hit_points_roll": "15d12 + 75",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Ancient Brass Dragon",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 12,
+    "hit_points": 332,
+    "hit_dice": "19d20",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 27,
+    "dexterity": 10,
+    "constitution": 25,
+    "intelligence": 16,
+    "wisdom": 15,
+    "charisma": 22,
+    "perception": 14,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "20",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Sleep Breath or (B) Spellcasting to cast Scorching Ray (level 3 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +14, reach 15 ft. Hit: 19 (2d10 + 8) Slashing damage plus 7 (2d6) Fire damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 21, each creature in a 90-foot-long, 5-footwide Line. Failure: 58 (13d8) Fire damage. Success: Half damage.",
+        "damage_dice": "13d8"
+      },
+      {
+        "name": "Sleep Breath",
+        "desc": "Constitution Saving Throw: DC 21, each creature in a 90-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 10 minutes. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Minor Illusion, Scorching Ray (level 3 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Control Weather, Detect Thoughts"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Blazing Light",
+        "desc": "The dragon uses Spellcasting to cast Scorching Ray (level 3 version)."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      },
+      {
+        "name": "Scorching Sands",
+        "desc": "Dexterity Saving Throw: DC 20, one creature the dragon can see within 120 feet. Failure: 36 (8d8) Fire damage, and the target’s Speed is halved until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn. Bronze Dragons",
+        "damage_dice": "8d8"
+      }
+    ],
+    "index": "ancient-brass-dragon",
+    "url": "/api/2024/monsters/ancient-brass-dragon",
+    "image": "/api/images/monsters/ancient-brass-dragon.png",
+    "hit_points_roll": "19d20 + 133",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Bronze Dragon Wyrmling",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 39,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 17,
+    "dexterity": 10,
+    "constitution": 15,
+    "intelligence": 12,
+    "wisdom": 11,
+    "charisma": 15,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Draconic",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 12, each creature in a 40-foot-long, 5-footwide Line. Failure: 16 (3d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "3d10"
+      },
+      {
+        "name": "Repulsion Breath",
+        "desc": "Strength Saving Throw: DC 12, each creature in a 30-foot Cone. Failure: The target is pushed up to 30 feet straight away from the dragon and has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "bronze-dragon-wyrmling",
+    "url": "/api/2024/monsters/bronze-dragon-wyrmling",
+    "image": "/api/images/monsters/bronze-dragon-wyrmling.png",
+    "hit_points_roll": "6d8 + 12",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Young Bronze Dragon",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 142,
+    "hit_dice": "15d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 21,
+    "dexterity": 10,
+    "constitution": 19,
+    "intelligence": 14,
+    "wisdom": 13,
+    "charisma": 17,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Repulsion Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 15, each creature in a 60-foot-long, 5-footwide Line. Failure: 49 (9d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "9d10"
+      },
+      {
+        "name": "Repulsion Breath",
+        "desc": "Strength Saving Throw: DC 15, each creature in a 30-foot Cone. Failure: The target is pushed up to 40 feet straight away from the dragon and has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "young-bronze-dragon",
+    "url": "/api/2024/monsters/young-bronze-dragon",
+    "image": "/api/images/monsters/young-bronze-dragon.png",
+    "hit_points_roll": "15d10 + 60",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Adult Bronze Dragon",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 212,
+    "hit_dice": "17d12",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 25,
+    "dexterity": 10,
+    "constitution": 23,
+    "intelligence": 16,
+    "wisdom": 15,
+    "charisma": 20,
+    "perception": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "15",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Repulsion Breath or (B) Spellcasting to cast Guiding Bolt (level 2 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 16 (2d8 + 7) Slashing damage plus 5 (1d10) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 19, each creature in a 90-foot-long, 5-footwide Line. Failure: 55 (10d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "10d10"
+      },
+      {
+        "name": "Repulsion Breath",
+        "desc": "Strength Saving Throw: DC 19, each creature in a 30-foot Cone. Failure: The target is pushed up to 60 feet straight away from the dragon and has the Prone condition."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17, +10 to hit with spell attacks):",
+        "attack_bonus": 10
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals, Thaumaturgy"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Detect Thoughts, Water Breathing"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Guiding Light",
+        "desc": "The dragon uses Spellcasting to cast Guiding Bolt (level 2 version)."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      },
+      {
+        "name": "Thunderclap",
+        "desc": "Constitution Saving Throw: DC 17, each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 10 (3d6) Thunder damage, and the target has the Deafened condition until the end of its next turn.",
+        "damage_dice": "3d6"
+      }
+    ],
+    "index": "adult-bronze-dragon",
+    "url": "/api/2024/monsters/adult-bronze-dragon",
+    "image": "/api/images/monsters/adult-bronze-dragon.png",
+    "hit_points_roll": "17d12 + 102",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Ancient Bronze Dragon",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 444,
+    "hit_dice": "24d20",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 29,
+    "dexterity": 10,
+    "constitution": 27,
+    "intelligence": 18,
+    "wisdom": 17,
+    "charisma": 25,
+    "perception": 17,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "22",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Repulsion Breath or (B) Spellcasting to cast Guiding Bolt (level 2 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +16, reach 15 ft. Hit: 18 (2d8 + 9) Slashing damage plus 9 (2d8) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 23, each creature in a 120-foot-long, 10-foot-wide Line. Failure: 82 (15d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "15d10"
+      },
+      {
+        "name": "Repulsion Breath",
+        "desc": "Strength Saving Throw: DC 23, each creature in a 30-foot Cone. Failure: The target is pushed up to 60 feet straight away from the dragon and has the Prone condition."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22, +14 to hit with spell attacks):",
+        "attack_bonus": 14
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals, Thaumaturgy"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Detect Thoughts, Control Water, Scrying, Water Breathing"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Guiding Light",
+        "desc": "The dragon uses Spellcasting to cast Guiding Bolt (level 2 version)."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      },
+      {
+        "name": "Thunderclap",
+        "desc": "Constitution Saving Throw: DC 22, each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 13 (3d8) Thunder damage, and the target has the Deafened condition until the end of its next turn. Bugbears",
+        "damage_dice": "3d8"
+      }
+    ],
+    "index": "ancient-bronze-dragon",
+    "url": "/api/2024/monsters/ancient-bronze-dragon",
+    "image": "/api/images/monsters/ancient-bronze-dragon.png",
+    "hit_points_roll": "24d20 + 192",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Bugbear Stalker",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 65,
+    "hit_dice": "10d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 17,
+    "dexterity": 14,
+    "constitution": 14,
+    "intelligence": 11,
+    "wisdom": 12,
+    "charisma": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Common, Goblin",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Abduct",
+        "desc": "The bugbear needn’t spend extra movement to move a creature it is grappling."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bugbear makes two Javelin or Morningstar attacks."
+      },
+      {
+        "name": "Javelin",
+        "desc": "Melee or Ranged Attack Roll: +5, reach 10 ft. or range 30/120 ft. Hit: 13 (3d6 + 3) Piercing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Morningstar",
+        "desc": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the bugbear), reach 10 ft. Hit: 12 (2d8 + 3) Piercing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Quick Grapple",
+        "desc": "Dexterity Saving Throw: DC 13, one Medium or smaller creature the bugbear can see within 10 feet. Failure: The target has the Grappled condition (escape DC 13)."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "bugbear-stalker",
+    "url": "/api/2024/monsters/bugbear-stalker",
+    "image": "/api/images/monsters/bugbear-stalker.png",
+    "hit_points_roll": "10d8 + 20",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Bugbear Warrior",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "chaotic evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 33,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 14,
+    "constitution": 13,
+    "intelligence": 8,
+    "wisdom": 11,
+    "charisma": 9,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Common, Goblin",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Abduct",
+        "desc": "The bugbear needn’t spend extra movement to move a creature it is grappling."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Grab",
+        "desc": "Melee Attack Roll: +4, reach 10 ft. Hit: 9 (2d6 + 2) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12).",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Light Hammer",
+        "desc": "Melee or Ranged Attack Roll: +4 (with Advantage if the target is Grappled by the bugbear), reach 10 ft. or range 20/60 ft. Hit: 9 (3d4 + 2) Bludgeoning damage.",
+        "damage_dice": "3d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "bugbear-warrior",
+    "url": "/api/2024/monsters/bugbear-warrior",
+    "image": "/api/images/monsters/bugbear-warrior.png",
+    "hit_points_roll": "6d8 + 6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Bulette",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 94,
+    "hit_dice": "9d10",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "40 ft."
+    },
+    "strength": 19,
+    "dexterity": 11,
+    "constitution": 21,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 5,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "tremorsense": "120 ft."
+    },
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bulette makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 17 (2d12 + 4) Piercing damage.",
+        "damage_dice": "2d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Deadly Leap",
+        "desc": "The bulette spends 5 feet of movement to jump to a space within 15 feet that contains one or more Large or smaller creatures. Dexterity Saving Throw: DC 15, each creature in the bulette’s destination space. Failure: 19 (3d12) Bludgeoning damage, and the target has the Prone condition. Success: Half damage, and the target is pushed 5 feet straight away from the bulette.",
+        "damage_dice": "3d12"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Leap",
+        "desc": "The bulette jumps up to 30 feet by spending 10 feet of movement. Centaur"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "bulette",
+    "url": "/api/2024/monsters/bulette",
+    "image": "/api/images/monsters/bulette.png",
+    "hit_points_roll": "9d10 + 45",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Tremorsense 120 ft.;"
+  },
+  {
+    "name": "Centaur Trooper",
+    "size": "Large",
+    "type": "fey",
+    "alignment": "neutral good",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 45,
+    "hit_dice": "6d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 18,
+    "dexterity": 14,
+    "constitution": 14,
+    "intelligence": 9,
+    "wisdom": 13,
+    "charisma": 11,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 13
+    },
+    "languages": "Elvish, Sylvan",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The centaur makes two attacks, using Pike or Longbow in any combination."
+      },
+      {
+        "name": "Pike",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Longbow",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Trampling Charge (Recharge 5–6)",
+        "desc": "The centaur moves up to its Speed without provoking Opportunity Attacks and can move through the spaces of Medium or smaller creatures. Each creature whose space the centaur enters is targeted once by the following effect. Strength Saving Throw: DC 14. Failure: 7 (1d6 + 4) Bludgeoning damage, and the target has the Prone condition."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "centaur-trooper",
+    "url": "/api/2024/monsters/centaur-trooper",
+    "image": "/api/images/monsters/centaur-trooper.png",
+    "hit_points_roll": "6d10 + 12",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 13"
+  },
+  {
+    "name": "Chain Devil",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 85,
+    "hit_dice": "10d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 18,
+    "dexterity": 15,
+    "constitution": 18,
+    "intelligence": 11,
+    "wisdom": 12,
+    "charisma": 14,
+    "damage_resistances": [
+      "bludgeoning",
+      "cold",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft. (unimpeded by magical"
+    },
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes two Chain attacks and uses Conjure Infernal Chain."
+      },
+      {
+        "name": "Chain",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of two chains, and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Conjure Infernal Chain",
+        "desc": "The devil conjures a fiery chain to bind a creature. Dexterity Saving Throw: DC 15, one creature the devil can see within 60 feet. Failure: 9 (2d4 + 4) Fire damage, and the target has the Restrained condition until the end of the devil’s next turn, at which point the chain disappears. If the target is Large or smaller, the devil moves the target up to 30 feet straight toward itself. Success: The chain disappears.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Unnerving Gaze",
+        "desc": "Trigger: A creature the devil can see starts its turn within 30 feet of the devil and can see the devil. Response—Wisdom Saving Throw: DC 15, the triggering creature. Failure: The target has the"
+      },
+      {
+        "name": "Frightened condition until the end of its turn",
+        "desc": "Success: The target is immune to this devil’s Unnerving Gaze for 24 hours."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "chain-devil",
+    "url": "/api/2024/monsters/chain-devil",
+    "image": "/api/images/monsters/chain-devil.png",
+    "hit_points_roll": "10d8 + 40",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft. (unimpeded by magical"
+  },
+  {
+    "name": "Chimera",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 114,
+    "hit_dice": "12d10",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 19,
+    "dexterity": 11,
+    "constitution": 19,
+    "intelligence": 3,
+    "wisdom": 14,
+    "charisma": 10,
+    "perception": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 18
+    },
+    "languages": "Understands Draconic but can’t speak",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The chimera makes one Ram attack, one Bite attack, and one Claw attack. It can replace the Claw attack with a use of Fire Breath if available."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage, or 18 (4d6 + 4) Piercing damage if the chimera had Advantage on the attack roll.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 7 (1d6 + 4) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 10 (1d12 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+        "damage_dice": "1d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 15, each creature in a 15-foot Cone. Failure: 31 (7d8) Fire damage. Success: Half damage.",
+        "damage_dice": "7d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "chimera",
+    "url": "/api/2024/monsters/chimera",
+    "image": "/api/images/monsters/chimera.png",
+    "hit_points_roll": "12d10 + 48",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 18"
+  },
+  {
+    "name": "Chuul",
+    "size": "Large",
+    "type": "aberration",
+    "alignment": "chaotic evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 76,
+    "hit_dice": "9d10",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 19,
+    "dexterity": 10,
+    "constitution": 16,
+    "intelligence": 5,
+    "wisdom": 11,
+    "charisma": 5,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Understands Deep Speech but can’t speak",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The chuul can breathe air and water."
+      },
+      {
+        "name": "Sense Magic",
+        "desc": "The chuul senses magic within 120 feet of itself. This trait otherwise works like the Detect Magic spell but isn’t itself magical."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The chuul makes two Pincer attacks and uses Paralyzing Tentacles."
+      },
+      {
+        "name": "Pincer",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of two pincers.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Paralyzing Tentacles",
+        "desc": "Constitution Saving Throw: DC 13, one creature Grappled by the chuul. Failure: The target has the Poisoned condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically. While Poisoned, the target has the Paralyzed condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "chuul",
+    "url": "/api/2024/monsters/chuul",
+    "image": "/api/images/monsters/chuul.png",
+    "hit_points_roll": "9d10 + 27",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Clay Golem",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 123,
+    "hit_dice": "13d10",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 20,
+    "dexterity": 9,
+    "constitution": 18,
+    "intelligence": 3,
+    "wisdom": 8,
+    "charisma": 1,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid",
+      "poison",
+      "psychic"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "9",
+    "special_abilities": [
+      {
+        "name": "Acid Absorption",
+        "desc": "Whenever the golem is subjected to Acid damage, it takes no damage and instead regains a number of Hit Points equal to the Acid damage dealt."
+      },
+      {
+        "name": "Berserk",
+        "desc": "Whenever the golem starts its turn Bloodied, roll 1d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it continues to be berserk until it is destroyed or it is no longer Bloodied."
+      },
+      {
+        "name": "Immutable Form",
+        "desc": "The golem can’t shape-shift."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The golem makes two Slam attacks, or it makes three Slam attacks if it used Hasten this turn."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 10 (1d10 + 5) Bludgeoning damage plus 6 (1d12) Acid damage, and the target’s Hit Point maximum decreases by an amount equal to the Acid damage taken.",
+        "damage_dice": "1d10",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Hasten (Recharge 5–6)",
+        "desc": "The golem takes the Dash and Disengage actions."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "clay-golem",
+    "url": "/api/2024/monsters/clay-golem",
+    "image": "/api/images/monsters/clay-golem.png",
+    "hit_points_roll": "13d10 + 52",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Cloaker",
+    "size": "Large",
+    "type": "aberration",
+    "alignment": "chaotic neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 91,
+    "hit_dice": "14d10",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "40 ft."
+    },
+    "strength": 17,
+    "dexterity": 15,
+    "constitution": 12,
+    "intelligence": 13,
+    "wisdom": 14,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "frightened"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 12
+    },
+    "languages": "Deep Speech, Undercommon",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Light Sensitivity",
+        "desc": "While in Bright Light, the cloaker has Disadvantage on attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The cloaker makes one Attach attack and two Tail attacks."
+      },
+      {
+        "name": "Attach",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (3d6 + 3) Piercing damage. If the target is a Large or smaller creature, the cloaker attaches to it. While the cloaker is attached, the target has the Blinded condition, and the cloaker can’t make Attach attacks against other targets. In addition, the cloaker halves the damage it takes (round down), and the target takes the same amount of damage. The cloaker can detach itself by spending 5 feet of movement. The target or a creature within 5 feet of it can take an action to try to detach the cloaker, doing so by succeeding on a DC 14 Strength (Athletics) check.",
+        "damage_dice": "3d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Moan",
+        "desc": "Wisdom Saving Throw: DC 13, each creature in a 60-foot Emanation originating from the cloaker. Failure: The target has the Frightened condition until the end of the cloaker’s next turn. Success: The target is immune to this cloaker’s Moan for the next 24 hours."
+      },
+      {
+        "name": "Phantasms (Recharge after a Short or Long Rest)",
+        "desc": "The cloaker casts the Mirror Image spell, requiring no spell components and using Wisdom as the spellcasting ability. The spell ends early if the cloaker starts or ends its turn in Bright Light."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "cloaker",
+    "url": "/api/2024/monsters/cloaker",
+    "image": "/api/images/monsters/cloaker.png",
+    "hit_points_roll": "14d10 + 14",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Cloud Giant",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 200,
+    "hit_dice": "16d12",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "20 ft.",
+      "hover": true
+    },
+    "strength": 27,
+    "dexterity": 10,
+    "constitution": 22,
+    "intelligence": 12,
+    "wisdom": 16,
+    "charisma": 16,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 21
+    },
+    "languages": "Common, Giant",
+    "challenge_rating": "9",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Thunderous Mace or Thundercloud in any combination. It can replace one attack with a use of Spellcasting to cast Fog Cloud."
+      },
+      {
+        "name": "Thunderous Mace",
+        "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 21 (3d8 + 8) Bludgeoning damage plus 7 (2d6) Thunder damage.",
+        "damage_dice": "3d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Thundercloud",
+        "desc": "Ranged Attack Roll: +12, range 240 ft. Hit: 18 (3d6 + 8) Thunder damage, and the target has the Incapacitated condition until the end of its next turn.",
+        "damage_dice": "3d6",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The giant casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Fog Cloud, Light"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Control Weather, Gaseous Form, Telekinesis"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Misty Step",
+        "desc": "The giant casts the Misty Step spell, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "cloud-giant",
+    "url": "/api/2024/monsters/cloud-giant",
+    "image": "/api/images/monsters/cloud-giant.png",
+    "hit_points_roll": "16d12 + 96",
+    "proficiencies": [
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 21"
+  },
+  {
+    "name": "Cockatrice",
+    "size": "Small",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 22,
+    "hit_dice": "5d6",
+    "speed": {
+      "walk": "20 ft.",
+      "fly": "40 ft."
+    },
+    "strength": 6,
+    "dexterity": 12,
+    "constitution": 12,
+    "intelligence": 2,
+    "wisdom": 13,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "petrified"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Petrifying Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Piercing damage. If the target is a creature, it is subjected to the following effect. Constitution Saving Throw: DC 11. First Failure: The target has the Restrained condition. The target repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition, instead of the Restrained condition, for 24 hours.",
+        "damage_dice": "1d4",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "cockatrice",
+    "url": "/api/2024/monsters/cockatrice",
+    "image": "/api/images/monsters/cockatrice.png",
+    "hit_points_roll": "5d6 + 5",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Commoner",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 4,
+    "hit_dice": "1d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 10,
+    "constitution": 10,
+    "intelligence": 10,
+    "wisdom": 10,
+    "charisma": 10,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Training",
+        "desc": "The commoner has proficiency in one skill of the GM’s choice and has Advantage whenever it makes an ability check using that skill."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Club",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Bludgeoning damage. Copper Dragons",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "commoner",
+    "url": "/api/2024/monsters/commoner",
+    "image": "/api/images/monsters/commoner.png",
+    "hit_points_roll": "1d8",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Copper Dragon Wyrmling",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 22,
+    "hit_dice": "4d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 15,
+    "dexterity": 12,
+    "constitution": 13,
+    "intelligence": 14,
+    "wisdom": 11,
+    "charisma": 13,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Draconic",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 11, each creature in a 20-foot-long, 5-footwide Line. Failure: 18 (4d8) Acid damage. Success: Half damage.",
+        "damage_dice": "4d8"
+      },
+      {
+        "name": "Slowing Breath",
+        "desc": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "copper-dragon-wyrmling",
+    "url": "/api/2024/monsters/copper-dragon-wyrmling",
+    "image": "/api/images/monsters/copper-dragon-wyrmling.png",
+    "hit_points_roll": "4d8 + 4",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Young Copper Dragon",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 119,
+    "hit_dice": "14d10",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 19,
+    "dexterity": 12,
+    "constitution": 17,
+    "intelligence": 16,
+    "wisdom": 13,
+    "charisma": 15,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "7",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Slowing Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 15 (2d10 + 4) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 14, each creature in a 40-foot-long, 5-footwide Line. Failure: 40 (9d8) Acid damage. Success: Half damage.",
+        "damage_dice": "9d8"
+      },
+      {
+        "name": "Slowing Breath",
+        "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "young-copper-dragon",
+    "url": "/api/2024/monsters/young-copper-dragon",
+    "image": "/api/images/monsters/young-copper-dragon.png",
+    "hit_points_roll": "14d10 + 42",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Adult Copper Dragon",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 11,
+    "hit_points": 184,
+    "hit_dice": "16d12",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 23,
+    "dexterity": 12,
+    "constitution": 21,
+    "intelligence": 18,
+    "wisdom": 15,
+    "charisma": 18,
+    "perception": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "14",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Slowing Breath or (B) Spellcasting to cast Mind Spike (level 4 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage plus 4 (1d8) Acid damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 18, each creature in an 60-foot-long, 5-footwide Line. Failure: 54 (12d8) Acid damage. Success: Half damage.",
+        "damage_dice": "12d8"
+      },
+      {
+        "name": "Slowing Breath",
+        "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Mind Spike (level 4 version), Minor Illusion, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Greater Restoration, Major Image"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Giggling Magic",
+        "desc": "Charisma Saving Throw: DC 17, one creature the dragon can see within 90 feet. Failure: 24 (7d6) Psychic damage. Until the end of its next turn, the target rolls 1d6 whenever it makes an ability check or attack roll and subtracts the number rolled from the D20 Test. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "7d6"
+      },
+      {
+        "name": "Mind Jolt",
+        "desc": "The dragon uses Spellcasting to cast Mind"
+      },
+      {
+        "name": "Spike (level 4 version)",
+        "desc": "The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "adult-copper-dragon",
+    "url": "/api/2024/monsters/adult-copper-dragon",
+    "image": "/api/images/monsters/adult-copper-dragon.png",
+    "hit_points_roll": "16d12 + 80",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Ancient Copper Dragon",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 21,
+    "armor_desc": "",
+    "initiative": 15,
+    "hit_points": 367,
+    "hit_dice": "21d20",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 27,
+    "dexterity": 12,
+    "constitution": 25,
+    "intelligence": 20,
+    "wisdom": 17,
+    "charisma": 22,
+    "perception": 17,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "21",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Slowing Breath or (B) Spellcasting to cast Mind Spike (level 5 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +15, reach 15 ft. Hit: 19 (2d10 + 8) Slashing damage plus 9 (2d8) Acid damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 22, each creature in an 90-foot-long, 10-footwide Line. Failure: 63 (14d8) Acid damage. Success: Half damage.",
+        "damage_dice": "14d8"
+      },
+      {
+        "name": "Slowing Breath",
+        "desc": "Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Mind Spike (level 5 version), Minor Illusion, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Greater Restoration, Major Image, Project Image"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Giggling Magic",
+        "desc": "Charisma Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 31 (9d6) Psychic damage. Until the end of its next turn, the target rolls 1d8 whenever it makes an ability check or attack roll and subtracts the number rolled from the D20 Test. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "9d6"
+      },
+      {
+        "name": "Mind Jolt",
+        "desc": "The dragon uses Spellcasting to cast Mind"
+      },
+      {
+        "name": "Spike (level 5 version)",
+        "desc": "The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "ancient-copper-dragon",
+    "url": "/api/2024/monsters/ancient-copper-dragon",
+    "image": "/api/images/monsters/ancient-copper-dragon.png",
+    "hit_points_roll": "21d20 + 147",
+    "proficiencies": [
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Couatl",
+    "size": "Medium",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 60,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "90 ft."
+    },
+    "strength": 16,
+    "dexterity": 20,
+    "constitution": 17,
+    "intelligence": 18,
+    "wisdom": 20,
+    "charisma": 18,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "psychic",
+      "radiant"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 15
+    },
+    "languages": "All; telepathy 120 ft.",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Shielded Mind",
+        "desc": "The couatl’s thoughts can’t be read by any means, and other creatures can communicate with it telepathically only if it allows them."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (1d12 + 5) Piercing damage, and the target has the Poisoned condition until the end of the couatl’s next turn.",
+        "damage_dice": "1d12",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 15, one Medium or smaller creature the couatl can see within 5 feet. Failure: 8 (1d6 + 5) Bludgeoning damage. The target has the Grappled condition (escape DC 13), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "1d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The couatl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability (spell save DC 15):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Detect Magic, Detect Thoughts, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Create Food and Water, Dream, Greater Restoration, Scrying, Sleep"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (2/Day)",
+        "desc": "The couatl casts Bless, Lesser Restoration, or Sanctuary, requiring no spell components and using the same spellcasting ability as Spellcasting. Crawling Claw"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "couatl",
+    "url": "/api/2024/monsters/couatl",
+    "image": "/api/images/monsters/couatl.png",
+    "hit_points_roll": "8d8 + 24",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Swarm of Crawling Claws",
+    "size": "Medium",
+    "type": "swarm of tiny undead",
+    "alignment": "neutral evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 49,
+    "hit_dice": "11d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 14,
+    "dexterity": 14,
+    "constitution": 11,
+    "intelligence": 5,
+    "wisdom": 10,
+    "charisma": 4,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "necrotic",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "grappled",
+      "incapacitated",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "prone",
+      "restrained",
+      "stunned"
+    ],
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Understands Common but can’t speak",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny creature. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Swarm of Grasping Hands",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 20 (4d8 + 2) Necrotic damage, or 11 (2d8 + 2) Necrotic damage if the swarm is Bloodied. If the target is a Medium or smaller creature, it has the Prone condition. Cultists",
+        "damage_dice": "4d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "swarm-of-crawling-claws",
+    "url": "/api/2024/monsters/swarm-of-crawling-claws",
+    "image": "/api/images/monsters/swarm-of-crawling-claws.png",
+    "hit_points_roll": "11d8",
+    "proficiencies": [],
+    "old_senses": "Blindsight 30 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Cultist",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 9,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 11,
+    "dexterity": 12,
+    "constitution": 10,
+    "intelligence": 10,
+    "wisdom": 11,
+    "charisma": 10,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Ritual Sickle",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 1 Necrotic damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "cultist",
+    "url": "/api/2024/monsters/cultist",
+    "image": "/api/images/monsters/cultist.png",
+    "hit_points_roll": "2d8",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Cultist Fanatic",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 44,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 11,
+    "dexterity": 14,
+    "constitution": 12,
+    "intelligence": 10,
+    "wisdom": 14,
+    "charisma": 13,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "Common",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Pact Blade",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 7 (2d6) Necrotic damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The cultist casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks):",
+        "attack_bonus": 4
+      },
+      {
+        "name": "At Will",
+        "desc": "Light, Thaumaturgy"
+      },
+      {
+        "name": "2/Day",
+        "desc": "Command"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Hold Person"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Spiritual Weapon (2/Day)",
+        "desc": "The cultist casts the Spiritual Weapon spell, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "cultist-fanatic",
+    "url": "/api/2024/monsters/cultist-fanatic",
+    "image": "/api/images/monsters/cultist-fanatic.png",
+    "hit_points_roll": "8d8 + 8",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Darkmantle",
+    "size": "Small",
+    "type": "aberration",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 22,
+    "hit_dice": "5d6",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 12,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Crush",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage, and the darkmantle attaches to the target. If the target is a Medium or smaller creature and the darkmantle had Advantage on the attack roll, it covers the target, which has the Blinded condition and is suffocating while the darkmantle is attached in this way. While attached to a target, the darkmantle can attack only the target but has Advantage on its attack rolls. Its Speed becomes 0, it can’t benefit from any bonus to its Speed, and it moves with the target. A creature can take an action to try to detach the darkmantle from itself, doing so with a successful DC 13 Strength (Athletics) check. On its turn, the darkmantle can detach itself by using 5 feet of movement.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Darkness Aura (1/Day)",
+        "desc": "Magical Darkness fills a 15-foot"
+      },
+      {
+        "name": "Emanation originating from the darkmantle",
+        "desc": "This effect lasts while the darkmantle maintains Concentration on it, up to 10 minutes. Darkvision can’t penetrate this area, and no light can illuminate it."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "darkmantle",
+    "url": "/api/2024/monsters/darkmantle",
+    "image": "/api/images/monsters/darkmantle.png",
+    "hit_points_roll": "5d6 + 5",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Death Dog",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 39,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 15,
+    "dexterity": 14,
+    "constitution": 14,
+    "intelligence": 3,
+    "wisdom": 13,
+    "charisma": 6,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "blinded",
+      "charmed",
+      "deafened",
+      "frightened",
+      "stunned",
+      "unconscious"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The death dog makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage. If the target is a creature, it is subjected to the following effect. Constitution Saving Throw: DC 12. First Failure: The target has the Poisoned condition. While Poisoned, the target’s Hit Point maximum doesn’t return to normal when finishing a Long Rest, and it repeats the save every 24 hours that elapse, ending the effect on itself on a success. Subsequent Failures: The Poisoned target’s Hit Point maximum decreases by 5 (1d10).",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "death-dog",
+    "url": "/api/2024/monsters/death-dog",
+    "image": "/api/images/monsters/death-dog.png",
+    "hit_points_roll": "6d8 + 12",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Deva",
+    "size": "Medium",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 229,
+    "hit_dice": "27d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "90 ft.",
+      "hover": true
+    },
+    "strength": 18,
+    "dexterity": 18,
+    "constitution": 18,
+    "intelligence": 17,
+    "wisdom": 20,
+    "charisma": 20,
+    "perception": 9,
+    "damage_resistances": [
+      "radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 19
+    },
+    "languages": "All; telepathy 120 ft.",
+    "challenge_rating": "10",
+    "special_abilities": [
+      {
+        "name": "Exalted Restoration",
+        "desc": "If the deva dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in Mount Celestia."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The deva has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The deva makes two Holy Mace attacks."
+      },
+      {
+        "name": "Holy Mace",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 18 (4d8) Radiant damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The deva casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Commune, Raise Dead"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (2/Day)",
+        "desc": "The deva casts Cure Wounds, Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "deva",
+    "url": "/api/2024/monsters/deva",
+    "image": "/api/images/monsters/deva.png",
+    "hit_points_roll": "27d8 + 108",
+    "proficiencies": [
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 19"
+  },
+  {
+    "name": "Djinni",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 218,
+    "hit_dice": "19d10",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "90 ft.",
+      "hover": true
+    },
+    "strength": 21,
+    "dexterity": 15,
+    "constitution": 22,
+    "intelligence": 15,
+    "wisdom": 16,
+    "charisma": 20,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning",
+      "thunder"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 13
+    },
+    "languages": "Primordial (Auran)",
+    "challenge_rating": "11",
+    "special_abilities": [
+      {
+        "name": "Elemental Restoration",
+        "desc": "If the djinni dies outside the Elemental Plane of Air, its body dissolves into mist, and it gains a new body in 1d4 days, reviving with all its Hit Points somewhere on the Plane of Air."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The djinni has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Wishes",
+        "desc": "The djinni has a 30 percent chance of knowing the Wish spell. If the djinni knows it, the djinni can cast it only on behalf of a non-genie creature who communicates a wish in a way the djinni can understand. If the djinni casts the spell for the creature, the djinni suffers none of the spell’s stress. Once the djinni has cast it three times, the djinni can’t do so again for 365 days."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The djinni makes three attacks, using Storm Blade or Storm Bolt in any combination."
+      },
+      {
+        "name": "Storm Blade",
+        "desc": "Melee Attack Roll: +9, reach 5 feet. Hit: 12 (2d6 + 5) Slashing damage plus 7 (2d6) Lightning damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Storm Bolt",
+        "desc": "Ranged Attack Roll: +9, range 120 feet. Hit: 13 (3d8) Thunder damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "3d8"
+      },
+      {
+        "name": "Create Whirlwind",
+        "desc": "The djinni conjures a whirlwind at a point it can see within 120 feet. The whirlwind fills a 20-foot-radius, 60-foot-high Cylinder centered on that point. The whirlwind lasts until the djinni’s Concentration on it ends. The djinni can move the whirlwind up to 20 feet at the start of each of its turns. Whenever the whirlwind enters a creature’s space or a creature enters the whirlwind, that creature is subjected to the following effect. Strength Saving Throw: DC 17 (a creature makes this save only once per turn, and the djinni is unaffected). Failure: While in the whirlwind, the target has the Restrained condition and moves with the whirlwind. At the start of each of its turns, the Restrained target takes 21 (6d6) Thunder damage. At the end of each of its turns, the target repeats the save, ending the effect on itself on a success.",
+        "damage_dice": "6d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The djinni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Detect Magic"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Create Food and Water (can create wine instead of water), Tongues, Wind Walk"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Creation, Gaseous Form, Invisibility, Major Image, Plane Shift"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "djinni",
+    "url": "/api/2024/monsters/djinni",
+    "image": "/api/images/monsters/djinni.png",
+    "hit_points_roll": "19d10 + 114",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Doppelganger",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 52,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 11,
+    "dexterity": 18,
+    "constitution": 14,
+    "intelligence": 11,
+    "wisdom": 12,
+    "charisma": 14,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Common plus three other languages",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The doppelganger makes two Slam attacks and uses Unsettling Visage if available."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +6 (with Advantage during the first round of each combat), reach 5 ft. Hit: 11 (2d6 + 4) Bludgeoning damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Read Thoughts",
+        "desc": "The doppelganger casts Detect Thoughts, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 12)."
+      },
+      {
+        "name": "Unsettling Visage (Recharge 6)",
+        "desc": "Wisdom Saving Throw: DC 12, each creature in a 15-foot Emanation originating from the doppelganger that can see the doppelganger. Failure: The target has the Frightened condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The doppelganger shape-shifts into a Medium or Small Humanoid, or it returns to its true form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "doppelganger",
+    "url": "/api/2024/monsters/doppelganger",
+    "image": "/api/images/monsters/doppelganger.png",
+    "hit_points_roll": "8d8 + 16",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Dragon Turtle",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "neutral",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 356,
+    "hit_dice": "23d20",
+    "speed": {
+      "walk": "20 ft.",
+      "swim": "50 ft."
+    },
+    "strength": 25,
+    "dexterity": 10,
+    "constitution": 20,
+    "intelligence": 10,
+    "wisdom": 12,
+    "charisma": 12,
+    "damage_resistances": [
+      "fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Draconic, Primordial (Aquan)",
+    "challenge_rating": "17",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Bite attacks. It can replace one attack with a Tail attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +13, reach 15 ft. Hit: 23 (3d10 + 7) Piercing damage plus 7 (2d6) Fire damage. Being underwater doesn’t grant Resistance to this Fire damage.",
+        "damage_dice": "3d10",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +13, reach 15 ft. Hit: 18 (2d10 + 7) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d10",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Steam Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 19, each creature in a 60-foot Cone. Failure: 56 (16d6) Fire damage. Success: Half damage. Failure or Success: Being underwater doesn’t grant Resistance to this Fire damage.",
+        "damage_dice": "16d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "dragon-turtle",
+    "url": "/api/2024/monsters/dragon-turtle",
+    "image": "/api/images/monsters/dragon-turtle.png",
+    "hit_points_roll": "23d20 + 115",
+    "proficiencies": [
+      {
+        "value": 11,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Dretch",
+    "size": "Small",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 18,
+    "hit_dice": "4d6",
+    "speed": {
+      "walk": "20 ft."
+    },
+    "strength": 12,
+    "dexterity": 11,
+    "constitution": 12,
+    "intelligence": 5,
+    "wisdom": 8,
+    "charisma": 3,
+    "damage_resistances": [
+      "cold",
+      "fire",
+      "lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "Abyssal; telepathy 60 ft. (works only with",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Fetid Cloud (1/Day)",
+        "desc": "Constitution Saving Throw: DC 11, each creature in a 10-foot Emanation originating from the dretch. Failure: The target has the Poisoned condition until the end of its next turn. While Poisoned, the creature can take either an action or a Bonus Action on its turn, not both, and it can’t take Reactions."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "dretch",
+    "url": "/api/2024/monsters/dretch",
+    "image": "/api/images/monsters/dretch.png",
+    "hit_points_roll": "4d6 + 4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Drider",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 123,
+    "hit_dice": "13d10",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 19,
+    "constitution": 18,
+    "intelligence": 13,
+    "wisdom": 16,
+    "charisma": 12,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 16
+    },
+    "languages": "Elvish, Undercommon",
+    "challenge_rating": "6",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The drider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Sunlight Sensitivity",
+        "desc": "While in sunlight, the drider has Disadvantage on ability checks and attack rolls."
+      },
+      {
+        "name": "Web Walker",
+        "desc": "The drider ignores movement restrictions caused by webs, and the drider knows the location of any other creature in contact with the same web."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The drider makes three attacks, using Foreleg or Poison Burst in any combination."
+      },
+      {
+        "name": "Foreleg",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 13 (2d8 + 4) Piercing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Poison Burst",
+        "desc": "Ranged Attack Roll: +6, range 120 ft. Hit: 13 (3d6 + 3) Poison damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Magic of the Spider Queen (Recharge 5–6)",
+        "desc": "The drider casts Darkness, Faerie Fire, or Web, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 14)."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "drider",
+    "url": "/api/2024/monsters/drider",
+    "image": "/api/images/monsters/drider.png",
+    "hit_points_roll": "13d10 + 52",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 16"
+  },
+  {
+    "name": "Druid",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 44,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 12,
+    "constitution": 13,
+    "intelligence": 12,
+    "wisdom": 16,
+    "charisma": 11,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 15
+    },
+    "languages": "Common, Druidic, Sylvan",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The druid makes two attacks, using Vine Staff or Verdant Wisp in any combination."
+      },
+      {
+        "name": "Vine Staff",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage plus 2 (1d4) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Verdant Wisp",
+        "desc": "Ranged Attack Roll: +5, range 90 ft. Hit: 10 (3d6) Radiant damage.",
+        "damage_dice": "3d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The druid casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Druidcraft, Speak with Animals"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Entangle, Thunderwave"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Animal Messenger, Longstrider, Moonbeam"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "druid",
+    "url": "/api/2024/monsters/druid",
+    "image": "/api/images/monsters/druid.png",
+    "hit_points_roll": "8d8 + 8",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 15"
+  },
+  {
+    "name": "Dryad",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "neutral",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 22,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 12,
+    "constitution": 11,
+    "intelligence": 14,
+    "wisdom": 15,
+    "charisma": 18,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Elvish, Sylvan",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The dryad has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Speak with Beasts and Plants",
+        "desc": "The dryad can communicate with Beasts and Plants as if they shared a language."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dryad makes one Vine Lash or Thorn Burst attack, and it can use Spellcasting to cast Charm Monster."
+      },
+      {
+        "name": "Vine Lash",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 8 (1d8 + 4) Slashing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Thorn Burst",
+        "desc": "Ranged Attack Roll: +6, range 60 ft. Hit: 7 (1d6 + 4) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dryad casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 14):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Animal Friendship, Charm Monster (lasts 24 hours; ends early if the dryad casts the spell again), Druidcraft"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Entangle, Pass without Trace"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Tree Stride",
+        "desc": "If within 5 feet of a Large or bigger tree, the dryad teleports to an unoccupied space within 5 feet of a second Large or bigger tree that is within 60 feet of the previous tree."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "dryad",
+    "url": "/api/2024/monsters/dryad",
+    "image": "/api/images/monsters/dryad.png",
+    "hit_points_roll": "5d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Earth Elemental",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 147,
+    "hit_dice": "14d10",
+    "speed": {
+      "walk": "30 ft.",
+      "burrow": "30 ft."
+    },
+    "strength": 20,
+    "dexterity": 8,
+    "constitution": 20,
+    "intelligence": 5,
+    "wisdom": 10,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "thunder"
+    ],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "unconscious"
+    ],
+    "senses": {
+      "darkvision": "60 ft., Tremorsense 60 ft."
+    },
+    "languages": "Primordial (Terran)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Earth Glide",
+        "desc": "The elemental can burrow through nonmagical, unworked earth and stone. While doing so, the elemental doesn’t disturb the material it moves through."
+      },
+      {
+        "name": "Siege Monster",
+        "desc": "The elemental deals double damage to objects and structures."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The elemental makes two attacks, using Slam or Rock Launch in any combination."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 14 (2d8 + 5) Bludgeoning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Rock Launch",
+        "desc": "Ranged Attack Roll: +8, range 60 ft. Hit: 8 (1d6 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "1d6",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "earth-elemental",
+    "url": "/api/2024/monsters/earth-elemental",
+    "image": "/api/images/monsters/earth-elemental.png",
+    "hit_points_roll": "14d10 + 70",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft., Tremorsense 60 ft.;"
+  },
+  {
+    "name": "Efreeti",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 212,
+    "hit_dice": "17d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "60 ft.",
+      "hover": true
+    },
+    "strength": 22,
+    "dexterity": 12,
+    "constitution": 24,
+    "intelligence": 16,
+    "wisdom": 15,
+    "charisma": 19,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 12
+    },
+    "languages": "Primordial (Ignan)",
+    "challenge_rating": "11",
+    "special_abilities": [
+      {
+        "name": "Elemental Restoration",
+        "desc": "If the efreeti dies outside the Elemental Plane of Fire, its body dissolves into ash, and it gains a new body in 1d4 days, reviving with all its Hit Points somewhere on the Plane of Fire."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The efreeti has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Wishes",
+        "desc": "The efreeti has a 30 percent chance of knowing the Wish spell. If the efreeti knows it, the efreeti can cast it only on behalf of a non-genie creature who communicates a wish in a way the efreeti can understand. If the efreeti casts the spell for the creature, the efreeti suffers none of the spell’s stress. Once the efreeti has cast it three times, the efreeti can’t do so again for 365 days."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The efreeti makes three attacks, using Heated Blade or Hurl Flame in any combination."
+      },
+      {
+        "name": "Heated Blade",
+        "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 13 (2d6 + 6) Slashing damage plus 13 (2d12) Fire damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Hurl Flame",
+        "desc": "Ranged Attack Roll: +8, range 120 ft. Hit: 24 (7d6) Fire damage.",
+        "damage_dice": "7d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The efreeti casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Elementalism"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Gaseous Form, Invisibility, Major Image, Plane Shift, Tongues, Wall of Fire (level 7 version)"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "efreeti",
+    "url": "/api/2024/monsters/efreeti",
+    "image": "/api/images/monsters/efreeti.png",
+    "hit_points_roll": "17d10 + 119",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Erinyes",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 178,
+    "hit_dice": "21d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 18,
+    "dexterity": 16,
+    "constitution": 18,
+    "intelligence": 14,
+    "wisdom": 14,
+    "charisma": 18,
+    "perception": 6,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 16
+    },
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "12",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the erinyes dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The erinyes has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Magic Rope",
+        "desc": "The erinyes has a magic rope. While bearing it, the erinyes can use the Entangling Rope action. The rope has AC 20, HP 90, and Immunity to Poison and Psychic damage. The rope turns to dust if reduced to 0 Hit Points, if it is 5+ feet away from the erinyes for 1 hour or more, or if the erinyes dies. If the rope is damaged or destroyed, the erinyes can fully restore it when finishing a Short or Long Rest."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The erinyes makes three Withering Sword attacks and can use Entangling Rope."
+      },
+      {
+        "name": "Withering Sword",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage plus 11 (2d10) Necrotic damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Entangling Rope (Requires Magic Rope)",
+        "desc": "Strength Saving Throw: DC 16, one creature the erinyes can see within 120 feet. Failure: 14 (4d6) Force damage, and the target has the Restrained condition until the rope is destroyed, the erinyes uses a Bonus Action to release the target, or the erinyes uses Entangling Rope again.",
+        "damage_dice": "4d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The erinyes is hit by a melee attack roll while holding a weapon. Response: The erinyes adds 4 to its AC against that attack, possibly causing it to miss."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "erinyes",
+    "url": "/api/2024/monsters/erinyes",
+    "image": "/api/images/monsters/erinyes.png",
+    "hit_points_roll": "21d8 + 84",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 16"
+  },
+  {
+    "name": "Ettercap",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 44,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 14,
+    "dexterity": 15,
+    "constitution": 13,
+    "intelligence": 7,
+    "wisdom": 12,
+    "charisma": 8,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The ettercap can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Web Walker",
+        "desc": "The ettercap ignores movement restrictions caused by webs, and the ettercap knows the location of any other creature in contact with the same web."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ettercap makes one Bite attack and one Claw attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 2 (1d4) Poison damage, and the target has the Poisoned condition until the start of the ettercap’s next turn.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Slashing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Web Strand (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 12, one Large or smaller creature the ettercap can see within 30 feet. Failure: The target has the Restrained condition until the web is destroyed (AC 10; HP 5; Vulnerability to Fire damage; Immunity to Bludgeoning, Poison, and Psychic damage)."
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Reel",
+        "desc": "The ettercap pulls one creature within 30 feet of itself that is Restrained by its Web Strand up to 25 feet straight toward itself."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ettercap",
+    "url": "/api/2024/monsters/ettercap",
+    "image": "/api/images/monsters/ettercap.png",
+    "hit_points_roll": "8d8 + 8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Ettin",
+    "size": "Large",
+    "type": "giant",
+    "alignment": "chaotic evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 85,
+    "hit_dice": "10d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 21,
+    "dexterity": 8,
+    "constitution": 17,
+    "intelligence": 6,
+    "wisdom": 10,
+    "charisma": 8,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "blinded",
+      "charmed",
+      "deafened",
+      "frightened",
+      "stunned",
+      "unconscious"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Giant",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ettin makes one Battleaxe attack and one Morningstar attack."
+      },
+      {
+        "name": "Battleaxe",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Morningstar",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Piercing damage, and the target has Disadvantage on the next attack roll it makes before the end of its next turn.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ettin",
+    "url": "/api/2024/monsters/ettin",
+    "image": "/api/images/monsters/ettin.png",
+    "hit_points_roll": "10d10 + 30",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Fire Elemental",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 93,
+    "hit_dice": "11d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 10,
+    "dexterity": 17,
+    "constitution": 16,
+    "intelligence": 6,
+    "wisdom": 10,
+    "charisma": 7,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "prone",
+      "restrained",
+      "unconscious"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Primordial (Ignan)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Fire Aura",
+        "desc": "At the end of each of the elemental’s turns, each creature in a 10-foot Emanation originating from the elemental takes 5 (1d10) Fire damage. Creatures and flammable objects in the Emanation start burning."
+      },
+      {
+        "name": "Fire Form",
+        "desc": "The elemental can move through a space as narrow as 1 inch without expending extra movement to do so, and it can enter a creature’s space and stop there. The first time it enters a creature’s space on a turn, that creature takes 5 (1d10) Fire damage."
+      },
+      {
+        "name": "Illumination",
+        "desc": "The elemental sheds Bright Light in a 30foot radius and Dim Light for an additional 30 feet."
+      },
+      {
+        "name": "Water Susceptibility",
+        "desc": "The elemental takes 3 (1d6) Cold damage for every 5 feet the elemental moves in water or for every gallon of water splashed on it."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The elemental makes two Burn attacks."
+      },
+      {
+        "name": "Burn",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Fire damage. If the target is a creature or a flammable object, it starts burning.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "fire-elemental",
+    "url": "/api/2024/monsters/fire-elemental",
+    "image": "/api/images/monsters/fire-elemental.png",
+    "hit_points_roll": "11d10 + 33",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Fire Giant",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 162,
+    "hit_dice": "13d12",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 25,
+    "dexterity": 9,
+    "constitution": 23,
+    "intelligence": 10,
+    "wisdom": 14,
+    "charisma": 13,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 16
+    },
+    "languages": "Giant",
+    "challenge_rating": "9",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Flame Sword or Hammer Throw in any combination."
+      },
+      {
+        "name": "Flame Sword",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 21 (4d6 + 7) Slashing damage plus 10 (3d6) Fire damage.",
+        "damage_dice": "4d6",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Hammer Throw",
+        "desc": "Ranged Attack Roll: +11, range 60/240 ft. Hit: 23 (3d10 + 7) Bludgeoning damage plus 4 (1d8) Fire damage, and the target is pushed up to 15 feet straight away from the giant and has Disadvantage on the next attack roll it makes before the end of its next turn.",
+        "damage_dice": "3d10",
+        "damage_bonus": 7
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "fire-giant",
+    "url": "/api/2024/monsters/fire-giant",
+    "image": "/api/images/monsters/fire-giant.png",
+    "hit_points_roll": "13d12 + 78",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 16"
+  },
+  {
+    "name": "Flesh Golem",
+    "size": "Medium",
+    "type": "construct",
+    "alignment": "neutral",
+    "armor_class": 9,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 127,
+    "hit_dice": "15d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 19,
+    "dexterity": 9,
+    "constitution": 18,
+    "intelligence": 6,
+    "wisdom": 10,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Understands Common plus one other language",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Aversion to Fire",
+        "desc": "If the golem takes Fire damage, it has Disadvantage on attack rolls and ability checks until the end of its next turn."
+      },
+      {
+        "name": "Berserk",
+        "desc": "Whenever the golem starts its turn Bloodied, roll 1d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it remains so until it is destroyed or it is no longer Bloodied. The golem’s creator, if within 60 feet of the berserk golem, can try to calm it by taking an action to make a DC 15 Charisma (Persuasion) check; the golem must be able to hear its creator. If this check succeeds, the golem ceases being berserk until the start of its next turn, at which point it resumes rolling for the Berserk trait again if it is still Bloodied."
+      },
+      {
+        "name": "Immutable Form",
+        "desc": "The golem can’t shape-shift."
+      },
+      {
+        "name": "Lightning Absorption",
+        "desc": "Whenever the golem is subjected to Lightning damage, it regains a number of Hit Points equal to the Lightning damage dealt."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The golem makes two Slam attacks."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage plus 4 (1d8) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "flesh-golem",
+    "url": "/api/2024/monsters/flesh-golem",
+    "image": "/api/images/monsters/flesh-golem.png",
+    "hit_points_roll": "15d8 + 60",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Frost Giant",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 149,
+    "hit_dice": "13d12",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 23,
+    "dexterity": 9,
+    "constitution": 21,
+    "intelligence": 9,
+    "wisdom": 10,
+    "charisma": 12,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 13
+    },
+    "languages": "Giant",
+    "challenge_rating": "8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Frost Axe or Great Bow in any combination."
+      },
+      {
+        "name": "Frost Axe",
+        "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 19 (2d12 + 6) Slashing damage plus 9 (2d8) Cold damage.",
+        "damage_dice": "2d12",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Great Bow",
+        "desc": "Ranged Attack Roll: +9, range 150/600 ft. Hit: 17 (2d10 + 6) Piercing damage plus 7 (2d6) Cold damage, and the target’s Speed decreases by 10 feet until the end of its next turn.",
+        "damage_dice": "2d10",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "War Cry (Recharge 5–6)",
+        "desc": "The giant or one creature of its choice that can see or hear it gains 16 (2d10 + 5) Temporary Hit Points and has Advantage on attack rolls until the start of the giant’s next turn. Fungi"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "frost-giant",
+    "url": "/api/2024/monsters/frost-giant",
+    "image": "/api/images/monsters/frost-giant.png",
+    "hit_points_roll": "13d12 + 65",
+    "proficiencies": [
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 13"
+  },
+  {
+    "name": "Shrieker Fungus",
+    "size": "Medium",
+    "type": "plant",
+    "alignment": "unaligned",
+    "armor_class": 5,
+    "armor_desc": "",
+    "initiative": -5,
+    "hit_points": 13,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": "5 ft."
+    },
+    "strength": 1,
+    "dexterity": 1,
+    "constitution": 10,
+    "intelligence": 1,
+    "wisdom": 3,
+    "charisma": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "blinded",
+      "charmed",
+      "deafened",
+      "frightened"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 6
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Shriek",
+        "desc": "Trigger: A creature or a source of Bright Light moves within 30 feet of the shrieker. Response: The shrieker emits a shriek audible within 300 feet of itself for 1 minute or until the shrieker dies."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "shrieker-fungus",
+    "url": "/api/2024/monsters/shrieker-fungus",
+    "image": "/api/images/monsters/shrieker-fungus.png",
+    "hit_points_roll": "3d8",
+    "proficiencies": [],
+    "old_senses": "Blindsight 30 ft.; Passive Perception 6"
+  },
+  {
+    "name": "Violet Fungus",
+    "size": "Medium",
+    "type": "plant",
+    "alignment": "unaligned",
+    "armor_class": 5,
+    "armor_desc": "",
+    "initiative": -5,
+    "hit_points": 18,
+    "hit_dice": "4d8",
+    "speed": {
+      "walk": "5 ft."
+    },
+    "strength": 3,
+    "dexterity": 1,
+    "constitution": 10,
+    "intelligence": 1,
+    "wisdom": 3,
+    "charisma": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "blinded",
+      "charmed",
+      "deafened",
+      "frightened"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 6
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The fungus makes two Rotting Touch attacks."
+      },
+      {
+        "name": "Rotting Touch",
+        "desc": "Melee Attack Roll: +2, reach 10 ft. Hit: 4 (1d8) Necrotic damage.",
+        "damage_dice": "1d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "violet-fungus",
+    "url": "/api/2024/monsters/violet-fungus",
+    "image": "/api/images/monsters/violet-fungus.png",
+    "hit_points_roll": "4d8",
+    "proficiencies": [],
+    "old_senses": "Blindsight 30 ft.; Passive Perception 6"
+  },
+  {
+    "name": "Gargoyle",
+    "size": "Medium",
+    "type": "elemental",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 67,
+    "hit_dice": "9d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 15,
+    "dexterity": 11,
+    "constitution": 16,
+    "intelligence": 6,
+    "wisdom": 11,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Primordial (Terran)",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The gargoyle doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The gargoyle makes two Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Slashing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "gargoyle",
+    "url": "/api/2024/monsters/gargoyle",
+    "image": "/api/images/monsters/gargoyle.png",
+    "hit_points_roll": "9d8 + 27",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Gelatinous Cube",
+    "size": "Large",
+    "type": "ooze",
+    "alignment": "unaligned",
+    "armor_class": 6,
+    "armor_desc": "",
+    "initiative": -4,
+    "hit_points": 63,
+    "hit_dice": "6d10",
+    "speed": {
+      "walk": "15 ft."
+    },
+    "strength": 14,
+    "dexterity": 3,
+    "constitution": 20,
+    "intelligence": 1,
+    "wisdom": 6,
+    "charisma": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid"
+    ],
+    "condition_immunities": [
+      "blinded",
+      "charmed",
+      "deafened",
+      "exhaustion",
+      "frightened",
+      "prone"
+    ],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 8
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Ooze Cube",
+        "desc": "The cube fills its entire space and is transparent. Other creatures can enter that space, but a creature that does so is subjected to the cube’s Engulf and has Disadvantage on the saving throw. Creatures inside the cube have Total Cover, and the cube can hold one Large creature or up to four Medium or Small creatures inside itself at a time. As an action, a creature within 5 feet of the cube can pull a creature or an object out of the cube by succeeding on a DC 12 Strength (Athletics) check, and the puller takes 10 (3d6) Acid damage."
+      },
+      {
+        "name": "Transparent",
+        "desc": "Even when the cube is in plain sight, a creature must succeed on a DC 15 Wisdom (Perception) check to notice the cube if the creature hasn’t witnessed the cube move or otherwise act."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Pseudopod",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 12 (3d6 + 2) Acid damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Engulf",
+        "desc": "The cube moves up to its Speed without provoking Opportunity Attacks. The cube can move through the spaces of Large or smaller creatures if it has room inside itself to contain them (see the Ooze Cube trait). Dexterity Saving Throw: DC 12, each creature whose space the cube enters for the first time during this move. Failure: 10 (3d6) Acid damage, and the target is engulfed. An engulfed target is suffocating, can’t cast spells with a Verbal component, has the Restrained condition, and takes 10 (3d6) Acid damage at the start of each of the cube’s turns. When the cube moves, the engulfed target moves with it. An engulfed target can try to escape by taking an action to make a DC 12 Strength (Athletics) check. On a successful check, the target escapes and enters the nearest unoccupied space. Success: Half damage, and the target moves to an unoccupied space within 5 feet of the cube. If there is no unoccupied space, the target fails the save instead.",
+        "damage_dice": "3d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "gelatinous-cube",
+    "url": "/api/2024/monsters/gelatinous-cube",
+    "image": "/api/images/monsters/gelatinous-cube.png",
+    "hit_points_roll": "6d10 + 30",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Ghast",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 36,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 17,
+    "constitution": 10,
+    "intelligence": 11,
+    "wisdom": 10,
+    "charisma": 8,
+    "damage_resistances": [
+      "necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Common",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Stench",
+        "desc": "Constitution Saving Throw: DC 10, any creature that starts its turn in a 5-foot Emanation originating from the ghast. Failure: The target has the Poisoned condition until the start of its next turn. Success: The target is immune to this ghast’s Stench for 24 hours."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 9 (2d8) Necrotic damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage. If the target is a non-Undead creature, it is subjected to the following effect. Constitution Saving Throw: DC 10. Failure: The target has the Paralyzed condition until the end of its next turn.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ghast",
+    "url": "/api/2024/monsters/ghast",
+    "image": "/api/images/monsters/ghast.png",
+    "hit_points_roll": "8d8",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Ghost",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "neutral",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 45,
+    "hit_dice": "10d8",
+    "speed": {
+      "walk": "5 ft.",
+      "fly": "40 ft.",
+      "hover": true
+    },
+    "strength": 7,
+    "dexterity": 13,
+    "constitution": 10,
+    "intelligence": 10,
+    "wisdom": 12,
+    "charisma": 17,
+    "damage_resistances": [
+      "acid",
+      "bludgeoning",
+      "cold",
+      "fire",
+      "lightning",
+      ""
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "necrotic",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "prone",
+      "restrained"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Ethereal Sight",
+        "desc": "The ghost can see 60 feet into the Ethereal Plane when it is on the Material Plane."
+      },
+      {
+        "name": "Incorporeal Movement",
+        "desc": "The ghost can move through other creatures and objects as if they were Difficult"
+      },
+      {
+        "name": "Terrain",
+        "desc": "It takes 5 (1d10) Force damage if it ends its turn inside an object."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ghost makes two Withering Touch attacks."
+      },
+      {
+        "name": "Withering Touch",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 19 (3d10 + 3) Necrotic damage.",
+        "damage_dice": "3d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Etherealness",
+        "desc": "The ghost casts the Etherealness spell, requiring no spell components and using Charisma as the spellcasting ability. The ghost is visible on the Material Plane while on the Border Ethereal and vice versa, but it can’t affect or be affected by anything on the other plane."
+      },
+      {
+        "name": "Horrific Visage",
+        "desc": "Wisdom Saving Throw: DC 13, each creature in a 60-foot Cone that can see the ghost and isn’t an Undead. Failure: 10 (2d6 + 3) Psychic damage, and the target has the Frightened condition until the start of the ghost’s next turn. Success: The target is immune to this ghost’s Horrific Visage for 24 hours.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Possession (Recharge 6)",
+        "desc": "Charisma Saving Throw: DC 13, one Humanoid the ghost can see within 5 feet. Failure: The target is possessed by the ghost; the ghost disappears, and the target has the Incapacitated condition and loses control of its body. The ghost now controls the body, but the target retains awareness. The ghost can’t be targeted by any attack, spell, or other effect, except ones that specifically target Undead. The ghost’s game statistics are the same, except it uses the possessed target’s Speed, as well as the target’s Strength, Dexterity, and Constitution modifiers. The possession lasts until the body drops to 0 Hit"
+      },
+      {
+        "name": "Points or the ghost leaves as a Bonus Action",
+        "desc": "When the possession ends, the ghost appears in an unoccupied space within 5 feet of the target, and the target is immune to this ghost’s Possession for 24 hours. Success: The target is immune to this ghost’s Possession for 24 hours."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ghost",
+    "url": "/api/2024/monsters/ghost",
+    "image": "/api/images/monsters/ghost.png",
+    "hit_points_roll": "10d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Ghoul",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 13,
+    "dexterity": 15,
+    "constitution": 10,
+    "intelligence": 7,
+    "wisdom": 10,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Common",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ghoul makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 3 (1d6) Necrotic damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Slashing damage. If the target is a creature that isn’t an Undead or elf, it is subjected to the following effect. Constitution Saving Throw: DC 10. Failure: The target has the Paralyzed condition until the end of its next turn.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ghoul",
+    "url": "/api/2024/monsters/ghoul",
+    "image": "/api/images/monsters/ghoul.png",
+    "hit_points_roll": "5d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Gibbering Mouther",
+    "size": "Medium",
+    "type": "aberration",
+    "alignment": "chaotic neutral",
+    "armor_class": 9,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 52,
+    "hit_dice": "7d8",
+    "speed": {
+      "walk": "20 ft.",
+      "swim": "20 ft."
+    },
+    "strength": 10,
+    "dexterity": 8,
+    "constitution": 16,
+    "intelligence": 3,
+    "wisdom": 10,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "prone"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Aberrant Ground",
+        "desc": "The ground in a 10-foot Emanation originating from the mouther is Difficult Terrain."
+      },
+      {
+        "name": "Gibbering",
+        "desc": "The mouther babbles incoherently while it doesn’t have the Incapacitated condition. Wisdom Saving Throw: DC 10, any creature that starts its turn within 20 feet of the mouther while it is babbling. Failure: The target rolls 1d8 to determine what it does during the current turn: 1–4. The target does nothing. 5–6. The target takes no action or Bonus Action and uses all its movement to move in a random direction. 7–8. The target makes a melee attack against a randomly determined creature within its reach or does nothing if it can’t make such an attack."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 7 (2d6) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition. The target dies if it is reduced to 0 Hit Points by this attack. Its body is then absorbed into the mouther, leaving only equipment behind."
+      },
+      {
+        "name": "Blinding Spittle (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 10, each creature in a 10-foot-radius Sphere centered on a point within 30 feet. Failure: 7 (2d6) Radiant damage, and the target has the Blinded condition until the end of the mouther’s next turn.",
+        "damage_dice": "2d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "gibbering-mouther",
+    "url": "/api/2024/monsters/gibbering-mouther",
+    "image": "/api/images/monsters/gibbering-mouther.png",
+    "hit_points_roll": "7d8 + 21",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Glabrezu",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 189,
+    "hit_dice": "18d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 20,
+    "dexterity": 15,
+    "constitution": 21,
+    "intelligence": 19,
+    "wisdom": 17,
+    "charisma": 16,
+    "perception": 7,
+    "damage_resistances": [
+      "cold",
+      "fire",
+      "lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 17
+    },
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "9",
+    "special_abilities": [
+      {
+        "name": "Demonic Restoration",
+        "desc": "If the glabrezu dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The glabrezu has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The glabrezu makes two Pincer attacks and uses Pummel or Spellcasting."
+      },
+      {
+        "name": "Pincer",
+        "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 15) from one of two pincers.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Pummel",
+        "desc": "Dexterity Saving Throw: DC 17, one creature"
+      },
+      {
+        "name": "Grappled by the glabrezu",
+        "desc": "Failure: 15 (3d6 + 5) Bludgeoning damage. Success: Half damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The glabrezu casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 16):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Darkness, Detect Magic, Dispel Magic"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Confusion, Fly, Power Word Stun"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "glabrezu",
+    "url": "/api/2024/monsters/glabrezu",
+    "image": "/api/images/monsters/glabrezu.png",
+    "hit_points_roll": "18d10 + 90",
+    "proficiencies": [
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 17"
+  },
+  {
+    "name": "Gladiator",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 112,
+    "hit_dice": "15d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 18,
+    "dexterity": 15,
+    "constitution": 16,
+    "intelligence": 10,
+    "wisdom": 12,
+    "charisma": 15,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 11
+    },
+    "languages": "Common",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The gladiator makes three Spear attacks. It can replace one attack with a use of Shield Bash."
+      },
+      {
+        "name": "Spear",
+        "desc": "Melee or Ranged Attack Roll: +7, reach 5 ft. or range 20/60 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Shield Bash",
+        "desc": "Strength Saving Throw: DC 15, one creature within 5 feet that the gladiator can see. Failure: 9 (2d4 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The gladiator is hit by a melee attack roll while holding a weapon. Response: The gladiator adds 3 to its AC against that attack, possibly causing it to miss. Gnoll"
+      }
+    ],
+    "legendary_actions": [],
+    "index": "gladiator",
+    "url": "/api/2024/monsters/gladiator",
+    "image": "/api/images/monsters/gladiator.png",
+    "hit_points_roll": "15d8 + 45",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 11"
+  },
+  {
+    "name": "Gnoll Warrior",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 27,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 14,
+    "dexterity": 12,
+    "constitution": 11,
+    "intelligence": 6,
+    "wisdom": 10,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Gnoll",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Bone Bow",
+        "desc": "Ranged Attack Roll: +3, range 150/600 ft. Hit: 6 (1d10 + 1) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Rampage (1/Day)",
+        "desc": "Immediately after dealing damage to a creature that is already Bloodied, the gnoll moves up to half its Speed, and it makes one Rend attack. Goblins"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "gnoll-warrior",
+    "url": "/api/2024/monsters/gnoll-warrior",
+    "image": "/api/images/monsters/gnoll-warrior.png",
+    "hit_points_roll": "6d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Goblin Minion",
+    "size": "Small",
+    "type": "fey",
+    "alignment": "chaotic neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 7,
+    "hit_dice": "2d6",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 8,
+    "dexterity": 15,
+    "constitution": 10,
+    "intelligence": 10,
+    "wisdom": 8,
+    "charisma": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "Common, Goblin",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Dagger",
+        "desc": "Melee or Ranged Attack Roll: +4, reach 5 ft. or range 20/60 ft. Hit: 4 (1d4 + 2) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The goblin takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "goblin-minion",
+    "url": "/api/2024/monsters/goblin-minion",
+    "image": "/api/images/monsters/goblin-minion.png",
+    "hit_points_roll": "2d6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Goblin Warrior",
+    "size": "Small",
+    "type": "fey",
+    "alignment": "chaotic neutral",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 10,
+    "hit_dice": "3d6",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 8,
+    "dexterity": 15,
+    "constitution": 10,
+    "intelligence": 10,
+    "wisdom": 8,
+    "charisma": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "Common, Goblin",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Scimitar",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage, plus 2 (1d4) Slashing damage if the attack roll had Advantage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Shortbow",
+        "desc": "Ranged Attack Roll: +4, range 80/320 ft. Hit: 5 (1d6 + 2) Piercing damage, plus 2 (1d4) Piercing damage if the attack roll had Advantage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The goblin takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "goblin-warrior",
+    "url": "/api/2024/monsters/goblin-warrior",
+    "image": "/api/images/monsters/goblin-warrior.png",
+    "hit_points_roll": "3d6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Goblin Boss",
+    "size": "Small",
+    "type": "fey",
+    "alignment": "chaotic neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 21,
+    "hit_dice": "6d6",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 15,
+    "constitution": 10,
+    "intelligence": 10,
+    "wisdom": 8,
+    "charisma": 10,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "Common, Goblin",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The goblin makes two attacks, using Scimitar or Shortbow in any combination."
+      },
+      {
+        "name": "Scimitar",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage, plus 2 (1d4) Slashing damage if the attack roll had Advantage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Shortbow",
+        "desc": "Ranged Attack Roll: +4, range 80/320 ft. Hit: 5 (1d6 + 2) Piercing damage, plus 2 (1d4) Piercing damage if the attack roll had Advantage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The goblin takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": [
+      {
+        "name": "Redirect Attack",
+        "desc": "Trigger: A creature the goblin can see makes an attack roll against it. Response: The goblin chooses a Small or Medium ally within 5 feet of itself. The goblin and that ally swap places, and the ally becomes the target of the attack instead. Gold Dragons"
+      }
+    ],
+    "legendary_actions": [],
+    "index": "goblin-boss",
+    "url": "/api/2024/monsters/goblin-boss",
+    "image": "/api/images/monsters/goblin-boss.png",
+    "hit_points_roll": "6d6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Gold Dragon Wyrmling",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 60,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 19,
+    "dexterity": 14,
+    "constitution": 17,
+    "intelligence": 14,
+    "wisdom": 11,
+    "charisma": 16,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Draconic",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 13, each creature in a 15-foot Cone. Failure: 22 (4d10) Fire damage. Success: Half damage.",
+        "damage_dice": "4d10"
+      },
+      {
+        "name": "Weakening Breath",
+        "desc": "Strength Saving Throw: DC 13, each creature that isn’t currently affected by this breath in a 15-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 2 (1d4) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "gold-dragon-wyrmling",
+    "url": "/api/2024/monsters/gold-dragon-wyrmling",
+    "image": "/api/images/monsters/gold-dragon-wyrmling.png",
+    "hit_points_roll": "8d8 + 24",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Young Gold Dragon",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 178,
+    "hit_dice": "17d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 23,
+    "dexterity": 14,
+    "constitution": 21,
+    "intelligence": 16,
+    "wisdom": 13,
+    "charisma": 20,
+    "perception": 9,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "10",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Weakening Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 17, each creature in a 30-foot Cone. Failure: 55 (10d10) Fire damage. Success: Half damage.",
+        "damage_dice": "10d10"
+      },
+      {
+        "name": "Weakening Breath",
+        "desc": "Strength Saving Throw: DC 17, each creature that isn’t currently affected by this breath in a 30-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 3 (1d6) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+        "damage_dice": "1d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "young-gold-dragon",
+    "url": "/api/2024/monsters/young-gold-dragon",
+    "image": "/api/images/monsters/young-gold-dragon.png",
+    "hit_points_roll": "17d10 + 85",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Adult Gold Dragon",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 243,
+    "hit_dice": "18d12",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 27,
+    "dexterity": 14,
+    "constitution": 25,
+    "intelligence": 16,
+    "wisdom": 15,
+    "charisma": 24,
+    "perception": 14,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "17",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Spellcasting to cast Guiding Bolt (level 2 version) or (B) Weakening Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 17 (2d8 + 8) Slashing damage plus 4 (1d8) Fire damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 21, each creature in a 60-foot Cone. Failure: 66 (12d10) Fire damage. Success: Half damage.",
+        "damage_dice": "12d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks):",
+        "attack_bonus": 13
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Flame Strike, Zone of Truth"
+      },
+      {
+        "name": "Weakening Breath",
+        "desc": "Strength Saving Throw: DC 21, each creature that isn’t currently affected by this breath in a 60-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 3 (1d6) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+        "damage_dice": "1d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Banish",
+        "desc": "Charisma Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 10 (3d6) Force damage, and the target has the Incapacitated condition and is transported to a harmless demiplane until the start of the dragon’s next turn, at which point it re appears in an unoccupied space of the dragon’s choice within 120 feet of the dragon. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "3d6"
+      },
+      {
+        "name": "Guiding Light",
+        "desc": "The dragon uses Spellcasting to cast Guiding Bolt (level 2 version)."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "adult-gold-dragon",
+    "url": "/api/2024/monsters/adult-gold-dragon",
+    "image": "/api/images/monsters/adult-gold-dragon.png",
+    "hit_points_roll": "18d12 + 126",
+    "proficiencies": [
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Ancient Gold Dragon",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 16,
+    "hit_points": 546,
+    "hit_dice": "28d20",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 30,
+    "dexterity": 14,
+    "constitution": 29,
+    "intelligence": 18,
+    "wisdom": 17,
+    "charisma": 28,
+    "perception": 17,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "24",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Spellcasting to cast Guiding Bolt (level 4 version) or (B) Weakening Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +17 to hit, reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 9 (2d8) Fire damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 10,
+        "attack_bonus": 17
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 24, each creature in a 90-foot Cone. Failure: 71 (13d10) Fire damage. Success: Half damage.",
+        "damage_dice": "13d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 24, +16 to hit with spell attacks):",
+        "attack_bonus": 16
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Guiding Bolt (level 4 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Flame Strike (level 6 version), Word of Recall, Zone of Truth"
+      },
+      {
+        "name": "Weakening Breath",
+        "desc": "Strength Saving Throw: DC 24, each creature that isn’t currently affected by this breath in a 90-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 5 (1d10) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+        "damage_dice": "1d10"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Banish",
+        "desc": "Charisma Saving Throw: DC 24, one creature the dragon can see within 120 feet. Failure: 24 (7d6) Force damage, and the target has the Incapacitated condition and is transported to a harmless demiplane until the start of the dragon’s next turn, at which point it reappears in an unoccupied space of the dragon’s choice within 120 feet of the dragon. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "7d6"
+      },
+      {
+        "name": "Guiding Light",
+        "desc": "The dragon uses Spellcasting to cast Guiding Bolt (level 4 version)."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "ancient-gold-dragon",
+    "url": "/api/2024/monsters/ancient-gold-dragon",
+    "image": "/api/images/monsters/ancient-gold-dragon.png",
+    "hit_points_roll": "28d20 + 252",
+    "proficiencies": [
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Gorgon",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 114,
+    "hit_dice": "12d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 20,
+    "dexterity": 11,
+    "constitution": 18,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "exhaustion",
+      "petrified"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 17
+    },
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 18 (2d12 + 5) Piercing damage. If the target is a Large or smaller creature and the gorgon moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+        "damage_dice": "2d12",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Petrifying Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 15, each creature in a 30-foot Cone. First Failure: The target has the Restrained condition and repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition instead of the Restrained condition."
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Trample",
+        "desc": "Dexterity Saving Throw: DC 16, one creature within 5 feet that has the Prone condition. Failure: 16 (2d10 + 5) Bludgeoning damage. Success: Half damage."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "gorgon",
+    "url": "/api/2024/monsters/gorgon",
+    "image": "/api/images/monsters/gorgon.png",
+    "hit_points_roll": "12d10 + 48",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 17"
+  },
+  {
+    "name": "Gray Ooze",
+    "size": "Medium",
+    "type": "ooze",
+    "alignment": "unaligned",
+    "armor_class": 9,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 22,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": "10 ft.",
+      "climb": "10 ft."
+    },
+    "strength": 12,
+    "dexterity": 6,
+    "constitution": 16,
+    "intelligence": 1,
+    "wisdom": 6,
+    "charisma": 2,
+    "damage_resistances": [
+      "acid",
+      "cold",
+      "fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "blinded",
+      "charmed",
+      "deafened",
+      "exhaustion",
+      "frightened",
+      "grappled",
+      "prone",
+      "restrained"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 8
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Amorphous",
+        "desc": "The ooze can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Corrosive Form",
+        "desc": "Nonmagical ammunition is destroyed immediately after hitting the ooze and dealing any damage. Any nonmagical weapon takes a cumulative −1 penalty to attack rolls immediately after dealing damage to the ooze and coming into contact with it. The weapon is destroyed if the penalty reaches −5. The penalty can be removed by casting the Mending spell on the weapon. The ooze can eat through 2-inch-thick, nonmagical metal or wood in 1 round."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Pseudopod",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 10 (2d8 + 1) Acid damage. Nonmagical armor worn by the target takes a −1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10. The penalty can be removed by casting the Mending spell on the armor. Green Dragons",
+        "damage_dice": "2d8",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "gray-ooze",
+    "url": "/api/2024/monsters/gray-ooze",
+    "image": "/api/images/monsters/gray-ooze.png",
+    "hit_points_roll": "3d8 + 9",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Green Dragon Wyrmling",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 38,
+    "hit_dice": "7d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 12,
+    "constitution": 13,
+    "intelligence": 14,
+    "wisdom": 11,
+    "charisma": 13,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Draconic",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage plus 3 (1d6) Poison damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Poison Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: 21 (6d6) Poison damage. Success: Half damage.",
+        "damage_dice": "6d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "green-dragon-wyrmling",
+    "url": "/api/2024/monsters/green-dragon-wyrmling",
+    "image": "/api/images/monsters/green-dragon-wyrmling.png",
+    "hit_points_roll": "7d8 + 7",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Young Green Dragon",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 136,
+    "hit_dice": "16d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 19,
+    "dexterity": 12,
+    "constitution": 17,
+    "intelligence": 16,
+    "wisdom": 13,
+    "charisma": 15,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "blindsight": "30 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Poison Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: 42 (12d6) Poison damage. Success: Half damage.",
+        "damage_dice": "12d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "young-green-dragon",
+    "url": "/api/2024/monsters/young-green-dragon",
+    "image": "/api/images/monsters/young-green-dragon.png",
+    "hit_points_roll": "16d10 + 48",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Adult Green Dragon",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 11,
+    "hit_points": 207,
+    "hit_dice": "18d12",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 23,
+    "dexterity": 12,
+    "constitution": 21,
+    "intelligence": 18,
+    "wisdom": 15,
+    "charisma": 18,
+    "perception": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "15",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Mind Spike (level 3 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 15 (2d8 + 6) Slashing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Poison Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: 56 (16d6) Poison damage. Success: Half damage.",
+        "damage_dice": "16d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Mind Spike (level 3 version)"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Geas"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Mind Invasion",
+        "desc": "The dragon uses Spellcasting to cast Mind Spike (level 3 version)."
+      },
+      {
+        "name": "Noxious Miasma",
+        "desc": "Constitution Saving Throw: DC 17, each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 7 (2d6) Poison damage, and the target takes a −2 penalty to AC until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "2d6"
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "adult-green-dragon",
+    "url": "/api/2024/monsters/adult-green-dragon",
+    "image": "/api/images/monsters/adult-green-dragon.png",
+    "hit_points_roll": "18d12 + 90",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Ancient Green Dragon",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 21,
+    "armor_desc": "",
+    "initiative": 15,
+    "hit_points": 402,
+    "hit_dice": "23d20",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 27,
+    "dexterity": 12,
+    "constitution": 25,
+    "intelligence": 20,
+    "wisdom": 17,
+    "charisma": 22,
+    "perception": 17,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "22",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Mind Spike (level 5 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +15, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 10 (3d6) Poison damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Poison Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Failure: 77 (22d6) Poison damage. Success: Half damage.",
+        "damage_dice": "22d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Mind Spike (level 5 version)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Geas, Modify Memory"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Mind Invasion",
+        "desc": "The dragon uses Spellcasting to cast Mind Spike (level 5 version)."
+      },
+      {
+        "name": "Noxious Miasma",
+        "desc": "Constitution Saving Throw: DC 21, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 17 (5d6) Poison damage, and the target takes a −2 penalty to AC until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "5d6"
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "ancient-green-dragon",
+    "url": "/api/2024/monsters/ancient-green-dragon",
+    "image": "/api/images/monsters/ancient-green-dragon.png",
+    "hit_points_roll": "23d20 + 161",
+    "proficiencies": [
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Green Hag",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "neutral evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 82,
+    "hit_dice": "11d8",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 18,
+    "dexterity": 12,
+    "constitution": 16,
+    "intelligence": 13,
+    "wisdom": 14,
+    "charisma": 14,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Common, Elvish, Sylvan",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The hag can breathe air and water."
+      },
+      {
+        "name": "Coven Magic",
+        "desc": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spellcasting ability (spell save DC 11): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant. The hag must finish a Long Rest before using this trait to cast that spell again."
+      },
+      {
+        "name": "Mimicry",
+        "desc": "The hag can mimic animal sounds and humanoid voices. A creature that hears the sounds can tell they are imitations only with a successful DC 14 Wisdom (Insight) check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hag makes two Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Slashing damage plus 3 (1d6) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The hag casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks):",
+        "attack_bonus": 4
+      },
+      {
+        "name": "At Will",
+        "desc": "Dancing Lights, Disguise Self (24-hour duration), Invisibility (self only, and the hag leaves no tracks while Invisible), Minor Illusion, Ray of Sickness (level 3 version)"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "green-hag",
+    "url": "/api/2024/monsters/green-hag",
+    "image": "/api/images/monsters/green-hag.png",
+    "hit_points_roll": "11d8 + 33",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Grick",
+    "size": "Medium",
+    "type": "aberration",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 54,
+    "hit_dice": "12d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 14,
+    "dexterity": 14,
+    "constitution": 11,
+    "intelligence": 3,
+    "wisdom": 14,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The grick makes one Beak attack and one Tentacles attack."
+      },
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Tentacles",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12) from all four tentacles.",
+        "damage_dice": "1d10",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "grick",
+    "url": "/api/2024/monsters/grick",
+    "image": "/api/images/monsters/grick.png",
+    "hit_points_roll": "12d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Griffon",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 59,
+    "hit_dice": "7d10",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 18,
+    "dexterity": 15,
+    "constitution": 16,
+    "intelligence": 2,
+    "wisdom": 13,
+    "charisma": 8,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The griffon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 14) from both of the griffon’s front claws."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "griffon",
+    "url": "/api/2024/monsters/griffon",
+    "image": "/api/images/monsters/griffon.png",
+    "hit_points_roll": "7d10 + 21",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Grimlock",
+    "size": "Medium",
+    "type": "aberration",
+    "alignment": "neutral evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 12,
+    "constitution": 12,
+    "intelligence": 9,
+    "wisdom": 8,
+    "charisma": 6,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bone Cudgel",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage plus 2 (1d4) Psychic damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "grimlock",
+    "url": "/api/2024/monsters/grimlock",
+    "image": "/api/images/monsters/grimlock.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [],
+    "old_senses": "Blindsight 30 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Guardian Naga",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 136,
+    "hit_dice": "16d10",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 19,
+    "dexterity": 18,
+    "constitution": 16,
+    "intelligence": 16,
+    "wisdom": 19,
+    "charisma": 18,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "paralyzed",
+      "poisoned",
+      "restrained"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Celestial, Common",
+    "challenge_rating": "10",
+    "special_abilities": [
+      {
+        "name": "Celestial Restoration",
+        "desc": "If the naga dies, it returns to life in 1d6 days and regains all its Hit Points unless Dispel Evil and Good is cast on its remains."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The naga makes two Bite attacks. It can replace any attack with a use of Poisonous Spittle."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 17 (2d12 + 4) Piercing damage plus 22 (4d10) Poison damage.",
+        "damage_dice": "2d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Poisonous Spittle",
+        "desc": "Constitution Saving Throw: DC 16, one creature the naga can see within 60 feet. Failure: 31 (7d8) Poison damage, and the target has the Blinded condition until the start of the naga’s next turn. Success: Half damage only.",
+        "damage_dice": "7d8"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The naga casts one of the following spells, requiring no Somatic or Material components and using Wisdom as the spellcasting ability (spell save DC 16):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Thaumaturgy"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Clairvoyance, Cure Wounds (level 6 version), Flame Strike (level 6 version), Geas, True Seeing Guards"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "guardian-naga",
+    "url": "/api/2024/monsters/guardian-naga",
+    "image": "/api/images/monsters/guardian-naga.png",
+    "hit_points_roll": "16d10 + 48",
+    "proficiencies": [
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Guard",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 13,
+    "dexterity": 12,
+    "constitution": 12,
+    "intelligence": 10,
+    "wisdom": 11,
+    "charisma": 10,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "Common",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Spear",
+        "desc": "Melee or Ranged Attack Roll: +3, reach 5 ft. or range 20/60 ft. Hit: 4 (1d6 + 1) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "guard",
+    "url": "/api/2024/monsters/guard",
+    "image": "/api/images/monsters/guard.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Guard Captain",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 75,
+    "hit_dice": "10d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 18,
+    "dexterity": 14,
+    "constitution": 16,
+    "intelligence": 12,
+    "wisdom": 14,
+    "charisma": 13,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 14
+    },
+    "languages": "Common",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The guard makes two attacks, using Javelin or Longsword in any combination."
+      },
+      {
+        "name": "Javelin",
+        "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 30/120 ft. Hit: 14 (3d6 + 4) Piercing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Longsword",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "guard-captain",
+    "url": "/api/2024/monsters/guard-captain",
+    "image": "/api/images/monsters/guard-captain.png",
+    "hit_points_roll": "10d8 + 30",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 14"
+  },
+  {
+    "name": "Half-Dragon",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "neutral",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 105,
+    "hit_dice": "14d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 19,
+    "dexterity": 14,
+    "constitution": 16,
+    "intelligence": 10,
+    "wisdom": 15,
+    "charisma": 14,
+    "perception": 5,
+    "damage_resistances": [
+      "damage type chosen for the draconic origin"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Draconic Origin",
+        "desc": "The half-dragon is related to a type of dragon associated with one of the following damage types (GM’s choice): Acid, Cold, Fire, Lightning, or Poison. This choice affects other aspects of the stat block."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The half-dragon makes two Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 6 (1d4 + 4) Slashing damage plus 7 (2d6) damage of the type chosen for the Draconic Origin trait. Dragon’s Breath (Recharge 5–6). Dexterity Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: 28 (8d6) damage of the type chosen for the Draconic",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Origin trait",
+        "desc": "Success: Half damage."
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Leap",
+        "desc": "The half-dragon jumps up to 30 feet by spending 10 feet of movement."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "half-dragon",
+    "url": "/api/2024/monsters/half-dragon",
+    "image": "/api/images/monsters/half-dragon.png",
+    "hit_points_roll": "14d8 + 42",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Harpy",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 38,
+    "hit_dice": "7d8",
+    "speed": {
+      "walk": "20 ft.",
+      "fly": "40 ft."
+    },
+    "strength": 12,
+    "dexterity": 13,
+    "constitution": 12,
+    "intelligence": 7,
+    "wisdom": 10,
+    "charisma": 13,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Slashing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Luring Song",
+        "desc": "The harpy sings a magical melody, which lasts until the harpy’s Concentration ends on it. Wisdom Saving Throw: DC 11, each Humanoid and Giant in a 300-foot Emanation originating from the harpy when the song starts. Failure: The target has the Charmed condition until the song ends and repeats the save at the end of each of its turns. While Charmed, the target has the Incapacitated condition and ignores the Luring"
+      },
+      {
+        "name": "Song of other harpies",
+        "desc": "If the target is more than 5 feet from the harpy, the target moves on its turn toward the harpy by the most direct route, trying to get within 5 feet of the harpy. It doesn’t avoid Opportunity Attacks; however, before moving into damaging terrain (such as lava or a pit) and whenever it takes damage from a source other than the harpy, the target repeats the save. Success: The target is immune to this harpy’s Luring Song for 24 hours."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "harpy",
+    "url": "/api/2024/monsters/harpy",
+    "image": "/api/images/monsters/harpy.png",
+    "hit_points_roll": "7d8 + 7",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Hell Hound",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 58,
+    "hit_dice": "9d8",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 17,
+    "dexterity": 12,
+    "constitution": 14,
+    "intelligence": 6,
+    "wisdom": 13,
+    "charisma": 6,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "Understands Infernal but can’t speak",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The hound has Advantage on an attack roll against a creature if at least one of the hound’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hound makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 3 (1d6) Fire damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 17 (5d6) Fire damage. Success: Half damage.",
+        "damage_dice": "5d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hell-hound",
+    "url": "/api/2024/monsters/hell-hound",
+    "image": "/api/images/monsters/hell-hound.png",
+    "hit_points_roll": "9d8 + 18",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Hezrou",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 157,
+    "hit_dice": "15d10",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 19,
+    "dexterity": 17,
+    "constitution": 20,
+    "intelligence": 5,
+    "wisdom": 12,
+    "charisma": 13,
+    "damage_resistances": [
+      "cold",
+      "fire",
+      "lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Demonic Restoration",
+        "desc": "If the hezrou dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The hezrou has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Stench",
+        "desc": "Constitution Saving Throw: DC 16, any creature that starts its turn in a 10-foot Emanation originating from the hezrou. Failure: The target has the Poisoned condition until the start of its next turn."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hezrou makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 6 (1d4 + 4) Slashing damage plus 9 (2d8) Poison damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Leap",
+        "desc": "The hezrou jumps up to 30 feet by spending 10 feet of movement."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hezrou",
+    "url": "/api/2024/monsters/hezrou",
+    "image": "/api/images/monsters/hezrou.png",
+    "hit_points_roll": "15d10 + 75",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Hill Giant",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 105,
+    "hit_dice": "10d12",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 21,
+    "dexterity": 8,
+    "constitution": 19,
+    "intelligence": 5,
+    "wisdom": 9,
+    "charisma": 6,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "Giant",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Tree Club or Trash Lob in any combination."
+      },
+      {
+        "name": "Tree Club",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 18 (3d8 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "3d8",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Trash Lob",
+        "desc": "Ranged Attack Roll: +8, range 60/240 ft. Hit: 16 (2d10 + 5) Bludgeoning damage, and the target has the Poisoned condition until the end of its next turn.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hill-giant",
+    "url": "/api/2024/monsters/hill-giant",
+    "image": "/api/images/monsters/hill-giant.png",
+    "hit_points_roll": "10d12 + 40",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Hippogriff",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 26,
+    "hit_dice": "4d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 17,
+    "dexterity": 13,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 8,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The hippogriff doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hippogriff makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage. Hobgoblins",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hippogriff",
+    "url": "/api/2024/monsters/hippogriff",
+    "image": "/api/images/monsters/hippogriff.png",
+    "hit_points_roll": "4d10 + 4",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 15"
+  },
+  {
+    "name": "Hobgoblin Warrior",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 13,
+    "dexterity": 12,
+    "constitution": 12,
+    "intelligence": 10,
+    "wisdom": 10,
+    "charisma": 9,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Common, Goblin",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The hobgoblin has Advantage on an attack roll against a creature if at least one of the hobgoblin’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Longsword",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 12 (2d10 + 1) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Longbow",
+        "desc": "Ranged Attack Roll: +3, range 150/600 ft. Hit: 5 (1d8 + 1) Piercing damage plus 7 (3d4) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hobgoblin-warrior",
+    "url": "/api/2024/monsters/hobgoblin-warrior",
+    "image": "/api/images/monsters/hobgoblin-warrior.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Hobgoblin Captain",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 58,
+    "hit_dice": "9d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 14,
+    "constitution": 14,
+    "intelligence": 12,
+    "wisdom": 10,
+    "charisma": 13,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Common, Goblin",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Aura of Authority",
+        "desc": "While in a 10-foot Emanation originating from the hobgoblin, the hobgoblin and its allies have Advantage on attack rolls and saving throws, provided the hobgoblin doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hobgoblin makes two attacks, using Greatsword or Longbow in any combination."
+      },
+      {
+        "name": "Greatsword",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Slashing damage plus 3 (1d6) Poison damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Longbow",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage plus 5 (2d4) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hobgoblin-captain",
+    "url": "/api/2024/monsters/hobgoblin-captain",
+    "image": "/api/images/monsters/hobgoblin-captain.png",
+    "hit_points_roll": "9d8 + 18",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Homunculus",
+    "size": "Tiny",
+    "type": "construct",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 4,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "20 ft.",
+      "fly": "40 ft."
+    },
+    "strength": 4,
+    "dexterity": 15,
+    "constitution": 14,
+    "intelligence": 10,
+    "wisdom": 10,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Understands Common plus one other language",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Telepathic Bond",
+        "desc": "While the homunculus is on the same plane of existence as its master, the two of them can communicate telepathically with each other."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage, and the target is subjected to the following effect. Constitution Saving Throw: DC 12. Failure: The target has the Poisoned condition until the end of the homunculus’s next turn. Failure by 5 or More: The target has the Poisoned condition for 1 minute. While Poisoned, the target has the Unconscious condition, which ends early if the target takes any damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "homunculus",
+    "url": "/api/2024/monsters/homunculus",
+    "image": "/api/images/monsters/homunculus.png",
+    "hit_points_roll": "1d4 + 2",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 0,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Horned Devil",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 199,
+    "hit_dice": "19d10",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 22,
+    "dexterity": 17,
+    "constitution": 21,
+    "intelligence": 12,
+    "wisdom": 16,
+    "charisma": 18,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "150 ft. (unimpeded by magical"
+    },
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "11",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes three attacks, using Searing Fork or Hurl Flame in any combination. It can replace one attack with a use of Infernal Tail."
+      },
+      {
+        "name": "Searing Fork",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (2d8 + 6) Piercing damage plus 9 (2d8) Fire damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Hurl Flame",
+        "desc": "Ranged Attack Roll: +8, range 150 ft. Hit: 26 (5d8 + 4) Fire damage. If the target is a flammable object that isn’t being worn or carried, it starts burning.",
+        "damage_dice": "5d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Infernal Tail",
+        "desc": "Dexterity Saving Throw: DC 17, one creature the devil can see within 10 feet. Failure: 10 (1d8 + 6) Necrotic damage, and the target receives an infernal wound if it doesn’t have one. While wounded, the target loses 10 (3d6) Hit Points at the start of each of its turns. The wound closes after 1 minute, after a spell restores Hit Points to the target, or after the target or a creature within 5 feet of it takes an action to stanch the wound, doing so by succeeding on a DC 17 Wisdom (Medicine) check.",
+        "damage_dice": "1d8",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "horned-devil",
+    "url": "/api/2024/monsters/horned-devil",
+    "image": "/api/images/monsters/horned-devil.png",
+    "hit_points_roll": "19d10 + 95",
+    "proficiencies": [
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 150 ft. (unimpeded by magical"
+  },
+  {
+    "name": "Hydra",
+    "size": "Huge",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 184,
+    "hit_dice": "16d12",
+    "speed": {
+      "walk": "40 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 20,
+    "dexterity": 12,
+    "constitution": 20,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 7,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "blinded",
+      "charmed",
+      "deafened",
+      "frightened",
+      "stunned",
+      "unconscious"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 16
+    },
+    "languages": "None",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The hydra can hold its breath for 1 hour."
+      },
+      {
+        "name": "Multiple Heads",
+        "desc": "The hydra has five heads. Whenever the hydra takes 25 damage or more on a single turn, one of its heads dies. The hydra dies if all its heads are dead. At the end of each of its turns when it has at least one living head, the hydra grows two heads for each of its heads that died since its last turn, unless it has taken"
+      },
+      {
+        "name": "Fire damage since its last turn",
+        "desc": "The hydra regains 20 Hit Points when it grows new heads."
+      },
+      {
+        "name": "Reactive Heads",
+        "desc": "For each head the hydra has beyond one, it gets an extra Reaction that can be used only for Opportunity Attacks."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hydra makes as many Bite attacks as it has heads."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 10 (1d10 + 5) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hydra",
+    "url": "/api/2024/monsters/hydra",
+    "image": "/api/images/monsters/hydra.png",
+    "hit_points_roll": "16d12 + 80",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 16"
+  },
+  {
+    "name": "Ice Devil",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 228,
+    "hit_dice": "24d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 21,
+    "dexterity": 14,
+    "constitution": 18,
+    "intelligence": 18,
+    "wisdom": 15,
+    "charisma": 18,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold",
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "blindsight": "120 ft.",
+      "passive_perception": 17
+    },
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "14",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes three Ice Spear attacks. It can replace one attack with a Tail attack."
+      },
+      {
+        "name": "Ice Spear",
+        "desc": "Melee or Ranged Attack Roll: +10, reach 5 ft. or range 30/120 ft. Hit: 14 (2d8 + 5) Piercing damage plus 10 (3d6) Cold damage. Until the end of its next turn, the target can’t take a Bonus Action or Reaction, its Speed decreases by 10 feet, and it can move or take one action on its turn, not both. Hit or Miss: The spear magically returns to the devil’s hand immediately after a ranged attack.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (3d6 + 5) Bludgeoning damage plus 18 (4d8) Cold damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Ice Wall (Recharge 6)",
+        "desc": "The devil casts Wall of Ice (level 8 version), requiring no spell components and using Intelligence as the spellcasting ability (spell save DC 17)."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ice-devil",
+    "url": "/api/2024/monsters/ice-devil",
+    "image": "/api/images/monsters/ice-devil.png",
+    "hit_points_roll": "24d10 + 96",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 120 ft.; Passive Perception 17"
+  },
+  {
+    "name": "Imp",
+    "size": "Tiny",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 21,
+    "hit_dice": "6d4",
+    "speed": {
+      "walk": "20 ft.",
+      "fly": "40 ft."
+    },
+    "strength": 6,
+    "dexterity": 17,
+    "constitution": 13,
+    "intelligence": 11,
+    "wisdom": 12,
+    "charisma": 14,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft. (unimpeded by magical"
+    },
+    "languages": "Common, Infernal",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The imp has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Sting",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Invisibility",
+        "desc": "The imp casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability."
+      },
+      {
+        "name": "Shape-Shift",
+        "desc": "The imp shape-shifts to resemble a rat (Speed 20 ft.), a raven (20 ft., Fly 60 ft.), or a spider (20 ft., Climb 20 ft.), or it returns to its true form. Its game statistics are the same in each form, except for its Speed. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "imp",
+    "url": "/api/2024/monsters/imp",
+    "image": "/api/images/monsters/imp.png",
+    "hit_points_roll": "6d4 + 6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft. (unimpeded by magical"
+  },
+  {
+    "name": "Incubus",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 66,
+    "hit_dice": "12d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 8,
+    "dexterity": 17,
+    "constitution": 13,
+    "intelligence": 15,
+    "wisdom": 12,
+    "charisma": 20,
+    "perception": 5,
+    "damage_resistances": [
+      "cold",
+      "fire",
+      "poison",
+      "psychic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "Abyssal, Common, Infernal; telepathy 60 ft.",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Succubus Form",
+        "desc": "When the incubus finishes a Long Rest, it can shape-shift into a Succubus, using that stat block instead of this one. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The incubus makes two Restless Touch attacks."
+      },
+      {
+        "name": "Restless Touch",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 15 (3d6 + 5) Psychic damage, and the target is cursed for 24 hours or until the incubus dies. Until the curse ends, the target gains no benefit from finishing Short Rests.",
+        "damage_dice": "3d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The incubus casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Disguise Self, Etherealness"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Dream, Hypnotic Pattern"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nightmare (Recharge 6)",
+        "desc": "Wisdom Saving Throw: DC 15, one creature the incubus can see within 60 feet. Failure: If the target has 20 Hit Points or fewer, it has the Unconscious condition for 1 hour, until it takes damage, or until a creature within 5 feet of it takes an action to wake it. Otherwise, the target takes 18 (4d8) Psychic damage."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "incubus",
+    "url": "/api/2024/monsters/incubus",
+    "image": "/api/images/monsters/incubus.png",
+    "hit_points_roll": "12d8 + 12",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Invisible Stalker",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 97,
+    "hit_dice": "13d10",
+    "speed": {
+      "walk": "50 ft.",
+      "fly": "50 ft.",
+      "hover": true
+    },
+    "strength": 16,
+    "dexterity": 19,
+    "constitution": 14,
+    "intelligence": 10,
+    "wisdom": 15,
+    "charisma": 11,
+    "perception": 8,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "prone",
+      "restrained",
+      "unconscious"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 18
+    },
+    "languages": "Common, Primordial (Auran)",
+    "challenge_rating": "6",
+    "special_abilities": [
+      {
+        "name": "Air Form",
+        "desc": "The stalker can enter an enemy’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Invisibility",
+        "desc": "The stalker has the Invisible condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The stalker makes three Wind Swipe attacks. It can replace one attack with a use of Vortex."
+      },
+      {
+        "name": "Wind Swipe",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (2d6 + 4) Force damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Vortex",
+        "desc": "Constitution Saving Throw: DC 14, one Large or smaller creature in the stalker’s space. Failure: 7 (1d8 + 3) Thunder damage, and the target has the Grappled condition (escape DC 13). Until the grapple ends, the target can’t cast spells with a Verbal component and takes 7 (2d6) Thunder damage at the start of each of the stalker’s turns.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "invisible-stalker",
+    "url": "/api/2024/monsters/invisible-stalker",
+    "image": "/api/images/monsters/invisible-stalker.png",
+    "hit_points_roll": "13d10 + 26",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 18"
+  },
+  {
+    "name": "Iron Golem",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 9,
+    "hit_points": 252,
+    "hit_dice": "24d10",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 24,
+    "dexterity": 9,
+    "constitution": 20,
+    "intelligence": 3,
+    "wisdom": 11,
+    "charisma": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison",
+      "psychic"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Understands Common plus two other",
+    "challenge_rating": "16",
+    "special_abilities": [
+      {
+        "name": "Fire Absorption",
+        "desc": "Whenever the golem is subjected to Fire damage, it regains a number of Hit Points equal to the Fire damage dealt."
+      },
+      {
+        "name": "Immutable Form",
+        "desc": "The golem can’t shape-shift."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The golem makes two attacks, using Bladed Arm or Fiery Bolt in any combination."
+      },
+      {
+        "name": "Bladed Arm",
+        "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 20 (3d8 + 7) Slashing damage plus 10 (3d6) Fire damage.",
+        "damage_dice": "3d8",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Fiery Bolt",
+        "desc": "Ranged Attack Roll: +10, range 120 ft. Hit: 36 (8d8) Fire damage.",
+        "damage_dice": "8d8"
+      },
+      {
+        "name": "Poison Breath (Recharge 6)",
+        "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: 55 (10d10) Poison damage. Success: Half damage.",
+        "damage_dice": "10d10"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "iron-golem",
+    "url": "/api/2024/monsters/iron-golem",
+    "image": "/api/images/monsters/iron-golem.png",
+    "hit_points_roll": "24d10 + 120",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Knight",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 52,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 11,
+    "constitution": 14,
+    "intelligence": 11,
+    "wisdom": 11,
+    "charisma": 15,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "frightened"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The knight makes two attacks, using Greatsword or Heavy Crossbow in any combination."
+      },
+      {
+        "name": "Greatsword",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage plus 4 (1d8) Radiant damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Heavy Crossbow",
+        "desc": "Ranged Attack Roll: +2, range 100/400 ft. Hit: 11 (2d10) Piercing damage plus 4 (1d8) Radiant damage.",
+        "damage_dice": "2d10"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The knight is hit by a melee attack roll while holding a weapon. Response: The knight adds 2 to its AC against that attack, possibly causing it to miss. Kobold"
+      }
+    ],
+    "legendary_actions": [],
+    "index": "knight",
+    "url": "/api/2024/monsters/knight",
+    "image": "/api/images/monsters/knight.png",
+    "hit_points_roll": "8d8 + 16",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Kobold Warrior",
+    "size": "Small",
+    "type": "dragon",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 7,
+    "hit_dice": "3d6",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 7,
+    "dexterity": 15,
+    "constitution": 9,
+    "intelligence": 8,
+    "wisdom": 7,
+    "charisma": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The kobold has Advantage on an attack roll against a creature if at least one of the kobold’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      },
+      {
+        "name": "Sunlight Sensitivity",
+        "desc": "While in sunlight, the kobold has Disadvantage on ability checks and attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Dagger",
+        "desc": "Melee or Ranged Attack Roll: +4, reach 5 ft. or range 20/60 ft. Hit: 4 (1d4 + 2) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "kobold-warrior",
+    "url": "/api/2024/monsters/kobold-warrior",
+    "image": "/api/images/monsters/kobold-warrior.png",
+    "hit_points_roll": "3d6 − 3",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Kraken",
+    "size": "Gargantuan",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 481,
+    "hit_dice": "26d20",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "120 ft."
+    },
+    "strength": 30,
+    "dexterity": 11,
+    "constitution": 26,
+    "intelligence": 22,
+    "wisdom": 18,
+    "charisma": 20,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold",
+      "lightning"
+    ],
+    "condition_immunities": [
+      "frightened",
+      "grappled",
+      "paralyzed",
+      "restrained"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 21
+    },
+    "languages": "Understands Abyssal, Celestial, Infernal, and",
+    "challenge_rating": "23",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The kraken can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the kraken fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Siege Monster",
+        "desc": "The kraken deals double damage to objects and structures."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The kraken makes two Tentacle attacks and uses Fling, Lightning Strike, or Swallow."
+      },
+      {
+        "name": "Tentacle",
+        "desc": "Melee Attack Roll: +17, reach 30 ft. Hit: 24 (4d6 + 10) Bludgeoning damage. The target has the Grappled condition (escape DC 20) from one of ten tentacles, and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "4d6",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Fling",
+        "desc": "The kraken throws a Large or smaller creature Grappled by it to a space it can see within 60 feet of itself that isn’t in the air. Dexterity Saving Throw: DC 25, the creature thrown and each creature in the destination space. Failure: 18 (4d8) Bludgeoning damage, and the target has the Prone condition. Success: Half damage only.",
+        "damage_dice": "4d8"
+      },
+      {
+        "name": "Lightning Strike",
+        "desc": "Dexterity Saving Throw: DC 23, one creature the kraken can see within 120 feet. Failure: 33 (6d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "6d10"
+      },
+      {
+        "name": "Swallow",
+        "desc": "Dexterity Saving Throw: DC 25, one creature Grappled by the kraken (it can have up to four creatures swallowed at a time). Failure: 23 (3d8 + 10) Piercing damage. If the target is Large or smaller, it is swallowed and no longer Grappled. A swallowed creature has the Restrained condition, has Total Cover against attacks and other effects outside the kraken, and takes 24 (7d6) Acid damage at the start of each of its turns. If the kraken takes 50 damage or more on a single turn from a creature inside it, the kraken must succeed on a DC 25 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 10 feet of the kraken with the Prone condition. If the kraken dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse using 15 feet of movement, exiting Prone.",
+        "damage_dice": "3d8",
+        "damage_bonus": 10
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Storm Bolt",
+        "desc": "The kraken uses Lightning Strike."
+      },
+      {
+        "name": "Toxic Ink",
+        "desc": "Constitution Saving Throw: DC 23, each creature in a 15-foot Emanation originating from the kraken while it is underwater. Failure: The target has the Blinded and Poisoned conditions until the end of the kraken’s next turn. The kraken then moves up to its Speed. Failure or Success: The kraken can’t take this action again until the start of its next turn."
+      }
+    ],
+    "index": "kraken",
+    "url": "/api/2024/monsters/kraken",
+    "image": "/api/images/monsters/kraken.png",
+    "hit_points_roll": "26d20 + 208",
+    "proficiencies": [
+      {
+        "value": 17,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 15,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 11,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 21"
+  },
+  {
+    "name": "Lamia",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 97,
+    "hit_dice": "13d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 16,
+    "dexterity": 13,
+    "constitution": 15,
+    "intelligence": 14,
+    "wisdom": 15,
+    "charisma": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
+    "languages": "Abyssal, Common",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The lamia makes two Claw attacks. It can replace one attack with a use of Corrupting Touch."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage plus 7 (2d6) Psychic damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Corrupting Touch",
+        "desc": "Wisdom Saving Throw: DC 13, one creature the lamia can see within 5 feet. Failure: 13 (3d8) Psychic damage, and the target is cursed for 1 hour. Until the curse ends, the target has the Charmed and Poisoned conditions.",
+        "damage_dice": "3d8"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The lamia casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Disguise Self (can appear as a Large or Medium biped), Minor Illusion"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Geas, Major Image, Scrying"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Leap",
+        "desc": "The lamia jumps up to 30 feet by spending 10 feet of movement."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "lamia",
+    "url": "/api/2024/monsters/lamia",
+    "image": "/api/images/monsters/lamia.png",
+    "hit_points_roll": "13d10 + 26",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Lemure",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 9,
+    "armor_desc": "",
+    "initiative": -3,
+    "hit_points": 9,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "20 ft."
+    },
+    "strength": 10,
+    "dexterity": 5,
+    "constitution": 11,
+    "intelligence": 1,
+    "wisdom": 11,
+    "charisma": 3,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "frightened",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft. (unimpeded by magical"
+    },
+    "languages": "Understands Infernal but can’t speak",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Hellish Restoration",
+        "desc": "If the lemure dies in the Nine Hells, it revives with all its Hit Points in 1d10 days unless it is killed by a creature under the effects of a Bless spell or its remains are sprinkled with Holy Water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Vile Slime",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Poison damage.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "lemure",
+    "url": "/api/2024/monsters/lemure",
+    "image": "/api/images/monsters/lemure.png",
+    "hit_points_roll": "2d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft. (unimpeded by magical"
+  },
+  {
+    "name": "Lich",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "neutral evil",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 17,
+    "hit_points": 315,
+    "hit_dice": "42d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 11,
+    "dexterity": 16,
+    "constitution": 16,
+    "intelligence": 21,
+    "wisdom": 14,
+    "charisma": 16,
+    "perception": 9,
+    "damage_resistances": [
+      "cold",
+      "lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "necrotic",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "poisoned"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 19
+    },
+    "languages": "All",
+    "challenge_rating": "21",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the lich fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Spirit Jar",
+        "desc": "If destroyed, the lich reforms in 1d10 days if it has a spirit jar, reviving with all its Hit Points. The new body appears in an unoccupied space within the lich’s lair."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The lich makes three attacks, using Eldritch Burst or Paralyzing Touch in any combination."
+      },
+      {
+        "name": "Eldritch Burst",
+        "desc": "Melee or Ranged Attack Roll: +12, reach 5 ft. or range 120 ft. Hit: 31 (4d12 + 5) Force damage.",
+        "damage_dice": "4d12",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Paralyzing Touch",
+        "desc": "Melee Attack Roll: +12, reach 5 ft. Hit: 15 (3d6 + 5) Cold damage, and the target has the Paralyzed condition until the start of the lich’s next turn.",
+        "damage_dice": "3d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The lich casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 20):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Detect Thoughts, Dispel Magic, Fireball (level 5 version), Invisibility, Lightning Bolt (level 5 version), Mage Hand, Prestidigitation"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Animate Dead, Dimension Door, Plane Shift"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Chain Lightning, Finger of Death, Power Word Kill, Scrying"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Protective Magic",
+        "desc": "The lich casts Counterspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "legendary_actions": [
+      {
+        "name": "Deathly Teleport",
+        "desc": "The lich teleports up to 60 feet to an unoccupied space it can see, and each creature within 10 feet of the space it left takes 11 (2d10) Necrotic damage.",
+        "damage_dice": "2d10"
+      },
+      {
+        "name": "Disrupt Life",
+        "desc": "Constitution Saving Throw: DC 20, each creature that isn’t an Undead in a 20-foot Emanation originating from the lich. Failure: 31 (9d6) Necrotic damage. Success: Half damage. Failure or Success: The lich can’t take this action again until the start of its next turn.",
+        "damage_dice": "9d6"
+      },
+      {
+        "name": "Frightening Gaze",
+        "desc": "The lich casts Fear, using the same spellcasting ability as Spellcasting. The lich can’t take this action again until the start of its next turn. Mages"
+      }
+    ],
+    "index": "lich",
+    "url": "/api/2024/monsters/lich",
+    "image": "/api/images/monsters/lich.png",
+    "hit_points_roll": "42d8 + 126",
+    "proficiencies": [
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 12,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 19"
+  },
+  {
+    "name": "Mage",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 81,
+    "hit_dice": "18d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 9,
+    "dexterity": 14,
+    "constitution": 11,
+    "intelligence": 17,
+    "wisdom": 12,
+    "charisma": 11,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 14
+    },
+    "languages": "Common plus three other languages",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The mage makes three Arcane Burst attacks."
+      },
+      {
+        "name": "Arcane Burst",
+        "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 120 ft. Hit: 16 (3d8 + 3) Force damage.",
+        "damage_dice": "3d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The mage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 14):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Light, Mage Armor (included in AC), Mage Hand, Prestidigitation"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Fireball (level 4 version), Invisibility"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Cone of Cold, Fly"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Misty Step (3/Day)",
+        "desc": "The mage casts Misty Step, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": [
+      {
+        "name": "Protective Magic (3/Day)",
+        "desc": "The mage casts Counterspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "mage",
+    "url": "/api/2024/monsters/mage",
+    "image": "/api/images/monsters/mage.png",
+    "hit_points_roll": "18d8",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 14"
+  },
+  {
+    "name": "Archmage",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 170,
+    "hit_dice": "31d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 14,
+    "constitution": 12,
+    "intelligence": 20,
+    "wisdom": 15,
+    "charisma": 16,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "psychic"
+    ],
+    "condition_immunities": [
+      "charmed (with mind blank)"
+    ],
+    "senses": {
+      "passive_perception": 16
+    },
+    "languages": "Common plus five other languages",
+    "challenge_rating": "12",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The archmage has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The archmage makes four Arcane Burst attacks."
+      },
+      {
+        "name": "Arcane Burst",
+        "desc": "Melee or Ranged Attack Roll: +9, reach 5 ft. or range 150 ft. Hit: 27 (4d10 + 5) Force damage.",
+        "damage_dice": "4d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The archmage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 17):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Detect Thoughts, Disguise Self, Invisibility, Light, Mage Armor (included in AC), Mage Hand, Prestidigitation"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Fly, Lightning Bolt (level 7 version)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Cone of Cold (level 9 version), Mind Blank (cast before combat), Scrying, Teleport"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Misty Step (3/Day)",
+        "desc": "The mage casts Misty Step, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": [
+      {
+        "name": "Protective Magic (3/Day)",
+        "desc": "The archmage casts Counterspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "archmage",
+    "url": "/api/2024/monsters/archmage",
+    "image": "/api/images/monsters/archmage.png",
+    "hit_points_roll": "31d8 + 31",
+    "proficiencies": [
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 16"
+  },
+  {
+    "name": "Magmin",
+    "size": "Small",
+    "type": "elemental",
+    "alignment": "chaotic neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 13,
+    "hit_dice": "3d6",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 7,
+    "dexterity": 15,
+    "constitution": 12,
+    "intelligence": 8,
+    "wisdom": 11,
+    "charisma": 10,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Primordial (Ignan)",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Death Burst",
+        "desc": "The magmin explodes when it dies. Dexterity Saving Throw: DC 11, each creature in a 10-foot"
+      },
+      {
+        "name": "Emanation originating from the magmin",
+        "desc": "Failure: 7 (2d6) Fire damage. Success: Half damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Touch",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Fire damage. If the target is a creature or a flammable object that isn’t being worn or carried, it starts burning.",
+        "damage_dice": "2d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Ignited Illumination",
+        "desc": "The magmin sets itself ablaze or extinguishes its flames. While ablaze, the magmin sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "magmin",
+    "url": "/api/2024/monsters/magmin",
+    "image": "/api/images/monsters/magmin.png",
+    "hit_points_roll": "3d6 + 3",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Manticore",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "lawful evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 68,
+    "hit_dice": "8d10",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "50 ft."
+    },
+    "strength": 17,
+    "dexterity": 16,
+    "constitution": 17,
+    "intelligence": 7,
+    "wisdom": 12,
+    "charisma": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Common",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The manticore makes three attacks, using Rend or Tail Spike in any combination."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tail Spike",
+        "desc": "Ranged Attack Roll: +5, range 100/200 ft. Hit: 7 (1d8 + 3) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "manticore",
+    "url": "/api/2024/monsters/manticore",
+    "image": "/api/images/monsters/manticore.png",
+    "hit_points_roll": "8d10 + 24",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Marilith",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 220,
+    "hit_dice": "21d10",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 20,
+    "constitution": 20,
+    "intelligence": 18,
+    "wisdom": 16,
+    "charisma": 20,
+    "perception": 8,
+    "damage_resistances": [
+      "cold",
+      "fire",
+      "lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 18
+    },
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "16",
+    "special_abilities": [
+      {
+        "name": "Demonic Restoration",
+        "desc": "If the marilith dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The marilith has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Reactive",
+        "desc": "The marilith can take one Reaction on every turn of combat."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The marilith makes six Pact Blade attacks and uses Constrict."
+      },
+      {
+        "name": "Pact Blade",
+        "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 10 (1d10 + 5) Slashing damage plus 7 (2d6) Necrotic damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 17, one Medium or smaller creature the marilith can see within 5 feet. Failure: 15 (2d10 + 4) Bludgeoning damage. The target has the Grappled condition (escape DC 14), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Teleport (Recharge 5–6)",
+        "desc": "The marilith teleports up to 120 feet to an unoccupied space it can see."
+      }
+    ],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The marilith is hit by a melee attack roll while holding a weapon. Response: The marilith adds 5 to its AC against that attack, possibly causing it to miss."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "marilith",
+    "url": "/api/2024/monsters/marilith",
+    "image": "/api/images/monsters/marilith.png",
+    "hit_points_roll": "21d10 + 105",
+    "proficiencies": [
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 18"
+  },
+  {
+    "name": "Medusa",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "lawful evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 127,
+    "hit_dice": "17d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 17,
+    "constitution": 16,
+    "intelligence": 12,
+    "wisdom": 13,
+    "charisma": 15,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "150 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The medusa makes two Claw attacks and one Snake Hair attack, or it makes three Poison Ray attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Snake Hair",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage plus 14 (4d6) Poison damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Poison Ray",
+        "desc": "Ranged Attack Roll: +5, range 150 ft. Hit: 11 (2d8 + 2) Poison damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Petrifying Gaze (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 13, each creature in a 30-foot Cone. If the medusa sees its reflection in the Cone, the medusa must make this save. First Failure: The target has the Restrained condition and repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition instead of the Restrained condition. Mephits"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "medusa",
+    "url": "/api/2024/monsters/medusa",
+    "image": "/api/images/monsters/medusa.png",
+    "hit_points_roll": "17d8 + 51",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 150 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Dust Mephit",
+    "size": "Small",
+    "type": "elemental",
+    "alignment": "neutral evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 17,
+    "hit_dice": "5d6",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "30 ft."
+    },
+    "strength": 5,
+    "dexterity": 14,
+    "constitution": 10,
+    "intelligence": 9,
+    "wisdom": 11,
+    "charisma": 10,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "fire"
+    ],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
+    "languages": "Primordial (Auran, Terran)",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Death Burst",
+        "desc": "The mephit explodes when it dies. Dexterity Saving Throw: DC 10, each creature in a 5-foot"
+      },
+      {
+        "name": "Emanation originating from the mephit",
+        "desc": "Failure: 5 (2d4) Bludgeoning damage. Success: Half damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Slashing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Blinding Breath (Recharge 6)",
+        "desc": "Dexterity Saving Throw: DC 10, each creature in a 15-foot Cone. Failure: The target has the Blinded condition until the end of the mephit’s next turn."
+      },
+      {
+        "name": "Sleep (1/Day)",
+        "desc": "The mephit casts the Sleep spell, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 10)."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "dust-mephit",
+    "url": "/api/2024/monsters/dust-mephit",
+    "image": "/api/images/monsters/dust-mephit.png",
+    "hit_points_roll": "5d6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Ice Mephit",
+    "size": "Small",
+    "type": "elemental",
+    "alignment": "neutral evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 21,
+    "hit_dice": "6d6",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "30 ft."
+    },
+    "strength": 7,
+    "dexterity": 13,
+    "constitution": 10,
+    "intelligence": 9,
+    "wisdom": 11,
+    "charisma": 12,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "fire"
+    ],
+    "damage_immunities": [
+      "cold",
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
+    "languages": "Primordial (Aquan, Auran)",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Death Burst",
+        "desc": "The mephit explodes when it dies. Constitution Saving Throw: DC 10, each creature in a 5-foot"
+      },
+      {
+        "name": "Emanation originating from the mephit",
+        "desc": "Failure: 5 (2d4) Cold damage. Success: Half damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 2 (1d4) Cold damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Fog Cloud (1/Day)",
+        "desc": "The mephit casts Fog Cloud, requiring no spell components and using Charisma as the spellcasting ability."
+      },
+      {
+        "name": "Frost Breath (Recharge 6)",
+        "desc": "Constitution Saving Throw: DC 10, each creature in a 15-foot Cone. Failure: 7 (3d4) Cold damage. Success: Half damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ice-mephit",
+    "url": "/api/2024/monsters/ice-mephit",
+    "image": "/api/images/monsters/ice-mephit.png",
+    "hit_points_roll": "6d6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Magma Mephit",
+    "size": "Small",
+    "type": "elemental",
+    "alignment": "neutral evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 18,
+    "hit_dice": "4d6",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "30 ft."
+    },
+    "strength": 8,
+    "dexterity": 12,
+    "constitution": 12,
+    "intelligence": 7,
+    "wisdom": 10,
+    "charisma": 10,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "cold"
+    ],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Primordial (Ignan, Terran)",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Death Burst",
+        "desc": "The mephit explodes when it dies. Dexterity Saving Throw: DC 11, each creature in a 5-foot"
+      },
+      {
+        "name": "Emanation originating from the mephit",
+        "desc": "Failure: 7 (2d6) Fire damage. Success: Half damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 3 (1d6) Fire damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Fire Breath (Recharge 6)",
+        "desc": "Dexterity Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: 7 (2d6) Fire damage. Success: Half damage.",
+        "damage_dice": "2d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "magma-mephit",
+    "url": "/api/2024/monsters/magma-mephit",
+    "image": "/api/images/monsters/magma-mephit.png",
+    "hit_points_roll": "4d6 + 4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Steam Mephit",
+    "size": "Small",
+    "type": "elemental",
+    "alignment": "neutral evil",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 17,
+    "hit_dice": "5d6",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "30 ft."
+    },
+    "strength": 5,
+    "dexterity": 11,
+    "constitution": 10,
+    "intelligence": 11,
+    "wisdom": 10,
+    "charisma": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Primordial (Aquan, Ignan)",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Blurred Form",
+        "desc": "Attack rolls against the mephit are made with Disadvantage unless the mephit has the Incapacitated condition."
+      },
+      {
+        "name": "Death Burst",
+        "desc": "The mephit explodes when it dies. Dexterity Saving Throw: DC 10, each creature in a 5-foot"
+      },
+      {
+        "name": "Emanation originating from the mephit",
+        "desc": "Failure: 5 (2d4) Fire damage. Success: Half damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Slashing damage plus 2 (1d4) Fire damage.",
+        "damage_dice": "1d4"
+      },
+      {
+        "name": "Steam Breath (Recharge 6)",
+        "desc": "Constitution Saving Throw: DC 10, each creature in a 15-foot Cone. Failure: 5 (2d4) Fire damage, and the target’s Speed decreases by 10 feet until the end of the mephit’s next turn. Success:",
+        "damage_dice": "2d4"
+      },
+      {
+        "name": "Half damage only",
+        "desc": "Failure or Success: Being underwater doesn’t grant Resistance to this Fire damage. Merfolk"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "steam-mephit",
+    "url": "/api/2024/monsters/steam-mephit",
+    "image": "/api/images/monsters/steam-mephit.png",
+    "hit_points_roll": "5d6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Merfolk Skirmisher",
+    "size": "Medium",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "10 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 10,
+    "dexterity": 13,
+    "constitution": 12,
+    "intelligence": 11,
+    "wisdom": 14,
+    "charisma": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "Common, Primordial (Aquan)",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The merfolk can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Ocean Spear",
+        "desc": "Melee or Ranged Attack Roll: +2, reach 5 ft. or range 20/60 ft. Hit: 3 (1d6) Piercing damage plus 2 (1d4) Cold damage. If the target is a creature, its Speed decreases by 10 feet until the end of its next turn. Hit or Miss: The spear magically returns to the merfolk’s hand immediately after a ranged attack.",
+        "damage_dice": "1d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "merfolk-skirmisher",
+    "url": "/api/2024/monsters/merfolk-skirmisher",
+    "image": "/api/images/monsters/merfolk-skirmisher.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Merrow",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 45,
+    "hit_dice": "6d10",
+    "speed": {
+      "walk": "10 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 15,
+    "constitution": 15,
+    "intelligence": 8,
+    "wisdom": 10,
+    "charisma": 9,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Abyssal, Primordial (Aquan)",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The merrow can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The merrow makes two attacks, using Bite, Claw, or Harpoon in any combination."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Piercing damage, and the target has the Poisoned condition until the end of the merrow’s next turn.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Slashing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Harpoon",
+        "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 20/60 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature, the merrow pulls the target up to 15 feet straight toward itself.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "merrow",
+    "url": "/api/2024/monsters/merrow",
+    "image": "/api/images/monsters/merrow.png",
+    "hit_points_roll": "6d10 + 12",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Mimic",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 58,
+    "hit_dice": "9d8",
+    "speed": {
+      "walk": "20 ft."
+    },
+    "strength": 17,
+    "dexterity": 12,
+    "constitution": 15,
+    "intelligence": 5,
+    "wisdom": 13,
+    "charisma": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "acid"
+    ],
+    "condition_immunities": [
+      "prone"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Adhesive (Object Form Only)",
+        "desc": "The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic has the Grappled condition (escape DC 13). Ability checks made to escape this grapple have Disadvantage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the mimic), reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage—or 12 (2d8 + 3) Piercing damage if the target is Grappled by the mimic—plus 4 (1d8) Acid damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Pseudopod",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage plus 4 (1d8) Acid damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13). Ability checks made to escape this grapple have Disadvantage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The mimic shape-shifts to resemble a Medium or Small object while retaining its game statistics, or it returns to its true blob form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "mimic",
+    "url": "/api/2024/monsters/mimic",
+    "image": "/api/images/monsters/mimic.png",
+    "hit_points_roll": "9d8 + 18",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Minotaur of Baphomet",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 85,
+    "hit_dice": "10d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 11,
+    "constitution": 16,
+    "intelligence": 6,
+    "wisdom": 16,
+    "charisma": 9,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 17
+    },
+    "languages": "Abyssal",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Abyssal Glaive",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 10 (1d12 + 4) Slashing damage plus 10 (3d6) Necrotic damage.",
+        "damage_dice": "1d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Gore (Recharge 5–6)",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 18 (4d6 + 4) Piercing damage. If the target is a Large or smaller creature and the minotaur moved 10+ feet straight toward it immediately before the hit, the target takes an extra 10 (3d6) Piercing damage and has the Prone condition. Mummies",
+        "damage_dice": "4d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "minotaur-of-baphomet",
+    "url": "/api/2024/monsters/minotaur-of-baphomet",
+    "image": "/api/images/monsters/minotaur-of-baphomet.png",
+    "hit_points_roll": "10d10 + 30",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 17"
+  },
+  {
+    "name": "Mummy",
+    "size": "Medium",
+    "type": "or small undead",
+    "alignment": "lawful evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 58,
+    "hit_dice": "9d8",
+    "speed": {
+      "walk": "20 ft."
+    },
+    "strength": 16,
+    "dexterity": 8,
+    "constitution": 15,
+    "intelligence": 6,
+    "wisdom": 12,
+    "charisma": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "fire"
+    ],
+    "damage_immunities": [
+      "necrotic",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Common plus two other languages",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The mummy makes two Rotting Fist attacks and uses Dreadful Glare."
+      },
+      {
+        "name": "Rotting Fist",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Bludgeoning damage plus 10 (3d6) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target can’t regain Hit Points, its Hit Point maximum doesn’t return to normal when finishing a Long Rest, and its Hit Point maximum decreases by 10 (3d6) every 24 hours that elapse. A creature dies and turns to dust if reduced to 0 Hit Points by this attack.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Dreadful Glare",
+        "desc": "Wisdom Saving Throw: DC 11, one creature the mummy can see within 60 feet. Failure: The target has the Frightened condition until the end of the mummy’s next turn. Success: The target is immune to this mummy’s Dreadful Glare for 24 hours."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "mummy",
+    "url": "/api/2024/monsters/mummy",
+    "image": "/api/images/monsters/mummy.png",
+    "hit_points_roll": "9d8 + 18",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Mummy Lord",
+    "size": "Medium",
+    "type": "or small undead",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 187,
+    "hit_dice": "25d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 18,
+    "dexterity": 10,
+    "constitution": 17,
+    "intelligence": 11,
+    "wisdom": 19,
+    "charisma": 16,
+    "perception": 9,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "fire"
+    ],
+    "damage_immunities": [
+      "necrotic",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "poisoned"
+    ],
+    "senses": {
+      "truesight": "60 ft.",
+      "passive_perception": 19
+    },
+    "languages": "Common plus three other languages",
+    "challenge_rating": "15",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the mummy fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The mummy has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Undead Restoration",
+        "desc": "If destroyed, the mummy gains a new body in 24 hours if its heart is intact, reviving with all its Hit Points. The new body appears in an unoccupied space within the mummy’s lair. The heart is a Tiny object that has AC 17, HP 10, and Immunity to all damage except Fire."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The mummy makes one Rotting Fist or Channel Negative Energy attack, and it uses Dreadful Glare."
+      },
+      {
+        "name": "Rotting Fist",
+        "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 15 (2d10 + 4) Bludgeoning damage plus 10 (3d6) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target can’t regain Hit Points, it gains no benefit from finishing a Long Rest, and its Hit Point maximum decreases by 10 (3d6) every 24 hours that elapse. A creature dies and turns to dust if reduced to 0 Hit Points by this attack.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Channel Negative Energy",
+        "desc": "Ranged Attack Roll: +9, range 60 ft. Hit: 25 (6d6 + 4) Necrotic damage.",
+        "damage_dice": "6d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Dreadful Glare",
+        "desc": "Wisdom Saving Throw: DC 17, one creature the mummy can see within 60 feet. Failure: 25 (6d6 + 4) Psychic damage, and the target has the Paralyzed condition until the end of the mummy’s next turn.",
+        "damage_dice": "6d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The mummy casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 17, +9 to hit with spell attacks):",
+        "attack_bonus": 9
+      },
+      {
+        "name": "At Will",
+        "desc": "Dispel Magic, Thaumaturgy"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Animate Dead, Harm, Insect Plague (level 7 version)"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Whirlwind of Sand",
+        "desc": "Trigger: The mummy is hit by an attack roll. Response: The mummy adds 2 to its AC against the attack, possibly causing the attack to miss, and the mummy teleports up to 60 feet to an unoccupied space it can see. Each creature of its choice that it can see within 5 feet of its destination space has the Blinded condition until the end of the mummy’s next turn."
+      }
+    ],
+    "legendary_actions": [
+      {
+        "name": "Dread Command",
+        "desc": "The mummy casts Command (level 2 version), using the same spellcasting ability as Spellcasting. The mummy can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Glare",
+        "desc": "The mummy uses Dreadful Glare. The mummy can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Necrotic Strike",
+        "desc": "The mummy makes one Rotting Fist or Channel Negative Energy attack."
+      }
+    ],
+    "index": "mummy-lord",
+    "url": "/api/2024/monsters/mummy-lord",
+    "image": "/api/images/monsters/mummy-lord.png",
+    "hit_points_roll": "25d8 + 75",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Truesight 60 ft.; Passive Perception 19"
+  },
+  {
+    "name": "Nalfeshnee",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 184,
+    "hit_dice": "16d10",
+    "speed": {
+      "walk": "20 ft.",
+      "fly": "30 ft."
+    },
+    "strength": 21,
+    "dexterity": 10,
+    "constitution": 22,
+    "intelligence": 19,
+    "wisdom": 12,
+    "charisma": 15,
+    "damage_resistances": [
+      "cold",
+      "fire",
+      "lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "frightened",
+      "poisoned"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Demonic Restoration",
+        "desc": "If the nalfeshnee dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The nalfeshnee has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The nalfeshnee makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage plus 11 (2d10) Force damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Teleport",
+        "desc": "The nalfeshnee teleports up to 120 feet to an unoccupied space it can see."
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Horror Nimbus (Recharge 5–6)",
+        "desc": "Wisdom Saving Throw: DC 15, each creature in a 15-foot Emanation originating from the nalfeshnee. Failure: 28 (8d6) Psychic damage, and the target has the Frightened condition for 1 minute, until it takes damage, or until it ends its turn with the nalfeshnee out of line of sight. Success: The target is immune to this nalfeshnee’s Horror Nimbus for 24 hours."
+      }
+    ],
+    "reactions": [
+      {
+        "name": "Pursuit",
+        "desc": "Trigger: Another creature the nalfeshnee can see ends its move within 120 feet of the nalfeshnee. Response: The nalfeshnee uses Teleport, but its destination space must be within 10 feet of the triggering creature."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "nalfeshnee",
+    "url": "/api/2024/monsters/nalfeshnee",
+    "image": "/api/images/monsters/nalfeshnee.png",
+    "hit_points_roll": "16d10 + 96",
+    "proficiencies": [
+      {
+        "value": 11,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Night Hag",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "neutral evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 112,
+    "hit_dice": "15d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 18,
+    "dexterity": 15,
+    "constitution": 16,
+    "intelligence": 16,
+    "wisdom": 14,
+    "charisma": 16,
+    "perception": 5,
+    "damage_resistances": [
+      "cold",
+      "fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 15
+    },
+    "languages": "Abyssal, Common, Infernal, Primordial",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Coven Magic",
+        "desc": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spellcasting ability (spell save DC 14): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant. The hag must finish a Long Rest before using this trait to cast that spell again."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The hag has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Soul Bag",
+        "desc": "The hag has a soul bag. While holding or carrying the bag, the hag can use its Nightmare Haunting action. The bag has AC 15, HP 20, and Resistance to all damage. The bag turns to dust if reduced to 0 Hit Points. If the bag is destroyed, any souls the bag is holding are released. The hag can create a new bag after 7 days."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hag makes two Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage. Nightmare Haunting (1/Day; Requires Soul Bag). While on the Ethereal Plane, the hag casts Dream, using the same spellcasting ability as Spellcasting. Only the hag can serve as the spell’s messenger, and the target must be a creature the hag can see on the Material",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Plane",
+        "desc": "The spell fails and is wasted if the target is under the effect of the Protection from Evil and Good spell or within a Magic Circle spell. If the target takes damage from the Dream spell, the target’s Hit Point maximum decreases by an amount equal to that damage. If the spell kills the target, its soul is trapped in the hag’s soul bag, and the target can’t be raised from the dead until its soul is released."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The hag casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 14):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Etherealness, Magic Missile (level 4 version)"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Phantasmal Killer, Plane Shift (self only)"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The hag shape-shifts into a Small or Medium Humanoid, or it returns to its true form. Other than its size, its game statistics are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "night-hag",
+    "url": "/api/2024/monsters/night-hag",
+    "image": "/api/images/monsters/night-hag.png",
+    "hit_points_roll": "15d8 + 45",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Nightmare",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "neutral evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 68,
+    "hit_dice": "8d10",
+    "speed": {
+      "walk": "60 ft.",
+      "fly": "90 ft.",
+      "hover": true
+    },
+    "strength": 18,
+    "dexterity": 15,
+    "constitution": 16,
+    "intelligence": 10,
+    "wisdom": 13,
+    "charisma": 15,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 11
+    },
+    "languages": "Understands Abyssal, Common, and Infernal",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Confer Fire Resistance",
+        "desc": "The nightmare can grant Resistance to Fire damage to a rider while it is on the nightmare."
+      },
+      {
+        "name": "Illumination",
+        "desc": "The nightmare sheds Bright Light in a 10foot radius and Dim Light for an additional 10 feet."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage plus 10 (3d6) Fire damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Ethereal Stride",
+        "desc": "The nightmare and up to three willing creatures within 5 feet of it teleport to the Ethereal Plane from the Material Plane or vice versa."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "nightmare",
+    "url": "/api/2024/monsters/nightmare",
+    "image": "/api/images/monsters/nightmare.png",
+    "hit_points_roll": "8d10 + 24",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 11"
+  },
+  {
+    "name": "Noble",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 9,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 11,
+    "dexterity": 12,
+    "constitution": 11,
+    "intelligence": 12,
+    "wisdom": 14,
+    "charisma": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "Common plus two other languages",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rapier",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The noble is hit by a melee attack roll while holding a weapon. Response: The noble adds 2 to its AC against that attack, possibly causing it to miss."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "noble",
+    "url": "/api/2024/monsters/noble",
+    "image": "/api/images/monsters/noble.png",
+    "hit_points_roll": "2d8",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Ochre Jelly",
+    "size": "Large",
+    "type": "ooze",
+    "alignment": "unaligned",
+    "armor_class": 8,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 52,
+    "hit_dice": "7d10",
+    "speed": {
+      "walk": "20 ft.",
+      "climb": "20 ft."
+    },
+    "strength": 15,
+    "dexterity": 6,
+    "constitution": 14,
+    "intelligence": 2,
+    "wisdom": 6,
+    "charisma": 1,
+    "damage_resistances": [
+      "acid"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning",
+      "slashing"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "deafened",
+      "exhaustion",
+      "frightened",
+      "grappled",
+      "prone",
+      "restrained"
+    ],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 8
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amorphous",
+        "desc": "The jelly can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Spider Climb",
+        "desc": "The jelly can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Pseudopod",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 12 (3d6 + 2) Acid damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Split",
+        "desc": "Trigger: While the jelly is Large or Medium and has 10+ Hit Points, it becomes Bloodied or is subjected to Lightning or Slashing damage. Response: The jelly splits into two new Ochre Jellies. Each new jelly is one size smaller than the original jelly and acts on its Initiative. The original jelly’s Hit Points are divided evenly between the new jellies (round down)."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "ochre-jelly",
+    "url": "/api/2024/monsters/ochre-jelly",
+    "image": "/api/images/monsters/ochre-jelly.png",
+    "hit_points_roll": "7d10 + 14",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Ogre",
+    "size": "Large",
+    "type": "giant",
+    "alignment": "chaotic evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 68,
+    "hit_dice": "8d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 19,
+    "dexterity": 8,
+    "constitution": 16,
+    "intelligence": 5,
+    "wisdom": 7,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
+    "languages": "Common, Giant",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Greatclub",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Javelin",
+        "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 30/120 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ogre",
+    "url": "/api/2024/monsters/ogre",
+    "image": "/api/images/monsters/ogre.png",
+    "hit_points_roll": "8d10 + 24",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Oni",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 119,
+    "hit_dice": "14d10",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "30 ft.",
+      "hover": true
+    },
+    "strength": 19,
+    "dexterity": 11,
+    "constitution": 16,
+    "intelligence": 14,
+    "wisdom": 12,
+    "charisma": 15,
+    "perception": 4,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Common, Giant",
+    "challenge_rating": "7",
+    "special_abilities": [
+      {
+        "name": "Regeneration",
+        "desc": "The oni regains 10 Hit Points at the start of each of its turns if it has at least 1 Hit Point."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The oni makes two Claw or Nightmare"
+      },
+      {
+        "name": "Ray attacks",
+        "desc": "It can replace one attack with a use of Spellcasting."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 10 (1d12 + 4) Slashing damage plus 9 (2d8) Necrotic damage.",
+        "damage_dice": "1d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Nightmare Ray",
+        "desc": "Ranged Attack Roll: +5, range 60 ft. Hit: 9 (2d6 + 2) Psychic damage, and the target has the Frightened condition until the start of the oni’s next turn.",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Shape-Shift",
+        "desc": "The oni shape-shifts into a Small or Medium Humanoid or a Large Giant, or it returns to its true form. Other than its size, its game statistics are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The oni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13):"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Charm Person (level 2 version), Darkness, Gaseous Form, Sleep"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Invisibility",
+        "desc": "The oni casts Invisibility on itself, requiring no spell components and using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "oni",
+    "url": "/api/2024/monsters/oni",
+    "image": "/api/images/monsters/oni.png",
+    "hit_points_roll": "14d10 + 42",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Otyugh",
+    "size": "Large",
+    "type": "aberration",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 104,
+    "hit_dice": "11d10",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 11,
+    "constitution": 19,
+    "intelligence": 6,
+    "wisdom": 13,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Otyugh; telepathy 120 ft. (doesn’t allow the",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The otyugh makes one Bite attack and two Tentacle attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage, and the target has the Poisoned condition. Whenever the Poisoned target finishes a Long Rest, it is subjected to the following effect. Constitution Saving Throw: DC 15. Failure: The target’s Hit Point maximum decreases by 5 (1d10) and doesn’t return to normal until the Poisoned condition ends on the target. Success: The Poisoned condition ends.",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tentacle",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 13) from one of two tentacles.",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tentacle Slam",
+        "desc": "Constitution Saving Throw: DC 14, each creature Grappled by the otyugh. Failure: 16 (3d8 + 3) Bludgeoning damage, and the target has the Stunned condition until the start of the otyugh’s next turn. Success: Half damage only.",
+        "damage_dice": "3d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "otyugh",
+    "url": "/api/2024/monsters/otyugh",
+    "image": "/api/images/monsters/otyugh.png",
+    "hit_points_roll": "11d10 + 44",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Owlbear",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 59,
+    "hit_dice": "7d10",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft."
+    },
+    "strength": 20,
+    "dexterity": 12,
+    "constitution": 17,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The owlbear makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Slashing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "owlbear",
+    "url": "/api/2024/monsters/owlbear",
+    "image": "/api/images/monsters/owlbear.png",
+    "hit_points_roll": "7d10 + 21",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Pegasus",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "chaotic good",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 59,
+    "hit_dice": "7d10",
+    "speed": {
+      "walk": "60 ft.",
+      "fly": "90 ft."
+    },
+    "strength": 18,
+    "dexterity": 15,
+    "constitution": 16,
+    "intelligence": 10,
+    "wisdom": 15,
+    "charisma": 13,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 16
+    },
+    "languages": "Understands Celestial, Common, Elvish, and",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 5 (2d4) Radiant damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "pegasus",
+    "url": "/api/2024/monsters/pegasus",
+    "image": "/api/images/monsters/pegasus.png",
+    "hit_points_roll": "7d10 + 21",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 16"
+  },
+  {
+    "name": "Phase Spider",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 45,
+    "hit_dice": "7d10",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 16,
+    "constitution": 12,
+    "intelligence": 6,
+    "wisdom": 10,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Ethereal Sight",
+        "desc": "The spider can see 60 feet into the Ethereal Plane while on the Material Plane and vice versa."
+      },
+      {
+        "name": "Spider Climb",
+        "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Web Walker",
+        "desc": "The spider ignores movement restrictions caused by webs, and the spider knows the location of any other creature in contact with the same web."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The spider makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Piercing damage plus 9 (2d8) Poison damage. If this damage reduces the target to 0 Hit Points, the target becomes Stable, and it has the Poisoned condition for 1 hour. While Poisoned, the target also has the Paralyzed condition.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Ethereal Jaunt",
+        "desc": "The spider teleports from the Material Plane to the Ethereal Plane or vice versa. Pirates"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "phase-spider",
+    "url": "/api/2024/monsters/phase-spider",
+    "image": "/api/images/monsters/phase-spider.png",
+    "hit_points_roll": "7d10 + 7",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Pirate",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 33,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 16,
+    "constitution": 12,
+    "intelligence": 8,
+    "wisdom": 12,
+    "charisma": 14,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 11
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The pirate makes two Dagger attacks. It can replace one attack with a use of Enthralling Panache."
+      },
+      {
+        "name": "Dagger",
+        "desc": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 20/60 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Enthralling Panache",
+        "desc": "Wisdom Saving Throw: DC 12, one creature the pirate can see within 30 feet. Failure: The target has the Charmed condition until the start of the pirate’s next turn."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "pirate",
+    "url": "/api/2024/monsters/pirate",
+    "image": "/api/images/monsters/pirate.png",
+    "hit_points_roll": "6d8 + 6",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 11"
+  },
+  {
+    "name": "Pirate Captain",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 84,
+    "hit_dice": "13d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 18,
+    "constitution": 14,
+    "intelligence": 10,
+    "wisdom": 14,
+    "charisma": 17,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 15
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The pirate makes three attacks, using Rapier or Pistol in any combination."
+      },
+      {
+        "name": "Rapier",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Piercing damage, and the pirate has Advantage on the next attack roll it makes before the end of this turn.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Pistol",
+        "desc": "Ranged Attack Roll: +7, range 30/90 ft. Hit: 15 (2d10 + 4) Piercing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Riposte",
+        "desc": "Trigger: The pirate is hit by a melee attack roll while holding a weapon. Response: The pirate adds 3 to its AC against that attack, possibly causing it to miss. On a miss, the pirate makes one Rapier attack against the triggering creature if within range."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "pirate-captain",
+    "url": "/api/2024/monsters/pirate-captain",
+    "image": "/api/images/monsters/pirate-captain.png",
+    "hit_points_roll": "13d8 + 26",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 15"
+  },
+  {
+    "name": "Pit Fiend",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 21,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 337,
+    "hit_dice": "27d10",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 26,
+    "dexterity": 14,
+    "constitution": 24,
+    "intelligence": 22,
+    "wisdom": 18,
+    "charisma": 24,
+    "perception": 10,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 20
+    },
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "20",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the pit fiend dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Fear Aura",
+        "desc": "The pit fiend emanates an aura in a 20foot Emanation while it doesn’t have the Incapacitated condition. Wisdom Saving Throw: DC 21, any enemy that starts its turn in the aura. Failure: The target has the Frightened condition until the start of its next turn. Success: The target is immune to this pit fiend’s aura for 24 hours."
+      },
+      {
+        "name": "Legendary Resistance (4/Day)",
+        "desc": "If the pit fiend fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The pit fiend has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The pit fiend makes one Bite attack, two Devilish Claw attacks, and one Fiery Mace attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 18 (3d6 + 8) Piercing damage. If the target is a creature, it must make the following saving throw. Constitution Saving Throw: DC 21. Failure: The target has the Poisoned condition. While Poisoned, the target can’t regain Hit Points and takes 21 (6d6) Poison damage at the start of each of its turns, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+        "damage_dice": "3d6",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Devilish Claw",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 26 (4d8 + 8) Necrotic damage.",
+        "damage_dice": "4d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Fiery Mace",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 22 (4d6 + 8) Force damage plus 21 (6d6) Fire damage.",
+        "damage_dice": "4d6",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Hellfire Spellcasting (Recharge 4–6)",
+        "desc": "The pit fiend casts Fireball (level 5 version) twice, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21). It can replace one Fireball with Hold Monster (level 7 version) or Wall of Fire."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "pit-fiend",
+    "url": "/api/2024/monsters/pit-fiend",
+    "image": "/api/images/monsters/pit-fiend.png",
+    "hit_points_roll": "27d10 + 189",
+    "proficiencies": [
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 20"
+  },
+  {
+    "name": "Planetar",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 262,
+    "hit_dice": "21d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "120 ft.",
+      "hover": true
+    },
+    "strength": 24,
+    "dexterity": 20,
+    "constitution": 24,
+    "intelligence": 19,
+    "wisdom": 22,
+    "charisma": 25,
+    "perception": 11,
+    "damage_resistances": [
+      "radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 21
+    },
+    "languages": "All; telepathy 120 ft.",
+    "challenge_rating": "16",
+    "special_abilities": [
+      {
+        "name": "Divine Awareness",
+        "desc": "The planetar knows if it hears a lie."
+      },
+      {
+        "name": "Exalted Restoration",
+        "desc": "If the planetar dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in Mount Celestia."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The planetar has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The planetar makes three Radiant Sword attacks or uses Holy Burst twice."
+      },
+      {
+        "name": "Radiant Sword",
+        "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 14 (2d6 + 7) Slashing damage plus 18 (4d8) Radiant damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Holy Burst",
+        "desc": "Dexterity Saving Throw: DC 20, each enemy in a 20-foot-radius Sphere centered on a point the planetar can see within 120 feet. Failure: 24 (7d6) Radiant damage. Success: Half damage.",
+        "damage_dice": "7d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The planetar casts one of the following spells, requiring no Material components and using Charisma as spellcasting ability (spell save DC 20):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Commune, Control Weather, Dispel Evil and Good, Raise Dead"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (2/Day)",
+        "desc": "The planetar casts Cure Wounds, Invisibility, Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting. Priests"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "planetar",
+    "url": "/api/2024/monsters/planetar",
+    "image": "/api/images/monsters/planetar.png",
+    "hit_points_roll": "21d10 + 147",
+    "proficiencies": [
+      {
+        "value": 12,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 12,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 11,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 12,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 21"
+  },
+  {
+    "name": "Priest Acolyte",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 14,
+    "dexterity": 10,
+    "constitution": 12,
+    "intelligence": 10,
+    "wisdom": 14,
+    "charisma": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "Common",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Mace",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage plus 2 (1d4) Radiant damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Radiant Flame",
+        "desc": "Ranged Attack Roll: +4, range 60 ft. Hit: 7 (2d6) Radiant damage.",
+        "damage_dice": "2d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The priest casts one of the following spells, using Wisdom as the spellcasting ability:"
+      },
+      {
+        "name": "At Will",
+        "desc": "Light, Thaumaturgy"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (1/Day)",
+        "desc": "The priest casts Bless, Healing Word, or Sanctuary, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "priest-acolyte",
+    "url": "/api/2024/monsters/priest-acolyte",
+    "image": "/api/images/monsters/priest-acolyte.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Priest",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 38,
+    "hit_dice": "7d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 10,
+    "constitution": 12,
+    "intelligence": 13,
+    "wisdom": 16,
+    "charisma": 13,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 15
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The priest makes two attacks, using Mace or Radiant Flame in any combination."
+      },
+      {
+        "name": "Mace",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage plus 5 (2d4) Radiant damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Radiant Flame",
+        "desc": "Ranged Attack Roll: +5, range 60 ft. Hit: 11 (2d10) Radiant damage.",
+        "damage_dice": "2d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The priest casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Light, Thaumaturgy"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Spirit Guardians"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (3/Day)",
+        "desc": "The priest casts Bless, Dispel Magic, Healing Word, or Lesser Restoration, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "priest",
+    "url": "/api/2024/monsters/priest",
+    "image": "/api/images/monsters/priest.png",
+    "hit_points_roll": "7d8 + 7",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 15"
+  },
+  {
+    "name": "Pseudodragon",
+    "size": "Tiny",
+    "type": "dragon",
+    "alignment": "neutral good",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 10,
+    "hit_dice": "3d4",
+    "speed": {
+      "walk": "15 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 6,
+    "dexterity": 15,
+    "constitution": 13,
+    "intelligence": 10,
+    "wisdom": 12,
+    "charisma": 10,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Understands Common and Draconic but can’t",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The pseudodragon has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The pseudodragon makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Sting",
+        "desc": "Constitution Saving Throw: DC 12, one creature the pseudodragon can see within 5 feet. Failure: 5 (2d4) Poison damage, and the target has the Poisoned condition for 1 hour. Failure by 5 or More: While Poisoned, the target also has the Unconscious condition, which ends early if the target takes damage or a creature within 5 feet of it takes an action to wake it.",
+        "damage_dice": "2d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "pseudodragon",
+    "url": "/api/2024/monsters/pseudodragon",
+    "image": "/api/images/monsters/pseudodragon.png",
+    "hit_points_roll": "3d4 + 3",
+    "proficiencies": [],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Purple Worm",
+    "size": "Gargantuan",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 247,
+    "hit_dice": "15d20",
+    "speed": {
+      "walk": "50 ft.",
+      "burrow": "50 ft."
+    },
+    "strength": 28,
+    "dexterity": 7,
+    "constitution": 22,
+    "intelligence": 1,
+    "wisdom": 8,
+    "charisma": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft., Tremorsense 60 ft."
+    },
+    "languages": "None",
+    "challenge_rating": "15",
+    "special_abilities": [
+      {
+        "name": "Tunneler",
+        "desc": "The worm can burrow through solid rock at half its Burrow Speed and leaves a 10-foot-diameter tunnel in its wake."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The worm makes one Bite attack and one Tail Stinger attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 22 (3d8 + 9) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 19), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "3d8",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Tail Stinger",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 16 (2d6 + 9) Piercing damage plus 35 (10d6) Poison damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 9
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Swallow",
+        "desc": "Strength Saving Throw: DC 19, one Large or smaller creature Grappled by the worm (it can have up to three creatures swallowed at a time). Failure: The target is swallowed by the worm, and the Grappled condition ends. A swallowed creature has the Blinded and Restrained conditions, has Total Cover against attacks and other effects outside the worm, and takes 17 (5d6) Acid damage at the start of each of the worm’s turns. If the worm takes 30 damage or more on a single turn from a creature inside it, the worm must succeed on a DC 21 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 5 feet of the worm and has the Prone condition. If the worm dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse using 20 feet of movement, exiting Prone."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "purple-worm",
+    "url": "/api/2024/monsters/purple-worm",
+    "image": "/api/images/monsters/purple-worm.png",
+    "hit_points_roll": "15d20 + 90",
+    "proficiencies": [
+      {
+        "value": 11,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Tremorsense 60 ft.;"
+  },
+  {
+    "name": "Quasit",
+    "size": "Tiny",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 25,
+    "hit_dice": "10d4",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 5,
+    "dexterity": 17,
+    "constitution": 10,
+    "intelligence": 7,
+    "wisdom": 10,
+    "charisma": 10,
+    "damage_resistances": [
+      "cold",
+      "fire",
+      "lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Abyssal, Common",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The quasit has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage, and the target has the Poisoned condition until the start of the quasit’s next turn.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Invisibility",
+        "desc": "The quasit casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability."
+      },
+      {
+        "name": "Scare (1/Day)",
+        "desc": "Wisdom Saving Throw: DC 10, one creature within 20 feet. Failure: The target has the Frightened condition. At the end of each of its turns, the target repeats the save, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      },
+      {
+        "name": "Shape-Shift",
+        "desc": "The quasit shape-shifts to resemble a bat (Speed 10 ft., Fly 40 ft.), a centipede (40 ft., Climb 40 ft.), or a toad (40 ft., Swim 40 ft.), or it returns to its true form. Its game statistics are the same in each form, except for its Speed. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "quasit",
+    "url": "/api/2024/monsters/quasit",
+    "image": "/api/images/monsters/quasit.png",
+    "hit_points_roll": "10d4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Rakshasa",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 8,
+    "hit_points": 221,
+    "hit_dice": "26d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 14,
+    "dexterity": 17,
+    "constitution": 18,
+    "intelligence": 13,
+    "wisdom": 16,
+    "charisma": 20,
+    "perception": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "piercing damage from weapons wielded by"
+    ],
+    "damage_immunities": [
+      "charmed",
+      "frightened"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "truesight": "60 ft.",
+      "passive_perception": 18
+    },
+    "languages": "Common, Infernal",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Greater Magic Resistance",
+        "desc": "The rakshasa automatically succeeds on saving throws against spells and other magical effects, and the attack rolls of spells automatically miss it. Without the rakshasa’s permission, no spell can observe the rakshasa remotely or detect its thoughts, creature type, or alignment."
+      },
+      {
+        "name": "Fiendish Restoration",
+        "desc": "If the rakshasa dies outside the Nine Hells, its body turns to ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The rakshasa makes three Cursed Touch attacks."
+      },
+      {
+        "name": "Cursed Touch",
+        "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 12 (2d6 + 5) Slashing damage plus 19 (3d12) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target gains no benefit from finishing a Short or Long Rest.",
+        "damage_dice": "2d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Baleful Command (Recharge 5–6)",
+        "desc": "Wisdom Saving Throw: DC 18, each enemy in a 30-foot Emanation originating from the rakshasa. Failure: 28 (8d6) Psychic damage, and the target has the Frightened and Incapacitated conditions until the start of the rakshasa’s next turn.",
+        "damage_dice": "8d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The rakshasa casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Detect Thoughts, Disguise Self, Mage Hand, Minor Illusion"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Fly, Invisibility, Major Image, Plane Shift Red Dragons"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "rakshasa",
+    "url": "/api/2024/monsters/rakshasa",
+    "image": "/api/images/monsters/rakshasa.png",
+    "hit_points_roll": "26d8 + 104",
+    "proficiencies": [],
+    "old_senses": "Truesight 60 ft.; Passive Perception 18"
+  },
+  {
+    "name": "Red Dragon Wyrmling",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 75,
+    "hit_dice": "10d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 19,
+    "dexterity": 10,
+    "constitution": 17,
+    "intelligence": 12,
+    "wisdom": 11,
+    "charisma": 15,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Draconic",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Slashing damage plus 3 (1d6) Fire damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 13, each creature in a 15-foot Cone. Failure: 24 (7d6) Fire damage. Success: Half damage.",
+        "damage_dice": "7d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "red-dragon-wyrmling",
+    "url": "/api/2024/monsters/red-dragon-wyrmling",
+    "image": "/api/images/monsters/red-dragon-wyrmling.png",
+    "hit_points_roll": "10d8 + 30",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Young Red Dragon",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 178,
+    "hit_dice": "17d10",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 23,
+    "dexterity": 10,
+    "constitution": 21,
+    "intelligence": 14,
+    "wisdom": 11,
+    "charisma": 19,
+    "perception": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "10",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 3 (1d6) Fire damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 17, each creature in a 30-foot Cone. Failure: 56 (16d6) Fire damage. Success: Half damage.",
+        "damage_dice": "16d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "young-red-dragon",
+    "url": "/api/2024/monsters/young-red-dragon",
+    "image": "/api/images/monsters/young-red-dragon.png",
+    "hit_points_roll": "17d10 + 85",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Adult Red Dragon",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 12,
+    "hit_points": 256,
+    "hit_dice": "19d12",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 27,
+    "dexterity": 10,
+    "constitution": 25,
+    "intelligence": 16,
+    "wisdom": 13,
+    "charisma": 23,
+    "perception": 13,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "17",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Scorching Ray."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 13 (1d10 + 8) Slashing damage plus 5 (2d4) Fire damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 21, each creature in a 60-foot Cone. Failure: 59 (17d6) Fire damage. Success: Half damage.",
+        "damage_dice": "17d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20, +12 to hit with spell attacks):",
+        "attack_bonus": 12
+      },
+      {
+        "name": "At Will",
+        "desc": "Command (level 2 version), Detect Magic, Scorching Ray"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Fireball"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Commanding Presence",
+        "desc": "The dragon uses Spellcasting to cast Command (level 2 version). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Fiery Rays",
+        "desc": "The dragon uses Spellcasting to cast Scorching Ray. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "adult-red-dragon",
+    "url": "/api/2024/monsters/adult-red-dragon",
+    "image": "/api/images/monsters/adult-red-dragon.png",
+    "hit_points_roll": "19d12 + 133",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Ancient Red Dragon",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 507,
+    "hit_dice": "26d20",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 30,
+    "dexterity": 10,
+    "constitution": 29,
+    "intelligence": 18,
+    "wisdom": 15,
+    "charisma": 27,
+    "perception": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "24",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Scorching Ray (level 3 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +17, reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 10 (3d6) Fire damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 24, each creature in a 90-foot Cone. Failure: 91 (26d6) Fire damage. Success: Half damage.",
+        "damage_dice": "26d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks):",
+        "attack_bonus": 15
+      },
+      {
+        "name": "At Will",
+        "desc": "Command (level 2 version), Detect Magic, Scorching Ray (level 3 version)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Fireball (level 6 version), Scrying"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Commanding Presence",
+        "desc": "The dragon uses Spellcasting to cast Command (level 2 version). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Fiery Rays",
+        "desc": "The dragon uses Spellcasting to cast Scorching Ray (level 3 version). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "ancient-red-dragon",
+    "url": "/api/2024/monsters/ancient-red-dragon",
+    "image": "/api/images/monsters/ancient-red-dragon.png",
+    "hit_points_roll": "26d20 + 234",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Remorhaz",
+    "size": "Huge",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 195,
+    "hit_dice": "17d12",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "30 ft."
+    },
+    "strength": 24,
+    "dexterity": 13,
+    "constitution": 21,
+    "intelligence": 4,
+    "wisdom": 10,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold",
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft., Tremorsense 60 ft."
+    },
+    "languages": "None",
+    "challenge_rating": "11",
+    "special_abilities": [
+      {
+        "name": "Heat Aura",
+        "desc": "At the end of each of the remorhaz’s turns, each creature in a 5-foot Emanation originating from the remorhaz takes 16 (3d10) Fire damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 18 (2d10 + 7) Piercing damage plus 14 (4d6) Fire damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 17), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "2d10",
+        "damage_bonus": 7
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Swallow",
+        "desc": "Strength Saving Throw: DC 19, one Large or smaller creature Grappled by the remorhaz (it can have up to two creatures swallowed at a time). Failure: The target is swallowed by the remorhaz, and the Grappled condition ends. A swallowed creature has the Blinded and Restrained conditions, it has Total Cover against attacks and other effects outside the remorhaz, and it takes 10 (3d6) Acid damage plus 10 (3d6) Fire damage at the start of each of the remorhaz’s turns. If the remorhaz takes 30 damage or more on a single turn from a creature inside it, the remorhaz must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 5 feet of the remorhaz and has the Prone condition. If the remorhaz dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse by using 15 feet of movement, exiting Prone."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "remorhaz",
+    "url": "/api/2024/monsters/remorhaz",
+    "image": "/api/images/monsters/remorhaz.png",
+    "hit_points_roll": "17d12 + 85",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft., Tremorsense 60 ft.;"
+  },
+  {
+    "name": "Roc",
+    "size": "Gargantuan",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 8,
+    "hit_points": 248,
+    "hit_dice": "16d20",
+    "speed": {
+      "walk": "20 ft.",
+      "fly": "120 ft."
+    },
+    "strength": 28,
+    "dexterity": 10,
+    "constitution": 20,
+    "intelligence": 3,
+    "wisdom": 10,
+    "charisma": 9,
+    "perception": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 18
+    },
+    "languages": "None",
+    "challenge_rating": "11",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The roc makes two Beak attacks. It can replace one attack with a Talons attack."
+      },
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +13, reach 10 ft. Hit: 28 (3d12 + 9) Piercing damage.",
+        "damage_dice": "3d12",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Talons",
+        "desc": "Melee Attack Roll: +13, reach 5 ft. Hit: 23 (4d6 + 9) Slashing damage. If the target is a Huge or smaller creature, it has the Grappled condition (escape DC 19) from both talons, and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "4d6",
+        "damage_bonus": 9
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Swoop (Recharge 5–6)",
+        "desc": "If the roc has a creature Grappled, the roc flies up to half its Fly Speed without provoking Opportunity Attacks and drops that creature."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "roc",
+    "url": "/api/2024/monsters/roc",
+    "image": "/api/images/monsters/roc.png",
+    "hit_points_roll": "16d20 + 80",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 18"
+  },
+  {
+    "name": "Roper",
+    "size": "Large",
+    "type": "aberration",
+    "alignment": "neutral evil",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 93,
+    "hit_dice": "11d10",
+    "speed": {
+      "walk": "10 ft.",
+      "climb": "20 ft."
+    },
+    "strength": 18,
+    "dexterity": 8,
+    "constitution": 17,
+    "intelligence": 7,
+    "wisdom": 16,
+    "charisma": 6,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 16
+    },
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The roper can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The roper makes two Tentacle attacks, uses Reel, and makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 17 (3d8 + 4) Piercing damage.",
+        "damage_dice": "3d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Tentacle",
+        "desc": "Melee Attack Roll: +7, reach 60 ft. Hit: The target has the Grappled condition (escape DC 14) from one of six tentacles, and the target has the Poisoned condition until the grapple ends. The tentacle can be damaged, freeing a creature it has Grappled when destroyed (AC 20, HP 10, Immunity to Poison and Psychic damage). Damaging the tentacle deals no damage to the roper, and a destroyed tentacle regrows at the start of the roper’s next turn."
+      },
+      {
+        "name": "Reel",
+        "desc": "The roper pulls each creature Grappled by it up to 30 feet straight toward it."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "roper",
+    "url": "/api/2024/monsters/roper",
+    "image": "/api/images/monsters/roper.png",
+    "hit_points_roll": "11d10 + 33",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 16"
+  },
+  {
+    "name": "Rust Monster",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 33,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 13,
+    "dexterity": 12,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 13,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Iron Scent",
+        "desc": "The rust monster can pinpoint the location of ferrous metal within 30 feet of itself."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The rust monster makes one Bite attack and uses Antennae twice."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Antennae",
+        "desc": "The rust monster targets one nonmagical metal object—armor or a weapon—worn or carried by a creature within 5 feet of itself. Dexterity Saving Throw: DC 11, the creature with the object. Failure: The object takes a −1 penalty to the AC it offers (armor) or to its attack rolls (weapon). Armor is destroyed if the penalty reduces its AC to 10, and a weapon is destroyed if its penalty reaches −5. The penalty can be removed by casting the Mending spell on the armor or weapon."
+      },
+      {
+        "name": "Destroy Metal",
+        "desc": "The rust monster touches a nonmagical metal object within 5 feet of itself that isn’t being worn or carried. The touch destroys a 1-foot Cube of the object."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Reflexive Antennae",
+        "desc": "Trigger: An attack roll hits the rust monster. Response: The rust monster uses Antennae. Sahuagin"
+      }
+    ],
+    "legendary_actions": [],
+    "index": "rust-monster",
+    "url": "/api/2024/monsters/rust-monster",
+    "image": "/api/images/monsters/rust-monster.png",
+    "hit_points_roll": "6d8 + 6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Sahuagin Warrior",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 22,
+    "hit_dice": "4d8",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 13,
+    "dexterity": 11,
+    "constitution": 12,
+    "intelligence": 12,
+    "wisdom": 13,
+    "charisma": 9,
+    "perception": 5,
+    "damage_resistances": [
+      "acid",
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 15
+    },
+    "languages": "Sahuagin",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Blood Frenzy",
+        "desc": "The sahuagin has Advantage on attack rolls against any creature that doesn’t have all its Hit Points."
+      },
+      {
+        "name": "Limited Amphibiousness",
+        "desc": "The sahuagin can breathe air and water, but it must be submerged at least once every 4 hours to avoid suffocating outside water."
+      },
+      {
+        "name": "Shark Telepathy",
+        "desc": "The sahuagin can magically control sharks within 120 feet of itself, using a special telepathy."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The sahuagin makes two Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Aquatic Charge",
+        "desc": "The sahuagin swims up to its Swim Speed straight toward an enemy it can see."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "sahuagin-warrior",
+    "url": "/api/2024/monsters/sahuagin-warrior",
+    "image": "/api/images/monsters/sahuagin-warrior.png",
+    "hit_points_roll": "4d8 + 4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Salamander",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 90,
+    "hit_dice": "12d10",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 18,
+    "dexterity": 14,
+    "constitution": 15,
+    "intelligence": 11,
+    "wisdom": 10,
+    "charisma": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "cold"
+    ],
+    "damage_immunities": [
+      "fire"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Primordial (Ignan)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Fire Aura",
+        "desc": "At the end of each of the salamander’s turns, each creature of the salamander’s choice in a 5-foot Emanation originating from the salamander takes 7 (2d6) Fire damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The salamander makes two Flame"
+      },
+      {
+        "name": "Spear attacks",
+        "desc": "It can replace one attack with a use of Constrict."
+      },
+      {
+        "name": "Flame Spear",
+        "desc": "Melee or Ranged Attack Roll: +7, reach 5 ft. or range 20/60 ft. Hit: 13 (2d8 + 4) Piercing damage plus 7 (2d6) Fire damage. Hit or Miss: The spear magically returns to the salamander’s hand immediately after a ranged attack.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 15, one Large or smaller creature the salamander can see within 10 feet. Failure: 11 (2d6 + 4) Bludgeoning damage plus 7 (2d6) Fire damage. The target has the Grappled condition (escape DC 14), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "salamander",
+    "url": "/api/2024/monsters/salamander",
+    "image": "/api/images/monsters/salamander.png",
+    "hit_points_roll": "12d10 + 24",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Satyr",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "chaotic neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 31,
+    "hit_dice": "7d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 12,
+    "dexterity": 16,
+    "constitution": 11,
+    "intelligence": 12,
+    "wisdom": 10,
+    "charisma": 14,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "Common, Elvish, Sylvan",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The satyr has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, the satyr pushes the target up to 10 feet straight away from itself.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Mockery",
+        "desc": "Wisdom Saving Throw: DC 12, one creature the satyr can see within 90 feet. Failure: 5 (1d6 + 2) Psychic damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "satyr",
+    "url": "/api/2024/monsters/satyr",
+    "image": "/api/images/monsters/satyr.png",
+    "hit_points_roll": "7d8",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Scout",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 16,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 11,
+    "dexterity": 14,
+    "constitution": 12,
+    "intelligence": 11,
+    "wisdom": 13,
+    "charisma": 11,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 15
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The scout makes two attacks, using Shortsword and Longbow in any combination."
+      },
+      {
+        "name": "Shortsword",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Longbow",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "scout",
+    "url": "/api/2024/monsters/scout",
+    "image": "/api/images/monsters/scout.png",
+    "hit_points_roll": "3d8 + 3",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 15"
+  },
+  {
+    "name": "Sea Hag",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "chaotic evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 52,
+    "hit_dice": "7d8",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 16,
+    "dexterity": 13,
+    "constitution": 16,
+    "intelligence": 12,
+    "wisdom": 12,
+    "charisma": 13,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Common, Giant, Primordial (Aquan)",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The hag can breathe air and water."
+      },
+      {
+        "name": "Coven Magic",
+        "desc": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spellcasting ability (spell save DC 11): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant. The hag must finish a Long Rest before using this trait to cast that spell again."
+      },
+      {
+        "name": "Vile Appearance",
+        "desc": "Wisdom Saving Throw: DC 11, any Beast or Humanoid that starts its turn within 30 feet of the hag and can see the hag’s true form. Failure: The target has the Frightened condition until the start of its next turn. Success: The target is immune to this hag’s Vile Appearance for 24 hours."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Death Glare (Recharge 5–6)",
+        "desc": "Wisdom Saving Throw: DC 11, one Frightened creature the hag can see within 30 feet. Failure: If the target has 20 Hit Points or fewer, it drops to 0 Hit Points. Otherwise, the target takes 13 (3d8) Psychic damage.",
+        "damage_dice": "3d8"
+      },
+      {
+        "name": "Illusory Appearance",
+        "desc": "The hag casts Disguise Self, using Constitution as the spellcasting ability (spell save DC 13). The spell’s duration is 24 hours."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "sea-hag",
+    "url": "/api/2024/monsters/sea-hag",
+    "image": "/api/images/monsters/sea-hag.png",
+    "hit_points_roll": "7d8 + 21",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Shadow",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 27,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 6,
+    "dexterity": 14,
+    "constitution": 13,
+    "intelligence": 6,
+    "wisdom": 10,
+    "charisma": 8,
+    "damage_resistances": [
+      "acid",
+      "cold",
+      "fire",
+      "lightning",
+      "thunder"
+    ],
+    "damage_vulnerabilities": [
+      "radiant"
+    ],
+    "damage_immunities": [
+      "necrotic",
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "frightened",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "prone",
+      "restrained",
+      "unconscious"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Amorphous",
+        "desc": "The shadow can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Sunlight Weakness",
+        "desc": "While in sunlight, the shadow has Disadvantage on D20 Tests."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Draining Swipe",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Necrotic damage, and the target’s Strength score decreases by 1d4. The target dies if this reduces that score to 0. If a Humanoid is slain by this attack, a Shadow rises from the corpse 1d4 hours later.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shadow Stealth",
+        "desc": "While in Dim Light or Darkness, the shadow takes the Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "shadow",
+    "url": "/api/2024/monsters/shadow",
+    "image": "/api/images/monsters/shadow.png",
+    "hit_points_roll": "5d8 + 5",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Shambling Mound",
+    "size": "Large",
+    "type": "plant",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 110,
+    "hit_dice": "13d10",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "20 ft."
+    },
+    "strength": 18,
+    "dexterity": 8,
+    "constitution": 16,
+    "intelligence": 5,
+    "wisdom": 10,
+    "charisma": 5,
+    "damage_resistances": [
+      "cold",
+      "fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning"
+    ],
+    "condition_immunities": [
+      "deafened",
+      "exhaustion"
+    ],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Lightning Absorption",
+        "desc": "Whenever the shambling mound is subjected to Lightning damage, it regains a number of Hit Points equal to the Lightning damage dealt."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The shambling mound makes three"
+      },
+      {
+        "name": "Charged Tendril attacks",
+        "desc": "It can replace one attack with a use of Engulf."
+      },
+      {
+        "name": "Charged Tendril",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 5 (2d4) Lightning damage. If the target is a Medium or smaller creature, the shambling mound pulls the target 5 feet straight toward itself.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Engulf",
+        "desc": "Strength Saving Throw: DC 15, one Medium or smaller creature within 5 feet. Failure: The target is pulled into the shambling mound’s space and has the"
+      },
+      {
+        "name": "Grappled condition (escape DC 14)",
+        "desc": "Until the grapple ends, the target has the Blinded and Restrained conditions, and it takes 10 (3d6) Lightning damage at the start of each of its turns. When the shambling mound moves, the Grappled target moves with it, costing it no extra movement. The shambling mound can have only one creature Grappled by this action at a time.",
+        "damage_dice": "3d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "shambling-mound",
+    "url": "/api/2024/monsters/shambling-mound",
+    "image": "/api/images/monsters/shambling-mound.png",
+    "hit_points_roll": "13d10 + 39",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Shield Guardian",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 142,
+    "hit_dice": "15d10",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 18,
+    "dexterity": 8,
+    "constitution": 18,
+    "intelligence": 7,
+    "wisdom": 10,
+    "charisma": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Understands commands given in any language",
+    "challenge_rating": "7",
+    "special_abilities": [
+      {
+        "name": "Bound",
+        "desc": "The guardian is magically bound to an amulet. While the guardian and its amulet are on the same plane of existence, the amulet’s wearer can telepathically call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. If the guardian is within 60 feet of the amulet’s wearer, half of any damage the wearer takes (round up) is transferred to the guardian."
+      },
+      {
+        "name": "Regeneration",
+        "desc": "The guardian regains 10 Hit Points at the start of each of its turns if it has at least 1 Hit Point."
+      },
+      {
+        "name": "Spell Storing",
+        "desc": "A spellcaster who wears the guardian’s amulet can cause the guardian to store one spell of level 4 or lower. To do so, the wearer must cast the spell on the guardian while within 5 feet of it. The spell has no effect but is stored within the guardian. Any previously stored spell is lost when a new spell is stored. The guardian can cast the spell stored with any parameters set by the original caster, requiring no spell components and using the caster’s spellcasting ability. The stored spell is then lost."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The guardian makes two Fist attacks."
+      },
+      {
+        "name": "Fist",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Bludgeoning damage plus 7 (2d6) Force damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Protection",
+        "desc": "Trigger: An attack roll hits the wearer of the guardian’s amulet while the wearer is within 5 feet of the guardian. Response: The wearer gains a +5 bonus to AC, including against the triggering attack and possibly causing it to miss, until the start of the guardian’s next turn. Silver Dragons"
+      }
+    ],
+    "legendary_actions": [],
+    "index": "shield-guardian",
+    "url": "/api/2024/monsters/shield-guardian",
+    "image": "/api/images/monsters/shield-guardian.png",
+    "hit_points_roll": "15d10 + 60",
+    "proficiencies": [],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Silver Dragon Wyrmling",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 45,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 19,
+    "dexterity": 10,
+    "constitution": 17,
+    "intelligence": 12,
+    "wisdom": 11,
+    "charisma": 15,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Draconic",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 13, each creature in a 15-foot Cone. Failure: 18 (4d8) Cold damage. Success: Half damage.",
+        "damage_dice": "4d8"
+      },
+      {
+        "name": "Paralyzing Breath",
+        "desc": "Constitution Saving Throw: DC 13, each creature in a 15-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "silver-dragon-wyrmling",
+    "url": "/api/2024/monsters/silver-dragon-wyrmling",
+    "image": "/api/images/monsters/silver-dragon-wyrmling.png",
+    "hit_points_roll": "6d8 + 18",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Young Silver Dragon",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 168,
+    "hit_dice": "16d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 23,
+    "dexterity": 10,
+    "constitution": 21,
+    "intelligence": 14,
+    "wisdom": 11,
+    "charisma": 19,
+    "perception": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "9",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Paralyzing Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (2d8 + 6) Slashing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 17, each creature in a 30-foot Cone. Failure: 49 (11d8) Cold damage. Success: Half damage.",
+        "damage_dice": "11d8"
+      },
+      {
+        "name": "Paralyzing Breath",
+        "desc": "Constitution Saving Throw: DC 17, each creature in a 30-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "young-silver-dragon",
+    "url": "/api/2024/monsters/young-silver-dragon",
+    "image": "/api/images/monsters/young-silver-dragon.png",
+    "hit_points_roll": "16d10 + 80",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Adult Silver Dragon",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 216,
+    "hit_dice": "16d12",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 27,
+    "dexterity": 10,
+    "constitution": 25,
+    "intelligence": 16,
+    "wisdom": 13,
+    "charisma": 22,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "16",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Paralyzing Breath or (B) Spellcasting to cast Ice Knife."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +13, reach 10 ft. Hit: 17 (2d8 + 8) Slashing damage plus 4 (1d8) Cold damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 20, each creature in a 60-foot Cone. Failure: 54 (12d8) Cold damage. Success: Half damage.",
+        "damage_dice": "12d8"
+      },
+      {
+        "name": "Paralyzing Breath",
+        "desc": "Constitution Saving Throw: DC 20, each creature in a 60-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 19, +11 to hit with spell attacks):",
+        "attack_bonus": 11
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Hold Monster, Ice Knife, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Ice Storm (level 5 version), Zone of Truth"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Chill",
+        "desc": "The dragon uses Spellcasting to cast Hold Monster. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Cold Gale",
+        "desc": "Dexterity Saving Throw: DC 19, each creature in a 60-foot-long, 10-foot-wide Line. Failure: 14 (4d6) Cold damage, and the target is pushed up to 30 feet straight away from the dragon. Success: Half damage only. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "4d6"
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "adult-silver-dragon",
+    "url": "/api/2024/monsters/adult-silver-dragon",
+    "image": "/api/images/monsters/adult-silver-dragon.png",
+    "hit_points_roll": "16d12 + 112",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Ancient Silver Dragon",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 468,
+    "hit_dice": "24d20",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 30,
+    "dexterity": 10,
+    "constitution": 29,
+    "intelligence": 18,
+    "wisdom": 15,
+    "charisma": 26,
+    "perception": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "23",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Paralyzing Breath or (B) Spellcasting to cast Ice Knife (level 2 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +17, reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 9 (2d8) Cold damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 24, each creature in a 90-foot Cone. Failure: 67 (15d8) Cold damage. Success: Half damage.",
+        "damage_dice": "15d8"
+      },
+      {
+        "name": "Paralyzing Breath",
+        "desc": "Constitution Saving Throw: DC 24, each creature in a 90-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks):",
+        "attack_bonus": 15
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Hold Monster, Ice Knife (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Control Weather, Ice Storm (level 7 version), Teleport, Zone of Truth"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Chill",
+        "desc": "The dragon uses Spellcasting to cast Hold Monster. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Cold Gale",
+        "desc": "Dexterity Saving Throw: DC 23, each creature in a 60-foot-long, 10-foot-wide Line. Failure: 14 (4d6) Cold damage, and the target is pushed up to 30 feet straight away from the dragon. Success: Half damage only. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "4d6"
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack. Skeletons"
+      }
+    ],
+    "index": "ancient-silver-dragon",
+    "url": "/api/2024/monsters/ancient-silver-dragon",
+    "image": "/api/images/monsters/ancient-silver-dragon.png",
+    "hit_points_roll": "24d20 + 216",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Skeleton",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "lawful evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 13,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 16,
+    "constitution": 15,
+    "intelligence": 6,
+    "wisdom": 8,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "bludgeoning"
+    ],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "Understands Common plus one other language",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Shortsword",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Shortbow",
+        "desc": "Ranged Attack Roll: +5, range 80/320 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "skeleton",
+    "url": "/api/2024/monsters/skeleton",
+    "image": "/api/images/monsters/skeleton.png",
+    "hit_points_roll": "2d8 + 4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Warhorse Skeleton",
+    "size": "Large",
+    "type": "undead",
+    "alignment": "lawful evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 22,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": "60 ft."
+    },
+    "strength": 18,
+    "dexterity": 12,
+    "constitution": 15,
+    "intelligence": 2,
+    "wisdom": 8,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "bludgeoning"
+    ],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage. If the target is a Large or smaller creature and the skeleton moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "warhorse-skeleton",
+    "url": "/api/2024/monsters/warhorse-skeleton",
+    "image": "/api/images/monsters/warhorse-skeleton.png",
+    "hit_points_roll": "3d10 + 6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Minotaur Skeleton",
+    "size": "Large",
+    "type": "undead",
+    "alignment": "lawful evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 45,
+    "hit_dice": "6d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 11,
+    "constitution": 15,
+    "intelligence": 6,
+    "wisdom": 8,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "bludgeoning"
+    ],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "Understands Abyssal but can’t speak",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature and the skeleton moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Bludgeoning damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "minotaur-skeleton",
+    "url": "/api/2024/monsters/minotaur-skeleton",
+    "image": "/api/images/monsters/minotaur-skeleton.png",
+    "hit_points_roll": "6d10 + 12",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Solar",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 21,
+    "armor_desc": "",
+    "initiative": 20,
+    "hit_points": 297,
+    "hit_dice": "22d10",
+    "speed": {
+      "walk": "50 ft.",
+      "fly": "150 ft.",
+      "hover": true
+    },
+    "strength": 26,
+    "dexterity": 22,
+    "constitution": 26,
+    "intelligence": 25,
+    "wisdom": 25,
+    "charisma": 30,
+    "perception": 14,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison",
+      "radiant"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "poisoned"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 24
+    },
+    "languages": "All; telepathy 120 ft.",
+    "challenge_rating": "21",
+    "special_abilities": [
+      {
+        "name": "Divine Awareness",
+        "desc": "The solar knows if it hears a lie."
+      },
+      {
+        "name": "Exalted Restoration",
+        "desc": "If the solar dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in Mount Celestia."
+      },
+      {
+        "name": "Legendary Resistance (4/Day)",
+        "desc": "If the solar fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The solar has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The solar makes two Flying Sword attacks. It can replace one attack with a use of Slaying Bow."
+      },
+      {
+        "name": "Flying Sword",
+        "desc": "Melee or Ranged Attack Roll: +15, reach 10 ft. or range 120 ft. Hit: 22 (4d6 + 8) Slashing damage plus 36 (8d8) Radiant damage. Hit or Miss: The sword magically returns to the solar’s hand or hovers within 5 feet of the solar immediately after a ranged attack.",
+        "damage_dice": "4d6",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Slaying Bow",
+        "desc": "Dexterity Saving Throw: DC 21, one creature the solar can see within 600 feet. Failure: If the creature has 100 Hit Points or fewer, it dies. It otherwise takes 24 (4d8 + 6) Piercing damage plus 36 (8d8) Radiant damage.",
+        "damage_dice": "4d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The solar casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 25):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Commune, Control Weather, Dispel Evil and Good, Resurrection"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (3/Day)",
+        "desc": "The solar casts Cure Wounds (level 2 version), Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Blinding Gaze",
+        "desc": "Constitution Saving Throw: DC 25, one creature the solar can see within 120 feet. Failure: The target has the Blinded condition for 1 minute. Failure or Success: The solar can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Radiant Teleport",
+        "desc": "The solar teleports up to 60 feet to an unoccupied space it can see. Dexterity Saving Throw: DC 25, each creature in a 10-foot Emanation originating from the solar at its destination space. Failure: 11 (2d10) Radiant damage. Success: Half damage.",
+        "damage_dice": "2d10"
+      }
+    ],
+    "index": "solar",
+    "url": "/api/2024/monsters/solar",
+    "image": "/api/images/monsters/solar.png",
+    "hit_points_roll": "22d10 + 176",
+    "proficiencies": [],
+    "old_senses": "Truesight 120 ft.; Passive Perception 24"
+  },
+  {
+    "name": "Specter",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "50 ft.",
+      "hover": true
+    },
+    "strength": 1,
+    "dexterity": 14,
+    "constitution": 11,
+    "intelligence": 10,
+    "wisdom": 10,
+    "charisma": 11,
+    "damage_resistances": [
+      "acid",
+      "bludgeoning",
+      "cold",
+      "fire",
+      "lightning",
+      ""
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "necrotic",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "prone",
+      "restrained",
+      "unconscious"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Understands Common plus one other language",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Incorporeal Movement",
+        "desc": "The specter can move through other creatures and objects as if they were Difficult"
+      },
+      {
+        "name": "Terrain",
+        "desc": "It takes 5 (1d10) Force damage if it ends its turn inside an object."
+      },
+      {
+        "name": "Sunlight Sensitivity",
+        "desc": "While in sunlight, the specter has Disadvantage on ability checks and attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Life Drain",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d6) Necrotic damage. If the target is a creature, its Hit Point maximum decreases by an amount equal to the damage taken. Sphinxes",
+        "damage_dice": "2d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "specter",
+    "url": "/api/2024/monsters/specter",
+    "image": "/api/images/monsters/specter.png",
+    "hit_points_roll": "5d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Sphinx of Wonder",
+    "size": "Tiny",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 24,
+    "hit_dice": "7d4",
+    "speed": {
+      "walk": "20 ft.",
+      "fly": "40 ft."
+    },
+    "strength": 6,
+    "dexterity": 17,
+    "constitution": 13,
+    "intelligence": 15,
+    "wisdom": 12,
+    "charisma": 11,
+    "damage_resistances": [
+      "necrotic",
+      "psychic",
+      "radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Celestial, Common",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The sphinx has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage plus 7 (2d6) Radiant damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Burst of Ingenuity (2/Day)",
+        "desc": "Trigger: The sphinx or another creature within 30 feet makes an ability check or a saving throw. Response: The sphinx adds 2 to the roll."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "sphinx-of-wonder",
+    "url": "/api/2024/monsters/sphinx-of-wonder",
+    "image": "/api/images/monsters/sphinx-of-wonder.png",
+    "hit_points_roll": "7d4 + 7",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Sphinx of Lore",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 170,
+    "hit_dice": "20d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 18,
+    "dexterity": 15,
+    "constitution": 16,
+    "intelligence": 18,
+    "wisdom": 18,
+    "charisma": 18,
+    "perception": 8,
+    "damage_resistances": [
+      "necrotic",
+      "radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "psychic"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "frightened"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 18
+    },
+    "languages": "Celestial, Common",
+    "challenge_rating": "11",
+    "special_abilities": [
+      {
+        "name": "Inscrutable",
+        "desc": "No magic can observe the sphinx remotely or detect its thoughts without its permission. Wisdom (Insight) checks made to ascertain its intentions or sincerity are made with Disadvantage."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the sphinx fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The sphinx makes three Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 14 (3d6 + 4) Slashing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Mind-Rending Roar (Recharge 5–6)",
+        "desc": "Wisdom Saving Throw: DC 16, each enemy in a 300-foot Emanation originating from the sphinx. Failure: 35 (10d6) Psychic damage, and the target has the Incapacitated condition until the start of the sphinx’s next turn.",
+        "damage_dice": "10d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The sphinx casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 16):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Identify, Mage Hand, Minor Illusion, Prestidigitation"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Dispel Magic, Legend Lore, Locate Object, Plane Shift, Remove Curse, Tongues"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Arcane Prowl",
+        "desc": "The sphinx can teleport up to 30 feet to an unoccupied space it can see, and it makes one Claw attack."
+      },
+      {
+        "name": "Weight of Years",
+        "desc": "Constitution Saving Throw: DC 16, one creature the sphinx can see within 120 feet. Failure: The target gains 1 Exhaustion level. While the target has any Exhaustion levels, it appears 3d10 years older. Failure or Success: The sphinx can’t take this action again until the start of its next turn."
+      }
+    ],
+    "index": "sphinx-of-lore",
+    "url": "/api/2024/monsters/sphinx-of-lore",
+    "image": "/api/images/monsters/sphinx-of-lore.png",
+    "hit_points_roll": "20d10 + 60",
+    "proficiencies": [],
+    "old_senses": "Truesight 120 ft.; Passive Perception 18"
+  },
+  {
+    "name": "Sphinx of Valor",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 12,
+    "hit_points": 199,
+    "hit_dice": "19d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 22,
+    "dexterity": 10,
+    "constitution": 20,
+    "intelligence": 16,
+    "wisdom": 23,
+    "charisma": 18,
+    "perception": 12,
+    "damage_resistances": [
+      "necrotic",
+      "radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "psychic"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "frightened"
+    ],
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 22
+    },
+    "languages": "Celestial, Common",
+    "challenge_rating": "17",
+    "special_abilities": [
+      {
+        "name": "Inscrutable",
+        "desc": "No magic can observe the sphinx remotely or detect its thoughts without its permission. Wisdom (Insight) checks made to ascertain its intentions or sincerity are made with Disadvantage."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the sphinx fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The sphinx makes two Claw attacks and uses Roar."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +12, reach 5 ft. Hit: 20 (4d6 + 6) Slashing damage.",
+        "damage_dice": "4d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Roar (3/Day)",
+        "desc": "The sphinx emits a magical roar. Whenever it roars, the roar has a different effect, as detailed below (the sequence resets when it takes a Long Rest):"
+      },
+      {
+        "name": "First Roar",
+        "desc": "Wisdom Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: The target has the Frightened condition for 1 minute."
+      },
+      {
+        "name": "Second Roar",
+        "desc": "Wisdom Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      },
+      {
+        "name": "Third Roar",
+        "desc": "Constitution Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: 44 (8d10) Thunder damage, and the target has the Prone condition. Success: Half damage only.",
+        "damage_dice": "8d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The sphinx casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 20):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Thaumaturgy"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Detect Magic, Dispel Magic, Greater Restoration, Heroes’ Feast, Zone of Truth"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Arcane Prowl",
+        "desc": "The sphinx can teleport up to 30 feet to an unoccupied space it can see, and it makes one Claw attack."
+      },
+      {
+        "name": "Weight of Years",
+        "desc": "Constitution Saving Throw: DC 16, one creature the sphinx can see within 120 feet. Failure: The target gains 1 Exhaustion level. While the target has any Exhaustion levels, it appears 3d10 years older. Failure or Success: The sphinx can’t take this action again until the start of its next turn."
+      }
+    ],
+    "index": "sphinx-of-valor",
+    "url": "/api/2024/monsters/sphinx-of-valor",
+    "image": "/api/images/monsters/sphinx-of-valor.png",
+    "hit_points_roll": "19d10 + 95",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 11,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 12,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Truesight 120 ft.; Passive Perception 22"
+  },
+  {
+    "name": "Spirit Naga",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 135,
+    "hit_dice": "18d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 17,
+    "constitution": 14,
+    "intelligence": 16,
+    "wisdom": 15,
+    "charisma": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
+    "languages": "Abyssal, Common",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Fiendish Restoration",
+        "desc": "If it dies, the naga returns to life in 1d6 days and regains all its Hit Points. Only a Wish spell can prevent this trait from functioning."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The naga makes three attacks, using Bite or Necrotic Ray in any combination."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 7 (1d6 + 4) Piercing damage plus 14 (4d6) Poison damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Necrotic Ray",
+        "desc": "Ranged Attack Roll: +6, range 60 ft. Hit: 21 (6d6) Necrotic damage.",
+        "damage_dice": "6d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The naga casts one of the following spells, requiring no Somatic or Material components and using Intelligence as the spellcasting ability (spell save DC 14):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Mage Hand, Minor Illusion, Water Breathing"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Detect Thoughts, Dimension Door, Hold Person (level 3 version), Lightning Bolt (level 4 version)"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "spirit-naga",
+    "url": "/api/2024/monsters/spirit-naga",
+    "image": "/api/images/monsters/spirit-naga.png",
+    "hit_points_roll": "18d10 + 36",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Sprite",
+    "size": "Tiny",
+    "type": "fey",
+    "alignment": "neutral good",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 10,
+    "hit_dice": "4d4",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "40 ft."
+    },
+    "strength": 3,
+    "dexterity": 18,
+    "constitution": 10,
+    "intelligence": 14,
+    "wisdom": 13,
+    "charisma": 11,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 13
+    },
+    "languages": "Common, Elvish, Sylvan",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Needle Sword",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Enchanting Bow",
+        "desc": "Ranged Attack Roll: +6, range 40/160 ft. Hit: 1 Piercing damage, and the target has the Charmed condition until the start of the sprite’s next turn."
+      },
+      {
+        "name": "Heart Sight",
+        "desc": "Charisma Saving Throw: DC 10, one creature within 5 feet the sprite can see (Celestials, Fiends, and Undead automatically fail the save). Failure: The sprite knows the target’s emotions and alignment."
+      },
+      {
+        "name": "Invisibility",
+        "desc": "The sprite casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "sprite",
+    "url": "/api/2024/monsters/sprite",
+    "image": "/api/images/monsters/sprite.png",
+    "hit_points_roll": "4d4",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 13"
+  },
+  {
+    "name": "Spy",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 27,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 15,
+    "constitution": 10,
+    "intelligence": 12,
+    "wisdom": 14,
+    "charisma": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 16
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Shortsword",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Hand Crossbow",
+        "desc": "Ranged Attack Roll: +4, range 30/120 ft. Hit: 5 (1d6 + 2) Piercing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Cunning Action",
+        "desc": "The spy takes the Dash, Disengage, or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "spy",
+    "url": "/api/2024/monsters/spy",
+    "image": "/api/images/monsters/spy.png",
+    "hit_points_roll": "6d8",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 16"
+  },
+  {
+    "name": "Stirge",
+    "size": "Tiny",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 5,
+    "hit_dice": "2d4",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "40 ft."
+    },
+    "strength": 4,
+    "dexterity": 16,
+    "constitution": 11,
+    "intelligence": 2,
+    "wisdom": 8,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Proboscis",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage, and the stirge attaches to the target. While attached, the stirge can’t make Proboscis attacks, and the target takes 5 (2d4) Necrotic damage at the start of each of the stirge’s turns. The stirge can detach itself by spending 5 feet of its movement. The target or a creature within 5 feet of it can detach the stirge as an action.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "stirge",
+    "url": "/api/2024/monsters/stirge",
+    "image": "/api/images/monsters/stirge.png",
+    "hit_points_roll": "2d4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Stone Giant",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 126,
+    "hit_dice": "11d12",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 23,
+    "dexterity": 15,
+    "constitution": 20,
+    "intelligence": 10,
+    "wisdom": 12,
+    "charisma": 9,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Giant",
+    "challenge_rating": "7",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Stone Club or Boulder in any combination."
+      },
+      {
+        "name": "Stone Club",
+        "desc": "Melee Attack Roll: +9, reach 15 ft. Hit: 22 (3d10 + 6) Bludgeoning damage.",
+        "damage_dice": "3d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Boulder",
+        "desc": "Ranged Attack Roll: +9, range 60/240 ft. Hit: 15 (2d8 + 6) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Deflect Missile (Recharge 5–6)",
+        "desc": "Trigger: The giant is hit by a ranged attack roll and takes Bludgeoning, Piercing, or Slashing damage from it. Response: The giant reduces the damage it takes from the attack by 11 (1d10 + 6), and if that damage is reduced to 0, the giant can redirect some of the attack’s force. Dexterity Saving Throw: DC 17, one creature the giant can see within 60 feet. Failure: 11 (1d10 + 6) Force damage."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "stone-giant",
+    "url": "/api/2024/monsters/stone-giant",
+    "image": "/api/images/monsters/stone-giant.png",
+    "hit_points_roll": "11d12 + 55",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Stone Golem",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 220,
+    "hit_dice": "21d10",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 22,
+    "dexterity": 9,
+    "constitution": 20,
+    "intelligence": 3,
+    "wisdom": 11,
+    "charisma": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison",
+      "psychic"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "frightened",
+      "paralyzed",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Understands Common plus two other",
+    "challenge_rating": "10",
+    "special_abilities": [
+      {
+        "name": "Immutable Form",
+        "desc": "The golem can’t shape-shift."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The golem makes two attacks, using Slam or Force Bolt in any combination."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 15 (2d8 + 6) Bludgeoning damage plus 9 (2d8) Force damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Force Bolt",
+        "desc": "Ranged Attack Roll: +9, range 120 ft. Hit: 22 (4d10) Force damage.",
+        "damage_dice": "4d10"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Slow (Recharge 5–6)",
+        "desc": "The golem casts the Slow spell, requiring no spell components and using Constitution as the spellcasting ability (spell save DC 17)."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "stone-golem",
+    "url": "/api/2024/monsters/stone-golem",
+    "image": "/api/images/monsters/stone-golem.png",
+    "hit_points_roll": "21d10 + 105",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Storm Giant",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "chaotic good",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 230,
+    "hit_dice": "20d12",
+    "speed": {
+      "walk": "50 ft.",
+      "fly": "25 ft.",
+      "hover": true,
+      "swim": "50 ft."
+    },
+    "strength": 29,
+    "dexterity": 14,
+    "constitution": 20,
+    "intelligence": 16,
+    "wisdom": 20,
+    "charisma": 18,
+    "perception": 10,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning",
+      "thunder"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft., Truesight 30 ft."
+    },
+    "languages": "Common, Giant",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The giant can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Storm Sword or Thunderbolt in any combination."
+      },
+      {
+        "name": "Storm Sword",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 23 (4d6 + 9) Slashing damage plus 13 (3d8) Lightning damage.",
+        "damage_dice": "4d6",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Thunderbolt",
+        "desc": "Ranged Attack Roll: +14, range 500 ft. Hit: 22 (2d12 + 9) Lightning damage, and the target has the Blinded and Deafened conditions until the start of the giant’s next turn.",
+        "damage_dice": "2d12",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Lightning Storm (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 18, each creature in a 10-foot-radius, 40-foot-high Cylinder originating from a point the giant can see within 500 feet. Failure: 55 (10d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "10d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The giant casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 18):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Light"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Control Weather"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "storm-giant",
+    "url": "/api/2024/monsters/storm-giant",
+    "image": "/api/images/monsters/storm-giant.png",
+    "hit_points_roll": "20d12 + 100",
+    "proficiencies": [
+      {
+        "value": 14,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft., Truesight 30 ft.;"
+  },
+  {
+    "name": "Succubus",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 71,
+    "hit_dice": "13d8",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 8,
+    "dexterity": 17,
+    "constitution": 13,
+    "intelligence": 15,
+    "wisdom": 12,
+    "charisma": 20,
+    "perception": 5,
+    "damage_resistances": [
+      "cold",
+      "fire",
+      "poison",
+      "psychic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "Abyssal, Common, Infernal; telepathy 60 ft.",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Incubus Form",
+        "desc": "When the succubus finishes a Long Rest, it can shape-shift into an Incubus, using that stat block instead of this one."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The succubus makes one Fiendish Touch attack and uses Charm or Draining Kiss."
+      },
+      {
+        "name": "Fiendish Touch",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 16 (2d10 + 5) Psychic damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Charm",
+        "desc": "The succubus casts Dominate Person (level 8 version), requiring no spell components and using Charisma as the spellcasting ability (spell save DC 15)."
+      },
+      {
+        "name": "Draining Kiss",
+        "desc": "Constitution Saving Throw: DC 15, one creature Charmed by the succubus within 5 feet. Failure: 13 (3d8) Psychic damage. Success: Half damage. Failure or Success: The target’s Hit Point maximum decreases by an amount equal to the damage taken.",
+        "damage_dice": "3d8"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The succubus shape-shifts into a Medium or Small Humanoid, or it returns to its true form. Its game statistics are the same in each form, except its Fly"
+      },
+      {
+        "name": "Speed is available only in its true form",
+        "desc": "Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "succubus",
+    "url": "/api/2024/monsters/succubus",
+    "image": "/api/images/monsters/succubus.png",
+    "hit_points_roll": "13d8 + 13",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Tarrasque",
+    "size": "Gargantuan",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 25,
+    "armor_desc": "",
+    "initiative": 18,
+    "hit_points": 697,
+    "hit_dice": "34d20",
+    "speed": {
+      "walk": "60 ft.",
+      "burrow": "40 ft.",
+      "climb": "60 ft."
+    },
+    "strength": 30,
+    "dexterity": 11,
+    "constitution": 30,
+    "intelligence": 3,
+    "wisdom": 11,
+    "charisma": 11,
+    "perception": 9,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "fire",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "deafened",
+      "frightened",
+      "paralyzed",
+      "poisoned"
+    ],
+    "senses": {
+      "blindsight": "120 ft.",
+      "passive_perception": 19
+    },
+    "languages": "None",
+    "challenge_rating": "30",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (6/Day)",
+        "desc": "If the tarrasque fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The tarrasque has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Reflective Carapace",
+        "desc": "If the tarrasque is targeted by a Magic Missile spell or a spell that requires a ranged attack roll, roll 1d6. On a 1–5, the tarrasque is unaffected. On a 6, the tarrasque is unaffected and reflects the spell, turning the caster into the target."
+      },
+      {
+        "name": "Siege Monster",
+        "desc": "The tarrasque deals double damage to objects and structures."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The tarrasque makes one Bite attack and three other attacks, using Claw or Tail in any combination."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +19, reach 15 ft. Hit: 36 (4d12 + 10) Piercing damage, and the target has the Grappled condition (escape DC 20). Until the grapple ends, the target has the Restrained condition and can’t teleport.",
+        "damage_dice": "4d12",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +19, reach 15 ft. Hit: 28 (4d8 + 10) Slashing damage.",
+        "damage_dice": "4d8",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +19, reach 30 ft. Hit: 23 (3d8 + 10) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+        "damage_dice": "3d8",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Thunderous Bellow (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 27, each creature and each object that isn’t being worn or carried in a 150-foot Cone. Failure: 78 (12d12) Thunder damage, and the target has the Deafened and Frightened conditions until the end of its next turn. Success: Half damage only.",
+        "damage_dice": "12d12"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Swallow",
+        "desc": "Strength Saving Throw: DC 27, one Large or smaller creature Grappled by the tarrasque (it can have up to six creatures swallowed at a time). Failure: The target is swallowed, and the Grappled condition ends. A swallowed creature has the Blinded and Restrained conditions and can’t teleport, it has Total Cover against attacks and other effects outside the tarrasque, and it takes 56 (16d6) Acid damage at the start of each of the tarrasque’s turns. If the tarrasque takes 60 damage or more on a single turn from a creature inside it, the tarrasque must succeed on a DC 20 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 10 feet of the tarrasque and has the Prone condition. If the tarrasque dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse using 20 feet of movement, exiting Prone."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Onslaught",
+        "desc": "The tarrasque moves up to half its Speed, and it makes one Claw or Tail attack."
+      },
+      {
+        "name": "World-Shaking Movement",
+        "desc": "The tarrasque moves up to its Speed. At the end of this movement, the tarrasque creates an instantaneous shock wave in a 60-foot Emanation originating from itself. Creatures in that area lose Concentration and, if Medium or smaller, have the Prone condition. The tarrasque can’t take this action again until the start of its next turn. Toughs"
+      }
+    ],
+    "index": "tarrasque",
+    "url": "/api/2024/monsters/tarrasque",
+    "image": "/api/images/monsters/tarrasque.png",
+    "hit_points_roll": "34d20 + 340",
+    "proficiencies": [
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 120 ft.; Passive Perception 19"
+  },
+  {
+    "name": "Tough",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 32,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 12,
+    "constitution": 14,
+    "intelligence": 10,
+    "wisdom": 10,
+    "charisma": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The tough has Advantage on an attack roll against a creature if at least one of the tough’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Mace",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Heavy Crossbow",
+        "desc": "Ranged Attack Roll: +3, range 100/400 ft. Hit: 6 (1d10 + 1) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "tough",
+    "url": "/api/2024/monsters/tough",
+    "image": "/api/images/monsters/tough.png",
+    "hit_points_roll": "5d8 + 10",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Tough Boss",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 82,
+    "hit_dice": "11d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 17,
+    "dexterity": 14,
+    "constitution": 16,
+    "intelligence": 11,
+    "wisdom": 10,
+    "charisma": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The tough has Advantage on an attack roll against a creature if at least one of the tough’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The tough makes two attacks, using Warhammer or Heavy Crossbow in any combination."
+      },
+      {
+        "name": "Warhammer",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Bludgeoning damage. If the target is a Large or smaller creature, the tough pushes the target up to 10 feet straight away from itself.",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Heavy Crossbow",
+        "desc": "Ranged Attack Roll: +4, range 100/400 ft. Hit: 13 (2d10 + 2) Piercing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "tough-boss",
+    "url": "/api/2024/monsters/tough-boss",
+    "image": "/api/images/monsters/tough-boss.png",
+    "hit_points_roll": "11d8 + 33",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Treant",
+    "size": "Huge",
+    "type": "plant",
+    "alignment": "chaotic good",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 138,
+    "hit_dice": "12d12",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 23,
+    "dexterity": 8,
+    "constitution": 21,
+    "intelligence": 12,
+    "wisdom": 16,
+    "charisma": 12,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing"
+    ],
+    "damage_vulnerabilities": [
+      "fire"
+    ],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 13
+    },
+    "languages": "Common, Druidic, Elvish, Sylvan",
+    "challenge_rating": "9",
+    "special_abilities": [
+      {
+        "name": "Siege Monster",
+        "desc": "The treant deals double damage to objects and structures."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The treant makes two Slam attacks."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 16 (3d6 + 6) Bludgeoning damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Hail of Bark",
+        "desc": "Ranged Attack Roll: +10, range 180 ft. Hit: 28 (4d10 + 6) Piercing damage.",
+        "damage_dice": "4d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Animate Trees (1/Day)",
+        "desc": "The treant magically animates up to two trees it can see within 60 feet of itself. Each tree uses the Treant stat block, except it has Intelligence and Charisma scores of 1, it can’t speak, and it lacks this action. The tree takes its turn immediately after the treant on the same Initiative count, and it obeys the treant. A tree remains animate for 1 day or until it dies, the treant dies, or it is more than 120 feet from the treant. The tree then takes root if possible."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "treant",
+    "url": "/api/2024/monsters/treant",
+    "image": "/api/images/monsters/treant.png",
+    "hit_points_roll": "12d12 + 60",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 13"
+  },
+  {
+    "name": "Troll",
+    "size": "Large",
+    "type": "giant",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 94,
+    "hit_dice": "9d10",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 18,
+    "dexterity": 13,
+    "constitution": 20,
+    "intelligence": 7,
+    "wisdom": 9,
+    "charisma": 7,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "Giant",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Loathsome Limbs (4/Day)",
+        "desc": "If the troll ends any turn Bloodied and took 15+ Slashing damage during that turn, one of the troll’s limbs is severed, falls into the troll’s space, and becomes a Troll Limb. The limb acts immediately after the troll’s turn. The troll has 1 Exhaustion level for each missing limb, and it grows replacement limbs the next time it regains Hit Points."
+      },
+      {
+        "name": "Regeneration",
+        "desc": "The troll regains 15 Hit Points at the start of each of its turns. If the troll takes Acid or Fire damage, this trait doesn’t function on the troll’s next turn. The troll dies only if it starts its turn with 0 Hit Points and doesn’t regenerate."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The troll makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Charge",
+        "desc": "The troll moves up to half its Speed straight toward an enemy it can see."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "troll",
+    "url": "/api/2024/monsters/troll",
+    "image": "/api/images/monsters/troll.png",
+    "hit_points_roll": "9d10 + 45",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Troll Limb",
+    "size": "Small",
+    "type": "giant",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 14,
+    "hit_dice": "4d6",
+    "speed": {
+      "walk": "20 ft."
+    },
+    "strength": 18,
+    "dexterity": 12,
+    "constitution": 10,
+    "intelligence": 1,
+    "wisdom": 9,
+    "charisma": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Regeneration",
+        "desc": "The limb regains 5 Hit Points at the start of each of its turns. If the limb takes Acid or Fire damage, this trait doesn’t function on the limb’s next turn. The limb dies only if it starts its turn with 0 Hit Points and doesn’t regenerate."
+      },
+      {
+        "name": "Troll Spawn",
+        "desc": "The limb uncannily has the same senses as a whole troll. If the limb isn’t destroyed within 24 hours, roll 1d12. On a 12, the limb turns into a Troll. Otherwise, the limb withers away."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Slashing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "troll-limb",
+    "url": "/api/2024/monsters/troll-limb",
+    "image": "/api/images/monsters/troll-limb.png",
+    "hit_points_roll": "4d6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Unicorn",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 8,
+    "hit_points": 97,
+    "hit_dice": "13d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 18,
+    "dexterity": 14,
+    "constitution": 15,
+    "intelligence": 11,
+    "wisdom": 17,
+    "charisma": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "paralyzed",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "Celestial, Elvish, Sylvan; telepathy 120 ft.",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day)",
+        "desc": "If the unicorn fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The unicorn has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The unicorn makes one Hooves attack and one Radiant Horn attack."
+      },
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (2d6 + 4) Bludgeoning damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Radiant Horn",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 9 (1d10 + 4) Radiant damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The unicorn casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 14):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Druidcraft"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Calm Emotions, Dispel Evil and Good, Entangle, Pass without Trace, Word of Recall"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Charging Horn",
+        "desc": "The unicorn moves up to half its Speed without provoking Opportunity Attacks, and it makes one Radiant Horn attack."
+      },
+      {
+        "name": "Shimmering Shield",
+        "desc": "The unicorn targets itself or one creature it can see within 60 feet of itself. The target gains 10 (3d6) Temporary Hit Points, and its AC increases by 2 until the end of the unicorn’s next turn. The unicorn can’t take this action again until the start of its next turn. Vampires"
+      }
+    ],
+    "index": "unicorn",
+    "url": "/api/2024/monsters/unicorn",
+    "image": "/api/images/monsters/unicorn.png",
+    "hit_points_roll": "13d10 + 26",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Vampire Familiar",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 65,
+    "hit_dice": "10d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 17,
+    "dexterity": 16,
+    "constitution": 15,
+    "intelligence": 10,
+    "wisdom": 10,
+    "charisma": 14,
+    "perception": 4,
+    "damage_resistances": [
+      "necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed (except from its vampire master)"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Vampiric Connection",
+        "desc": "While the familiar and its vampire master are on the same plane of existence, the vampire can communicate with the familiar telepathically, and the vampire can perceive through the familiar’s senses."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The familiar makes two Umbral Dagger attacks."
+      },
+      {
+        "name": "Umbral Dagger",
+        "desc": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 20/60 ft. Hit: 5 (1d4 + 3) Piercing damage plus 7 (3d4) Necrotic damage. If the target is reduced to 0 Hit Points by this attack, the target becomes Stable but has the Poisoned condition for 1 hour. While it has the Poisoned condition, the target has the Paralyzed condition.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Deathless Agility",
+        "desc": "The familiar takes the Dash or Disengage action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "vampire-familiar",
+    "url": "/api/2024/monsters/vampire-familiar",
+    "image": "/api/images/monsters/vampire-familiar.png",
+    "hit_points_roll": "10d8 + 20",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Vampire Spawn",
+    "size": "Medium",
+    "type": "or small undead",
+    "alignment": "neutral evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 90,
+    "hit_dice": "12d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 16,
+    "constitution": 16,
+    "intelligence": 11,
+    "wisdom": 10,
+    "charisma": 12,
+    "perception": 3,
+    "damage_resistances": [
+      "necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The vampire can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Vampire Weakness",
+        "desc": "The vampire has these weaknesses:"
+      },
+      {
+        "name": "Forbiddance",
+        "desc": "The vampire can’t enter a residence without an invitation from an occupant."
+      },
+      {
+        "name": "Running Water",
+        "desc": "The vampire takes 20 Acid damage if it ends its turn in running water."
+      },
+      {
+        "name": "Stake to the Heart",
+        "desc": "The vampire is destroyed if a weapon that deals Piercing damage is driven into the vampire’s heart while the vampire has the Incapacitated condition."
+      },
+      {
+        "name": "Sunlight",
+        "desc": "The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Disadvantage on attack rolls and ability checks."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The vampire makes two Claw attacks and uses Bite."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (2d4 + 3) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 13) from one of two claws."
+      },
+      {
+        "name": "Bite",
+        "desc": "Constitution Saving Throw: DC 14, one creature within 5 feet that is willing or that has the Grappled, Incapacitated, or Restrained condition. Failure: 5 (1d4 + 3) Piercing damage plus 10 (3d6) Necrotic damage. The target’s Hit Point maximum decreases by an amount equal to the Necrotic damage taken, and the vampire regains Hit Points equal to that amount.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Deathless Agility",
+        "desc": "The vampire takes the Dash or Disengage action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "vampire-spawn",
+    "url": "/api/2024/monsters/vampire-spawn",
+    "image": "/api/images/monsters/vampire-spawn.png",
+    "hit_points_roll": "12d8 + 36",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Vampire",
+    "size": "Medium",
+    "type": "or small undead",
+    "alignment": "lawful evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 195,
+    "hit_dice": "23d8",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 18,
+    "constitution": 18,
+    "intelligence": 17,
+    "wisdom": 15,
+    "charisma": 18,
+    "perception": 7,
+    "damage_resistances": [
+      "necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 17
+    },
+    "languages": "Common plus two other languages",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the vampire fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Misty Escape",
+        "desc": "If the vampire drops to 0 Hit Points outside its resting place, the vampire uses Shape-Shift to become mist (no action required). If it can’t use ShapeShift, it is destroyed. While it has 0 Hit Points in mist form, it can’t return to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it returns to its vampire form and has the Paralyzed condition until it regains any Hit Points, and it regains 1 Hit Point after spending 1 hour there."
+      },
+      {
+        "name": "Spider Climb",
+        "desc": "The vampire can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Vampire Weakness",
+        "desc": "The vampire has these weaknesses:"
+      },
+      {
+        "name": "Forbiddance",
+        "desc": "The vampire can’t enter a residence without an invitation from an occupant."
+      },
+      {
+        "name": "Running Water",
+        "desc": "The vampire takes 20 Acid damage if it ends its turn in running water."
+      },
+      {
+        "name": "Stake to the Heart",
+        "desc": "If a weapon that deals Piercing damage is driven into the vampire’s heart while the vampire has the Incapacitated condition in its resting place, the vampire has the Paralyzed condition until the weapon is removed."
+      },
+      {
+        "name": "Sunlight",
+        "desc": "The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Disadvantage on attack rolls and ability checks."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack (Vampire Form Only)",
+        "desc": "The vampire makes two Grave Strike attacks and uses Bite."
+      },
+      {
+        "name": "Grave Strike (Vampire Form Only)",
+        "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 8 (1d8 + 4) Bludgeoning damage plus 7 (2d6) Necrotic damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of two hands.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Bite (Bat or Vampire Form Only)",
+        "desc": "Constitution Saving Throw: DC 17, one creature within 5 feet that is willing or that has the Grappled, Incapacitated, or Restrained condition. Failure: 6 (1d4 + 4) Piercing damage plus 13 (3d8) Necrotic damage. The target’s Hit Point maximum decreases by an amount equal to the Necrotic damage taken, and the vampire regains Hit Points equal to that amount. A Humanoid reduced to 0 Hit Points by this damage and then buried rises the following sunset as a Vampire Spawn under the vampire’s control.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Charm (Recharge 5–6)",
+        "desc": "The vampire casts Charm Person, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 17), and the duration is 24 hours. The Charmed target is a willing recipient of the vampire’s Bite, the damage of which doesn’t end the spell. When the spell ends, the target is unaware it was Charmed by the vampire."
+      },
+      {
+        "name": "Shape-Shift",
+        "desc": "If the vampire isn’t in sunlight or running water, it shape-shifts into a Tiny bat (Speed 5 ft., Fly Speed 30 ft.) or a Medium cloud of mist (Speed 5 ft., Fly Speed 20 ft. [hover]), or it returns to its vampire form. Anything it is wearing transforms with it. While in bat form, the vampire can’t speak. Its game statistics, other than its size and Speed, are unchanged. While in mist form, the vampire can’t take any actions, speak, or manipulate objects. It is weightless and can enter an enemy’s space and stop there. If air can pass through a space, the mist can do so, but it can’t pass through liquid. It has Resistance to all damage, except the damage it takes from sunlight."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Beguile",
+        "desc": "The vampire casts Command, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 17). The vampire can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Deathless Strike",
+        "desc": "The vampire moves up to half its Speed, and it makes one Grave Strike attack."
+      }
+    ],
+    "index": "vampire",
+    "url": "/api/2024/monsters/vampire",
+    "image": "/api/images/monsters/vampire.png",
+    "hit_points_roll": "23d8 + 92",
+    "proficiencies": [
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 17"
+  },
+  {
+    "name": "Vrock",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 152,
+    "hit_dice": "16d10",
+    "speed": {
+      "walk": "40 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 17,
+    "dexterity": 15,
+    "constitution": 18,
+    "intelligence": 8,
+    "wisdom": 13,
+    "charisma": 8,
+    "damage_resistances": [
+      "cold",
+      "fire",
+      "lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 11
+    },
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "6",
+    "special_abilities": [
+      {
+        "name": "Demonic Restoration",
+        "desc": "If the vrock dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The vrock has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The vrock makes two Shred attacks."
+      },
+      {
+        "name": "Shred",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage plus 10 (3d6) Poison damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Spores (Recharge 6)",
+        "desc": "Constitution Saving Throw: DC 15, each creature in a 20-foot Emanation originating from the vrock. Failure: The target has the Poisoned condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. While Poisoned, the target takes 5 (1d10) Poison damage at the start of each of its turns. Emptying a flask of Holy Water on the target ends the effect early.",
+        "damage_dice": "1d10"
+      },
+      {
+        "name": "Stunning Screech (1/Day)",
+        "desc": "Constitution Saving Throw: DC 15, each creature in a 20-foot Emanation originating from the vrock (demons succeed automatically). Failure: 10 (3d6) Thunder damage, and the target has the Stunned condition until the end of the vrock’s next turn. Warriors",
+        "damage_dice": "3d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "vrock",
+    "url": "/api/2024/monsters/vrock",
+    "image": "/api/images/monsters/vrock.png",
+    "hit_points_roll": "16d10 + 64",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/2024/proficiencies/saving-throw-cha"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Warrior Infantry",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 9,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 13,
+    "dexterity": 11,
+    "constitution": 11,
+    "intelligence": 8,
+    "wisdom": 11,
+    "charisma": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "Common",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The warrior has Advantage on an attack roll against a creature if at least one of the warrior’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Spear",
+        "desc": "Melee or Ranged Attack Roll: +3, reach 5 ft. or range 20/60 ft. Hit: 4 (1d6 + 1) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "warrior-infantry",
+    "url": "/api/2024/monsters/warrior-infantry",
+    "image": "/api/images/monsters/warrior-infantry.png",
+    "hit_points_roll": "2d8",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Warrior Veteran",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 65,
+    "hit_dice": "10d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 13,
+    "constitution": 14,
+    "intelligence": 10,
+    "wisdom": 11,
+    "charisma": 10,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The warrior makes two Greatsword or Heavy Crossbow attacks."
+      },
+      {
+        "name": "Greatsword",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Heavy Crossbow",
+        "desc": "Ranged Attack Roll: +3, range 100/400 ft. Hit: 12 (2d10 + 1) Piercing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The warrior is hit by a melee attack roll while holding a weapon. Response: The warrior adds 2 to its AC against that attack, possibly causing it to miss."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "warrior-veteran",
+    "url": "/api/2024/monsters/warrior-veteran",
+    "image": "/api/images/monsters/warrior-veteran.png",
+    "hit_points_roll": "10d8 + 20",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Water Elemental",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 114,
+    "hit_dice": "12d10",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "90 ft."
+    },
+    "strength": 18,
+    "dexterity": 14,
+    "constitution": 18,
+    "intelligence": 5,
+    "wisdom": 10,
+    "charisma": 8,
+    "damage_resistances": [
+      "acid",
+      "fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "prone",
+      "restrained",
+      "unconscious"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "Primordial (Aquan)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Freeze",
+        "desc": "If the elemental takes Cold damage, its Speed decreases by 20 feet until the end of its next turn."
+      },
+      {
+        "name": "Water Form",
+        "desc": "The elemental can enter an enemy’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The elemental makes two Slam attacks."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Whelm (Recharge 4–6)",
+        "desc": "Strength Saving Throw: DC 15, each creature in the elemental’s space. Failure: 22 (4d8 + 4) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14). Until the grapple ends, the target has the Restrained condition, is suffocating unless it can breathe water, and takes 9 (2d8) Bludgeoning damage at the start of each of the elemental’s turns. The elemental can grapple one Large creature or up to two Medium or smaller creatures at a time with Whelm. As an action, a creature within 5 feet of the elemental can pull a creature out of it by succeeding on a DC 14 Strength (Athletics) check. Success: Half damage only.",
+        "damage_dice": "4d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "water-elemental",
+    "url": "/api/2024/monsters/water-elemental",
+    "image": "/api/images/monsters/water-elemental.png",
+    "hit_points_roll": "12d10 + 48",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Werebear",
+    "size": "Medium",
+    "type": "or small monstrosity",
+    "alignment": "neutral good",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 135,
+    "hit_dice": "18d8",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 19,
+    "dexterity": 10,
+    "constitution": 17,
+    "intelligence": 11,
+    "wisdom": 12,
+    "charisma": 12,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 17
+    },
+    "languages": "Common (can’t speak in bear form)",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The werebear makes two attacks, using"
+      },
+      {
+        "name": "Handaxe or Rend in any combination",
+        "desc": "It can replace one attack with a Bite attack."
+      },
+      {
+        "name": "Bite (Bear or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 17 (2d12 + 4) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 14. Failure:",
+        "damage_dice": "2d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "The target is cursed",
+        "desc": "If the cursed target drops to 0 Hit Points, it instead becomes a Werebear under the GM’s control and has 10 Hit Points. Success: The target is immune to this werebear’s curse for 24 hours."
+      },
+      {
+        "name": "Handaxe (Humanoid or Hybrid Form Only)",
+        "desc": "Melee or Ranged Attack Roll: +7, reach 5 ft or range 20/60 ft. Hit: 14 (3d6 + 4) Slashing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Rend (Bear or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The werebear shape-shifts into a Large bear-humanoid hybrid form or a Large bear, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "werebear",
+    "url": "/api/2024/monsters/werebear",
+    "image": "/api/images/monsters/werebear.png",
+    "hit_points_roll": "18d8 + 54",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 17"
+  },
+  {
+    "name": "Wereboar",
+    "size": "Medium",
+    "type": "or small monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 97,
+    "hit_dice": "15d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 17,
+    "dexterity": 10,
+    "constitution": 15,
+    "intelligence": 10,
+    "wisdom": 11,
+    "charisma": 8,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "Common (can’t speak in boar form)",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The wereboar makes two attacks, using"
+      },
+      {
+        "name": "Javelin or Tusk in any combination",
+        "desc": "It can replace one attack with a Gore attack."
+      },
+      {
+        "name": "Gore (Boar or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 12. Failure:",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "The target is cursed",
+        "desc": "If the cursed target drops to 0 Hit Points, it instead becomes a Wereboar under the GM’s control and has 10 Hit Points. Success: The target is immune to this wereboar’s curse for 24 hours."
+      },
+      {
+        "name": "Javelin (Humanoid or Hybrid Form Only)",
+        "desc": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 30/120 ft. Hit: 13 (3d6 + 3) Piercing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tusk (Boar or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Medium or smaller creature and the wereboar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 7 (2d6) Piercing damage and has the Prone condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The wereboar shape-shifts into a Medium boar-humanoid hybrid or a Small boar, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "wereboar",
+    "url": "/api/2024/monsters/wereboar",
+    "image": "/api/images/monsters/wereboar.png",
+    "hit_points_roll": "15d8 + 30",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Wererat",
+    "size": "Medium",
+    "type": "or small monstrosity",
+    "alignment": "lawful evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 60,
+    "hit_dice": "11d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 10,
+    "dexterity": 16,
+    "constitution": 12,
+    "intelligence": 11,
+    "wisdom": 10,
+    "charisma": 8,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Common (can’t speak in rat form)",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The wererat makes two attacks, using"
+      },
+      {
+        "name": "Scratch or Hand Crossbow in any combination",
+        "desc": "It can replace one attack with a Bite attack."
+      },
+      {
+        "name": "Bite (Rat or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (2d4 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 11. Failure: The target is cursed. If the cursed target drops to 0 Hit Points, it instead becomes a Wererat under the GM’s control and has 10 Hit Points. Success: The target is immune to this wererat’s curse for 24 hours.",
+        "damage_dice": "2d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Scratch",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage. Hand Crossbow (Humanoid or Hybrid Form Only). Ranged Attack Roll: +5, range 30/120 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The wererat shape-shifts into a Medium rat-humanoid hybrid or a Small rat, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "wererat",
+    "url": "/api/2024/monsters/wererat",
+    "image": "/api/images/monsters/wererat.png",
+    "hit_points_roll": "11d8 + 11",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Weretiger",
+    "size": "Medium",
+    "type": "or small monstrosity",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 120,
+    "hit_dice": "16d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 17,
+    "dexterity": 15,
+    "constitution": 16,
+    "intelligence": 10,
+    "wisdom": 13,
+    "charisma": 11,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "Common (can’t speak in tiger form)",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The weretiger makes two attacks, using"
+      },
+      {
+        "name": "Scratch or Longbow in any combination",
+        "desc": "It can replace one attack with a Bite attack."
+      },
+      {
+        "name": "Bite (Tiger or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 13. Failure:",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "The target is cursed",
+        "desc": "If the cursed target drops to 0 Hit Points, it instead becomes a Weretiger under the GM’s control and has 10 Hit Points. Success: The target is immune to this weretiger’s curse for 24 hours."
+      },
+      {
+        "name": "Scratch",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Longbow (Humanoid or Hybrid Form Only)",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 11 (2d8 + 2) Piercing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Prowl (Tiger or Hybrid Form Only)",
+        "desc": "The weretiger moves up to its Speed without provoking Opportunity"
+      },
+      {
+        "name": "Attacks",
+        "desc": "At the end of this movement, the weretiger can take the Hide action."
+      },
+      {
+        "name": "Shape-Shift",
+        "desc": "The weretiger shape-shifts into a Large tiger-humanoid hybrid or a Large tiger, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "weretiger",
+    "url": "/api/2024/monsters/weretiger",
+    "image": "/api/images/monsters/weretiger.png",
+    "hit_points_roll": "16d8 + 48",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Werewolf",
+    "size": "Medium",
+    "type": "or small monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 71,
+    "hit_dice": "11d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 16,
+    "dexterity": 14,
+    "constitution": 14,
+    "intelligence": 10,
+    "wisdom": 11,
+    "charisma": 10,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Common (can’t speak in wolf form)",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The werewolf has Advantage on an attack roll against a creature if at least one of the werewolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The werewolf makes two attacks, using"
+      },
+      {
+        "name": "Scratch or Longbow in any combination",
+        "desc": "It can replace one attack with a Bite attack."
+      },
+      {
+        "name": "Bite (Wolf or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 12. Failure:",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "The target is cursed",
+        "desc": "If the cursed target drops to 0 Hit Points, it instead becomes a Werewolf under the GM’s control and has 10 Hit Points. Success: The target is immune to this werewolf’s curse for 24 hours."
+      },
+      {
+        "name": "Scratch",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Longbow (Humanoid or Hybrid Form Only)",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 11 (2d8 + 2) Piercing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The werewolf shape-shifts into a Large wolf-humanoid hybrid or a Medium wolf, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. White Dragons"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "werewolf",
+    "url": "/api/2024/monsters/werewolf",
+    "image": "/api/images/monsters/werewolf.png",
+    "hit_points_roll": "11d8 + 22",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "White Dragon Wyrmling",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 32,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": "30 ft.",
+      "burrow": "15 ft.",
+      "fly": "60 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 14,
+    "dexterity": 10,
+    "constitution": 14,
+    "intelligence": 5,
+    "wisdom": 10,
+    "charisma": 11,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "Draconic",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Ice Walk",
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 2 (1d4) Cold damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 22 (5d8) Cold damage. Success: Half damage.",
+        "damage_dice": "5d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "white-dragon-wyrmling",
+    "url": "/api/2024/monsters/white-dragon-wyrmling",
+    "image": "/api/images/monsters/white-dragon-wyrmling.png",
+    "hit_points_roll": "5d8 + 10",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Young White Dragon",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 123,
+    "hit_dice": "13d10",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "20 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 10,
+    "constitution": 18,
+    "intelligence": 6,
+    "wisdom": 11,
+    "charisma": 12,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "6",
+    "special_abilities": [
+      {
+        "name": "Ice Walk",
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 9 (2d4 + 4) Slashing damage plus 2 (1d4) Cold damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 15, each creature in a 30-foot Cone. Failure: 40 (9d8) Cold damage. Success: Half damage.",
+        "damage_dice": "9d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "young-white-dragon",
+    "url": "/api/2024/monsters/young-white-dragon",
+    "image": "/api/images/monsters/young-white-dragon.png",
+    "hit_points_roll": "13d10 + 52",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-int",
+          "name": "Saving Throw: INT",
+          "url": "/api/2024/proficiencies/saving-throw-int"
+        }
+      },
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Adult White Dragon",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 200,
+    "hit_dice": "16d12",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "30 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 22,
+    "dexterity": 10,
+    "constitution": 22,
+    "intelligence": 8,
+    "wisdom": 12,
+    "charisma": 12,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Ice Walk",
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 4 (1d8) Cold damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 19, each creature in a 60-foot Cone. Failure: 54 (12d8) Cold damage. Success: Half damage.",
+        "damage_dice": "12d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Freezing Burst",
+        "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 7 (2d6) Cold damage, and the target’s Speed is 0 until the end of the target’s next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "2d6"
+      },
+      {
+        "name": "Frightful Presence",
+        "desc": "The dragon casts Fear, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 14). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "adult-white-dragon",
+    "url": "/api/2024/monsters/adult-white-dragon",
+    "image": "/api/images/monsters/adult-white-dragon.png",
+    "hit_points_roll": "16d12 + 96",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Ancient White Dragon",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 12,
+    "hit_points": 333,
+    "hit_dice": "18d20",
+    "speed": {
+      "walk": "40 ft.",
+      "burrow": "40 ft.",
+      "fly": "80 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 26,
+    "dexterity": 10,
+    "constitution": 26,
+    "intelligence": 10,
+    "wisdom": 13,
+    "charisma": 18,
+    "perception": 13,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft., Darkvision 120 ft."
+    },
+    "languages": "Common, Draconic",
+    "challenge_rating": "20",
+    "special_abilities": [
+      {
+        "name": "Ice Walk",
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +14, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 7 (2d6) Cold damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Failure: 63 (14d8) Cold damage. Success: Half damage.",
+        "damage_dice": "14d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Freezing Burst",
+        "desc": "Constitution Saving Throw: DC 20, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 14 (4d6) Cold damage, and the target’s Speed is 0 until the end of the target’s next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "4d6"
+      },
+      {
+        "name": "Frightful Presence",
+        "desc": "The dragon casts Fear, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ],
+    "index": "ancient-white-dragon",
+    "url": "/api/2024/monsters/ancient-white-dragon",
+    "image": "/api/images/monsters/ancient-white-dragon.png",
+    "hit_points_roll": "18d20 + 144",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
+  },
+  {
+    "name": "Wight",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "neutral evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 82,
+    "hit_dice": "11d8",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 14,
+    "constitution": 16,
+    "intelligence": 10,
+    "wisdom": 13,
+    "charisma": 15,
+    "perception": 3,
+    "damage_resistances": [
+      "necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Sunlight Sensitivity",
+        "desc": "While in sunlight, the wight has Disadvantage on ability checks and attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The wight makes two attacks, using Necrotic Sword or Necrotic Bow in any combination. It can replace one attack with a use of Life Drain."
+      },
+      {
+        "name": "Necrotic Sword",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 4 (1d8) Necrotic damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Necrotic Bow",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage plus 4 (1d8) Necrotic damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Life Drain",
+        "desc": "Constitution Saving Throw: DC 13, one creature within 5 feet. Failure: 6 (1d8 + 2) Necrotic damage, and the target’s Hit Point maximum decreases by an amount equal to the damage taken. A Humanoid slain by this attack rises 24 hours later as a Zombie under the wight’s control, unless the Humanoid is restored to life or its body is destroyed. The wight can have no more than twelve zombies under its control at a time.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "wight",
+    "url": "/api/2024/monsters/wight",
+    "image": "/api/images/monsters/wight.png",
+    "hit_points_roll": "11d8 + 33",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Will-o’-Wisp",
+    "size": "Tiny",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 9,
+    "hit_points": 27,
+    "hit_dice": "11d4",
+    "speed": {
+      "walk": "5 ft.",
+      "fly": "50 ft.",
+      "hover": true
+    },
+    "strength": 1,
+    "dexterity": 28,
+    "constitution": 10,
+    "intelligence": 13,
+    "wisdom": 14,
+    "charisma": 11,
+    "damage_resistances": [
+      "acid",
+      "bludgeoning",
+      "cold",
+      "fire",
+      "necrotic",
+      ""
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "lightning",
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "prone",
+      "restrained",
+      "unconscious"
+    ],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 12
+    },
+    "languages": "Common plus one other language",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Ephemeral",
+        "desc": "The wisp can’t wear or carry anything."
+      },
+      {
+        "name": "Illumination",
+        "desc": "The wisp sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet."
+      },
+      {
+        "name": "Incorporeal Movement",
+        "desc": "The wisp can move through other creatures and objects as if they were Difficult"
+      },
+      {
+        "name": "Terrain",
+        "desc": "It takes 5 (1d10) Force damage if it ends its turn inside an object."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Shock",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 11 (2d8 + 2) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Consume Life",
+        "desc": "Constitution Saving Throw: DC 10, one living creature the wisp can see within 5 feet that has 0 Hit Points. Failure: The target dies, and the wisp regains 10 (3d6) Hit Points."
+      },
+      {
+        "name": "Vanish",
+        "desc": "The wisp and its light have the Invisible condition until the wisp’s Concentration ends on this effect, which ends early immediately after the wisp makes an attack roll or uses Consume Life."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "will-o-wisp",
+    "url": "/api/2024/monsters/will-o-wisp",
+    "image": "/api/images/monsters/will-o-wisp.png",
+    "hit_points_roll": "11d4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Winter Wolf",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 75,
+    "hit_dice": "10d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 18,
+    "dexterity": 13,
+    "constitution": 14,
+    "intelligence": 7,
+    "wisdom": 12,
+    "charisma": 8,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "cold"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 15
+    },
+    "languages": "Common, Giant",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The wolf has Advantage on an attack roll against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature, it has the Prone condition."
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 18 (4d8) Cold damage. Success: Half damage.",
+        "damage_dice": "4d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "winter-wolf",
+    "url": "/api/2024/monsters/winter-wolf",
+    "image": "/api/images/monsters/winter-wolf.png",
+    "hit_points_roll": "10d10 + 20",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 15"
+  },
+  {
+    "name": "Worg",
+    "size": "Large",
+    "type": "fey",
+    "alignment": "neutral evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 26,
+    "hit_dice": "4d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 16,
+    "dexterity": 13,
+    "constitution": 13,
+    "intelligence": 7,
+    "wisdom": 11,
+    "charisma": 8,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Goblin, Worg",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage, and the next attack roll made against the target before the start of the worg’s next turn has Advantage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "worg",
+    "url": "/api/2024/monsters/worg",
+    "image": "/api/images/monsters/worg.png",
+    "hit_points_roll": "4d10 + 4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Wraith",
+    "size": "Medium",
+    "type": "or small undead",
+    "alignment": "neutral evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 67,
+    "hit_dice": "9d8",
+    "speed": {
+      "walk": "5 ft.",
+      "fly": "60 ft.",
+      "hover": true
+    },
+    "strength": 6,
+    "dexterity": 16,
+    "constitution": 16,
+    "intelligence": 12,
+    "wisdom": 14,
+    "charisma": 15,
+    "damage_resistances": [
+      "acid",
+      "bludgeoning",
+      "cold",
+      "fire",
+      "piercing",
+      ""
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "necrotic",
+      "poison"
+    ],
+    "condition_immunities": [
+      "charmed",
+      "exhaustion",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "poisoned",
+      "prone",
+      "restrained",
+      "unconscious"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
+    "languages": "Common plus two other languages",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Incorporeal Movement",
+        "desc": "The wraith can move through other creatures and objects as if they were Difficult"
+      },
+      {
+        "name": "Terrain",
+        "desc": "It takes 5 (1d10) Force damage if it ends its turn inside an object."
+      },
+      {
+        "name": "Sunlight Sensitivity",
+        "desc": "While in sunlight, the wraith has Disadvantage on ability checks and attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Life Drain",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 21 (4d8 + 3) Necrotic damage. If the target is a creature, its Hit Point maximum decreases by an amount equal to the damage taken.",
+        "damage_dice": "4d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Create Specter",
+        "desc": "The wraith targets a Humanoid corpse within 10 feet of itself that has been dead for no longer than 1 minute. The target’s spirit rises as a Specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith’s control. The wraith can have no more than seven specters under its control at a time."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "wraith",
+    "url": "/api/2024/monsters/wraith",
+    "image": "/api/images/monsters/wraith.png",
+    "hit_points_roll": "9d8 + 27",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Wyvern",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 127,
+    "hit_dice": "15d10",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 19,
+    "dexterity": 10,
+    "constitution": 16,
+    "intelligence": 5,
+    "wisdom": 12,
+    "charisma": 6,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 14
+    },
+    "languages": "None",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The wyvern makes one Bite attack and one Sting attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Piercing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Sting",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage plus 24 (7d6) Poison damage, and the target has the Poisoned condition until the start of the wyvern’s next turn.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "wyvern",
+    "url": "/api/2024/monsters/wyvern",
+    "image": "/api/images/monsters/wyvern.png",
+    "hit_points_roll": "15d10 + 45",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Xorn",
+    "size": "Medium",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 84,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "20 ft.",
+      "burrow": "20 ft."
+    },
+    "strength": 17,
+    "dexterity": 10,
+    "constitution": 22,
+    "intelligence": 11,
+    "wisdom": 10,
+    "charisma": 11,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "paralyzed",
+      "petrified",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft., Tremorsense 60 ft."
+    },
+    "languages": "Primordial (Terran)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Earth Glide",
+        "desc": "The xorn can burrow through nonmagical, unworked earth and stone. While doing so, the xorn doesn’t disturb the material it moves through."
+      },
+      {
+        "name": "Treasure Sense",
+        "desc": "The xorn can pinpoint the location of precious metals and stones within 60 feet of itself."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The xorn makes one Bite attack and three Claw attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 17 (4d6 + 3) Piercing damage.",
+        "damage_dice": "4d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Charge",
+        "desc": "The xorn moves up to its Speed or Burrow Speed straight toward an enemy it can sense. Zombies"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "xorn",
+    "url": "/api/2024/monsters/xorn",
+    "image": "/api/images/monsters/xorn.png",
+    "hit_points_roll": "8d8 + 48",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft., Tremorsense 60 ft.;"
+  },
+  {
+    "name": "Zombie",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "neutral evil",
+    "armor_class": 8,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 15,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "20 ft."
+    },
+    "strength": 13,
+    "dexterity": 6,
+    "constitution": 16,
+    "intelligence": 3,
+    "wisdom": 6,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
+    "languages": "Understands Common plus one other language",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Undead Fortitude",
+        "desc": "If damage reduces the zombie to 0 Hit Points, it makes a Constitution saving throw (DC 5 plus the damage taken) unless the damage is Radiant or from a Critical Hit. On a successful save, the zombie drops to 1 Hit Point instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Bludgeoning damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "zombie",
+    "url": "/api/2024/monsters/zombie",
+    "image": "/api/images/monsters/zombie.png",
+    "hit_points_roll": "2d8 + 6",
+    "proficiencies": [
+      {
+        "value": 0,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Ogre Zombie",
+    "size": "Large",
+    "type": "undead",
+    "alignment": "neutral evil",
+    "armor_class": 8,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 85,
+    "hit_dice": "9d10",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 19,
+    "dexterity": 6,
+    "constitution": 18,
+    "intelligence": 3,
+    "wisdom": 6,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "poison"
+    ],
+    "condition_immunities": [
+      "exhaustion",
+      "poisoned"
+    ],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
+    "languages": "Understands Common and Giant but can’t",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Undead Fortitude",
+        "desc": "If damage reduces the zombie to 0 Hit Points, it makes a Constitution saving throw (DC 5 plus the damage taken) unless the damage is Radiant or from a Critical Hit. On a successful save, the zombie drops to 1 Hit Point instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage. Animals",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ogre-zombie",
+    "url": "/api/2024/monsters/ogre-zombie",
+    "image": "/api/images/monsters/ogre-zombie.png",
+    "hit_points_roll": "9d10 + 36",
+    "proficiencies": [
+      {
+        "value": 0,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Allosaurus",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 51,
+    "hit_dice": "6d10",
+    "speed": {
+      "walk": "60 ft."
+    },
+    "strength": 19,
+    "dexterity": 13,
+    "constitution": 17,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 5,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Piercing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Claws",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Slashing damage. If the target is a Large or smaller creature and the allosaurus moved 30+ feet straight toward it immediately before the hit, the target has the Prone condition, and the allosaurus can make one Bite attack against it.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "allosaurus",
+    "url": "/api/2024/monsters/allosaurus",
+    "image": "/api/images/monsters/allosaurus.png",
+    "hit_points_roll": "6d10 + 18",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 15"
+  },
+  {
+    "name": "Ankylosaurus",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 68,
+    "hit_dice": "8d12",
+    "speed": {
+      "walk": "30 ft."
+    },
+    "strength": 19,
+    "dexterity": 11,
+    "constitution": 15,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ankylosaurus makes two Tail attacks."
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ankylosaurus",
+    "url": "/api/2024/monsters/ankylosaurus",
+    "image": "/api/images/monsters/ankylosaurus.png",
+    "hit_points_roll": "8d12 + 16",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 11"
+  },
+  {
+    "name": "Ape",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 19,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 16,
+    "dexterity": 14,
+    "constitution": 14,
+    "intelligence": 6,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ape makes two Fist attacks."
+      },
+      {
+        "name": "Fist",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Bludgeoning damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Rock (Recharge 6)",
+        "desc": "Ranged Attack Roll: +5, range 25/50 ft. Hit: 10 (2d6 + 3) Bludgeoning damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "ape",
+    "url": "/api/2024/monsters/ape",
+    "image": "/api/images/monsters/ape.png",
+    "hit_points_roll": "3d8 + 6",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 13"
+  },
+  {
+    "name": "Archelon",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 90,
+    "hit_dice": "12d12",
+    "speed": {
+      "walk": "20 ft.",
+      "swim": "80 ft."
+    },
+    "strength": 18,
+    "dexterity": 16,
+    "constitution": 13,
+    "intelligence": 4,
+    "wisdom": 14,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The archelon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The archelon makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 14 (3d6 + 4) Piercing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "archelon",
+    "url": "/api/2024/monsters/archelon",
+    "image": "/api/images/monsters/archelon.png",
+    "hit_points_roll": "12d12 + 12",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Baboon",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 3,
+    "hit_dice": "1d6",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 8,
+    "dexterity": 14,
+    "constitution": 11,
+    "intelligence": 4,
+    "wisdom": 12,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The baboon has Advantage on an attack roll against a creature if at least one of the baboon’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 (1d4 − 1) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": -1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "baboon",
+    "url": "/api/2024/monsters/baboon",
+    "image": "/api/images/monsters/baboon.png",
+    "hit_points_roll": "1d6",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 11"
+  },
+  {
+    "name": "Badger",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 5,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "20 ft.",
+      "burrow": "5 ft."
+    },
+    "strength": 10,
+    "dexterity": 11,
+    "constitution": 16,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 5,
+    "perception": 3,
+    "damage_resistances": [
+      "poison"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "badger",
+    "url": "/api/2024/monsters/badger",
+    "image": "/api/images/monsters/badger.png",
+    "hit_points_roll": "1d4 + 3",
+    "proficiencies": [],
+    "old_senses": "Darkvision 30 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Bat",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 1,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "5 ft.",
+      "fly": "30 ft."
+    },
+    "strength": 2,
+    "dexterity": 15,
+    "constitution": 8,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "bat",
+    "url": "/api/2024/monsters/bat",
+    "image": "/api/images/monsters/bat.png",
+    "hit_points_roll": "1d4 − 1",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Black Bear",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 12,
+    "constitution": 14,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bear makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "black-bear",
+    "url": "/api/2024/monsters/black-bear",
+    "image": "/api/images/monsters/black-bear.png",
+    "hit_points_roll": "3d8 + 6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Blood Hawk",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 7,
+    "hit_dice": "2d6",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 6,
+    "dexterity": 14,
+    "constitution": 10,
+    "intelligence": 3,
+    "wisdom": 14,
+    "charisma": 5,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 16
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The hawk has Advantage on an attack roll against a creature if at least one of the hawk’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage, or 6 (1d8 + 2) Piercing damage if the target is Bloodied.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "blood-hawk",
+    "url": "/api/2024/monsters/blood-hawk",
+    "image": "/api/images/monsters/blood-hawk.png",
+    "hit_points_roll": "2d6",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 16"
+  },
+  {
+    "name": "Boar",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 13,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 13,
+    "dexterity": 11,
+    "constitution": 14,
+    "intelligence": 2,
+    "wisdom": 9,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 9
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Bloodied Fury",
+        "desc": "While Bloodied, the boar has Advantage on attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Piercing damage. If the target is a Medium or smaller creature and the boar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 3 (1d6) Piercing damage and has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "boar",
+    "url": "/api/2024/monsters/boar",
+    "image": "/api/images/monsters/boar.png",
+    "hit_points_roll": "2d8 + 4",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 9"
+  },
+  {
+    "name": "Brown Bear",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 22,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 17,
+    "dexterity": 12,
+    "constitution": 15,
+    "intelligence": 2,
+    "wisdom": 13,
+    "charisma": 7,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bear makes one Bite attack and one Claw attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "brown-bear",
+    "url": "/api/2024/monsters/brown-bear",
+    "image": "/api/images/monsters/brown-bear.png",
+    "hit_points_roll": "3d10 + 6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Camel",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 17,
+    "hit_dice": "2d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 15,
+    "dexterity": 8,
+    "constitution": 17,
+    "intelligence": 2,
+    "wisdom": 11,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Bludgeoning damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "camel",
+    "url": "/api/2024/monsters/camel",
+    "image": "/api/images/monsters/camel.png",
+    "hit_points_roll": "2d10 + 6",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Cat",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 2,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft."
+    },
+    "strength": 3,
+    "dexterity": 15,
+    "constitution": 10,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Jumper",
+        "desc": "The cat’s jump distance is determined using its Dexterity rather than its Strength."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Scratch",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Slashing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "cat",
+    "url": "/api/2024/monsters/cat",
+    "image": "/api/images/monsters/cat.png",
+    "hit_points_roll": "1d4",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Constrictor Snake",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 13,
+    "hit_dice": "2d10",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 14,
+    "constitution": 12,
+    "intelligence": 1,
+    "wisdom": 10,
+    "charisma": 3,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 12, one Medium or smaller creature the snake can see within 5 feet. Failure: 7 (3d4) Bludgeoning damage, and the target has the Grappled condition (escape DC 12).",
+        "damage_dice": "3d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "constrictor-snake",
+    "url": "/api/2024/monsters/constrictor-snake",
+    "image": "/api/images/monsters/constrictor-snake.png",
+    "hit_points_roll": "2d10 + 2",
+    "proficiencies": [],
+    "old_senses": "Blindsight 10 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Crab",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 3,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "20 ft.",
+      "swim": "20 ft."
+    },
+    "strength": 6,
+    "dexterity": 11,
+    "constitution": 12,
+    "intelligence": 1,
+    "wisdom": 8,
+    "charisma": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 9
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The crab can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Bludgeoning damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "crab",
+    "url": "/api/2024/monsters/crab",
+    "image": "/api/images/monsters/crab.png",
+    "hit_points_roll": "1d4 + 1",
+    "proficiencies": [],
+    "old_senses": "Blindsight 30 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Crocodile",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 13,
+    "hit_dice": "2d10",
+    "speed": {
+      "walk": "20 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 10,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The crocodile can hold its breath for 1 hour."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12). While Grappled, the target has the Restrained condition.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "crocodile",
+    "url": "/api/2024/monsters/crocodile",
+    "image": "/api/images/monsters/crocodile.png",
+    "hit_points_roll": "2d10 + 2",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Deer",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 4,
+    "hit_dice": "1d8",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 11,
+    "dexterity": 16,
+    "constitution": 11,
+    "intelligence": 2,
+    "wisdom": 14,
+    "charisma": 5,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Agile",
+        "desc": "The deer doesn’t provoke an Opportunity Attack when it moves out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Bludgeoning damage.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "deer",
+    "url": "/api/2024/monsters/deer",
+    "image": "/api/images/monsters/deer.png",
+    "hit_points_roll": "1d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Dire Wolf",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 17,
+    "dexterity": 15,
+    "constitution": 15,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The wolf has Advantage on an attack roll against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Piercing damage. If the target is a Large or smaller creature, it has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "dire-wolf",
+    "url": "/api/2024/monsters/dire-wolf",
+    "image": "/api/images/monsters/dire-wolf.png",
+    "hit_points_roll": "3d10 + 6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Draft Horse",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 15,
+    "hit_dice": "2d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 10,
+    "constitution": 15,
+    "intelligence": 2,
+    "wisdom": 11,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Bludgeoning damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "draft-horse",
+    "url": "/api/2024/monsters/draft-horse",
+    "image": "/api/images/monsters/draft-horse.png",
+    "hit_points_roll": "2d10 + 4",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Eagle",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 4,
+    "hit_dice": "1d6",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 6,
+    "dexterity": 15,
+    "constitution": 12,
+    "intelligence": 2,
+    "wisdom": 14,
+    "charisma": 7,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 16
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Talons",
+        "desc": "Melee Attack Roll: +4, reach 5 feet. Hit: 4 (1d4 + 2) Slashing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "eagle",
+    "url": "/api/2024/monsters/eagle",
+    "image": "/api/images/monsters/eagle.png",
+    "hit_points_roll": "1d6 + 1",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 16"
+  },
+  {
+    "name": "Elephant",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 76,
+    "hit_dice": "8d12",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 22,
+    "dexterity": 9,
+    "constitution": 17,
+    "intelligence": 3,
+    "wisdom": 11,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The elephant makes two Gore attacks."
+      },
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 15 (2d8 + 6) Piercing damage. If the target is a Huge or smaller creature and the elephant moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Trample",
+        "desc": "Dexterity Saving Throw: DC 16, one creature within 5 feet that has the Prone condition. Failure: 17 (2d10 + 6) Bludgeoning damage. Success: Half damage."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "elephant",
+    "url": "/api/2024/monsters/elephant",
+    "image": "/api/images/monsters/elephant.png",
+    "hit_points_roll": "8d12 + 24",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Elk",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 11,
+    "hit_dice": "2d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 16,
+    "dexterity": 10,
+    "constitution": 11,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 6,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature and the elk moved 20+ feet straight toward it immediately before the hit, the target takes an extra 3 (1d6) Bludgeoning damage and has the Prone condition.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "elk",
+    "url": "/api/2024/monsters/elk",
+    "image": "/api/images/monsters/elk.png",
+    "hit_points_roll": "2d10",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Flying Snake",
+    "size": "Tiny",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 5,
+    "hit_dice": "2d4",
+    "speed": {
+      "walk": "30 ft.",
+      "fly": "60 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 4,
+    "dexterity": 15,
+    "constitution": 11,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The snake doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage plus 5 (2d4) Poison damage.",
+        "damage_dice": "2d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "flying-snake",
+    "url": "/api/2024/monsters/flying-snake",
+    "image": "/api/images/monsters/flying-snake.png",
+    "hit_points_roll": "2d4",
+    "proficiencies": [],
+    "old_senses": "Blindsight 10 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Frog",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 1,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "20 ft.",
+      "swim": "20 ft."
+    },
+    "strength": 1,
+    "dexterity": 13,
+    "constitution": 8,
+    "intelligence": 1,
+    "wisdom": 8,
+    "charisma": 3,
+    "perception": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The frog can breathe air and water."
+      },
+      {
+        "name": "Standing Leap",
+        "desc": "The frog’s Long Jump is up to 10 feet and its High Jump is up to 5 feet with or without a running start."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "frog",
+    "url": "/api/2024/monsters/frog",
+    "image": "/api/images/monsters/frog.png",
+    "hit_points_roll": "1d4 − 1",
+    "proficiencies": [],
+    "old_senses": "Darkvision 30 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Giant Ape",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 168,
+    "hit_dice": "16d12",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft."
+    },
+    "strength": 23,
+    "dexterity": 14,
+    "constitution": 18,
+    "intelligence": 5,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 14
+    },
+    "languages": "None",
+    "challenge_rating": "7",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ape makes two Fist attacks."
+      },
+      {
+        "name": "Fist",
+        "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 22 (3d10 + 6) Bludgeoning damage.",
+        "damage_dice": "3d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Boulder Toss (Recharge 6)",
+        "desc": "The ape hurls a boulder at a point it can see within 90 feet. Dexterity Saving Throw: DC 17, each creature in a 5-foot-radius Sphere centered on that point. Failure: 24 (7d6) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition. Success: Half damage only.",
+        "damage_dice": "7d6"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Leap",
+        "desc": "The ape jumps up to 30 feet by spending 10 feet of movement."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-ape",
+    "url": "/api/2024/monsters/giant-ape",
+    "image": "/api/images/monsters/giant-ape.png",
+    "hit_points_roll": "16d12 + 64",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 14"
+  },
+  {
+    "name": "Giant Badger",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 15,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "30 ft.",
+      "burrow": "10 ft."
+    },
+    "strength": 13,
+    "dexterity": 10,
+    "constitution": 17,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 5,
+    "perception": 3,
+    "damage_resistances": [
+      "poison"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Piercing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-badger",
+    "url": "/api/2024/monsters/giant-badger",
+    "image": "/api/images/monsters/giant-badger.png",
+    "hit_points_roll": "2d8 + 6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Giant Bat",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 22,
+    "hit_dice": "4d10",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 15,
+    "dexterity": 16,
+    "constitution": 11,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "120 ft.",
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-bat",
+    "url": "/api/2024/monsters/giant-bat",
+    "image": "/api/images/monsters/giant-bat.png",
+    "hit_points_roll": "4d10",
+    "proficiencies": [],
+    "old_senses": "Blindsight 120 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Giant Boar",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 42,
+    "hit_dice": "5d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 17,
+    "dexterity": 10,
+    "constitution": 16,
+    "intelligence": 2,
+    "wisdom": 7,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 8
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Bloodied Fury",
+        "desc": "The boar has Advantage on melee attack rolls while it is Bloodied."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Large or smaller creature and the boar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 7 (2d6) Piercing damage and has the Prone condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-boar",
+    "url": "/api/2024/monsters/giant-boar",
+    "image": "/api/images/monsters/giant-boar.png",
+    "hit_points_roll": "5d10 + 15",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 8"
+  },
+  {
+    "name": "Giant Centipede",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 9,
+    "hit_dice": "2d6",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 5,
+    "dexterity": 14,
+    "constitution": 12,
+    "intelligence": 1,
+    "wisdom": 7,
+    "charisma": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 8
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage, and the target has the Poisoned condition until the start of the centipede’s next turn.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-centipede",
+    "url": "/api/2024/monsters/giant-centipede",
+    "image": "/api/images/monsters/giant-centipede.png",
+    "hit_points_roll": "2d6 + 2",
+    "proficiencies": [],
+    "old_senses": "Blindsight 30 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Giant Constrictor Snake",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 60,
+    "hit_dice": "8d12",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 19,
+    "dexterity": 14,
+    "constitution": 12,
+    "intelligence": 1,
+    "wisdom": 10,
+    "charisma": 3,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The snake makes one Bite attack and uses Constrict."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 14, one Large or smaller creature the snake can see within 10 feet. Failure: 13 (2d8 + 4) Bludgeoning damage, and the target has the Grappled condition (escape DC 14).",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-constrictor-snake",
+    "url": "/api/2024/monsters/giant-constrictor-snake",
+    "image": "/api/images/monsters/giant-constrictor-snake.png",
+    "hit_points_roll": "8d12 + 8",
+    "proficiencies": [],
+    "old_senses": "Blindsight 10 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Giant Crab",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 13,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 13,
+    "dexterity": 13,
+    "constitution": 11,
+    "intelligence": 1,
+    "wisdom": 9,
+    "charisma": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 9
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The crab can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 11) from one of two claws."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-crab",
+    "url": "/api/2024/monsters/giant-crab",
+    "image": "/api/images/monsters/giant-crab.png",
+    "hit_points_roll": "3d8",
+    "proficiencies": [],
+    "old_senses": "Blindsight 30 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Giant Crocodile",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 85,
+    "hit_dice": "9d12",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "50 ft."
+    },
+    "strength": 21,
+    "dexterity": 9,
+    "constitution": 17,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The crocodile can hold its breath for 1 hour."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The crocodile makes one Bite attack and one Tail attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 21 (3d10 + 5) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 15). While Grappled, the target has the Restrained condition and can’t be targeted by the crocodile’s Tail.",
+        "damage_dice": "3d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 18 (3d8 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "3d8",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-crocodile",
+    "url": "/api/2024/monsters/giant-crocodile",
+    "image": "/api/images/monsters/giant-crocodile.png",
+    "hit_points_roll": "9d12 + 27",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Giant Eagle",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "neutral good",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 26,
+    "hit_dice": "4d10",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "80 ft."
+    },
+    "strength": 16,
+    "dexterity": 17,
+    "constitution": 13,
+    "intelligence": 8,
+    "wisdom": 14,
+    "charisma": 10,
+    "perception": 6,
+    "damage_resistances": [
+      "necrotic",
+      "radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 16
+    },
+    "languages": "Celestial; understands Common and Primordial",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The eagle makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage plus 3 (1d6) Radiant damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-eagle",
+    "url": "/api/2024/monsters/giant-eagle",
+    "image": "/api/images/monsters/giant-eagle.png",
+    "hit_points_roll": "4d10 + 4",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 16"
+  },
+  {
+    "name": "Giant Elk",
+    "size": "Huge",
+    "type": "celestial",
+    "alignment": "neutral good",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 42,
+    "hit_dice": "5d12",
+    "speed": {
+      "walk": "60 ft."
+    },
+    "strength": 19,
+    "dexterity": 18,
+    "constitution": 14,
+    "intelligence": 7,
+    "wisdom": 14,
+    "charisma": 10,
+    "perception": 4,
+    "damage_resistances": [
+      "necrotic",
+      "radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "90 ft.",
+      "passive_perception": 14
+    },
+    "languages": "Celestial; understands Common, Elvish, and",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Bludgeoning damage plus 5 (2d4) Radiant damage. If the target is a Huge or smaller creature and the elk moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-elk",
+    "url": "/api/2024/monsters/giant-elk",
+    "image": "/api/images/monsters/giant-elk.png",
+    "hit_points_roll": "5d12 + 10",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 90 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Giant Fire Beetle",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 4,
+    "hit_dice": "1d6",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 8,
+    "dexterity": 10,
+    "constitution": 12,
+    "intelligence": 1,
+    "wisdom": 7,
+    "charisma": 3,
+    "damage_resistances": [
+      "fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 8
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Illumination",
+        "desc": "The beetle sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 Fire damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-fire-beetle",
+    "url": "/api/2024/monsters/giant-fire-beetle",
+    "image": "/api/images/monsters/giant-fire-beetle.png",
+    "hit_points_roll": "1d6 + 1",
+    "proficiencies": [],
+    "old_senses": "Blindsight 30 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Giant Frog",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 18,
+    "hit_dice": "4d8",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 12,
+    "dexterity": 13,
+    "constitution": 11,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 3,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The frog can breathe air and water."
+      },
+      {
+        "name": "Standing Leap",
+        "desc": "The frog’s Long Jump is up to 20 feet and its High Jump is up to 10 feet with or without a running start."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 11)."
+      },
+      {
+        "name": "Swallow",
+        "desc": "The frog swallows a Small or smaller target it is grappling. While swallowed, the target isn’t Grappled but has the Blinded and Restrained conditions, and it has Total Cover against attacks and other effects outside the frog. While swallowing the target, the frog can’t use Bite, and if the frog dies, the swallowed target is no longer Restrained and can escape from the corpse using 5 feet of movement, exiting with the Prone condition. At the end of the frog’s next turn, the swallowed target takes 5 (2d4) Acid damage. If that damage doesn’t kill it, the frog disgorges it, causing it to exit Prone.",
+        "damage_dice": "2d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-frog",
+    "url": "/api/2024/monsters/giant-frog",
+    "image": "/api/images/monsters/giant-frog.png",
+    "hit_points_roll": "4d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 30 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Giant Goat",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 17,
+    "dexterity": 13,
+    "constitution": 12,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 6,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature and the goat moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-goat",
+    "url": "/api/2024/monsters/giant-goat",
+    "image": "/api/images/monsters/giant-goat.png",
+    "hit_points_roll": "3d10 + 3",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Giant Hyena",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 45,
+    "hit_dice": "6d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 16,
+    "dexterity": 14,
+    "constitution": 14,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Rampage (1/Day)",
+        "desc": "Immediately after dealing damage to a creature that was already Bloodied, the hyena can move up to half its Speed, and it makes one Bite attack."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-hyena",
+    "url": "/api/2024/monsters/giant-hyena",
+    "image": "/api/images/monsters/giant-hyena.png",
+    "hit_points_roll": "6d10 + 12",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Giant Lizard",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft."
+    },
+    "strength": 15,
+    "dexterity": 12,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The lizard can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-lizard",
+    "url": "/api/2024/monsters/giant-lizard",
+    "image": "/api/images/monsters/giant-lizard.png",
+    "hit_points_roll": "3d10 + 3",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Giant Octopus",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 45,
+    "hit_dice": "7d10",
+    "speed": {
+      "walk": "10 ft.",
+      "swim": "60 ft."
+    },
+    "strength": 17,
+    "dexterity": 13,
+    "constitution": 13,
+    "intelligence": 5,
+    "wisdom": 10,
+    "charisma": 4,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The octopus can breathe only underwater. It can hold its breath for 1 hour outside water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Tentacles",
+        "desc": "Melee Attack Roll: +5, reach 10 ft. Hit: 10 (2d6 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 13) from all eight tentacles. While Grappled, the target has the Restrained condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Ink Cloud (1/Day)",
+        "desc": "Trigger: The octopus takes damage while underwater. Response: The octopus releases ink that fills a 10-foot Cube centered on itself, and the octopus moves up to its Swim Speed. The Cube is Heavily Obscured for 1 minute or until a strong current or similar effect disperses the ink."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "giant-octopus",
+    "url": "/api/2024/monsters/giant-octopus",
+    "image": "/api/images/monsters/giant-octopus.png",
+    "hit_points_roll": "7d10 + 7",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Giant Owl",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 19,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": "5 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 13,
+    "dexterity": 15,
+    "constitution": 12,
+    "intelligence": 10,
+    "wisdom": 14,
+    "charisma": 10,
+    "perception": 6,
+    "damage_resistances": [
+      "necrotic",
+      "radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 16
+    },
+    "languages": "Celestial; understands Common, Elvish, and",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The owl doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Talons",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The owl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability:"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Detect Magic"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Clairvoyance"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-owl",
+    "url": "/api/2024/monsters/giant-owl",
+    "image": "/api/images/monsters/giant-owl.png",
+    "hit_points_roll": "3d10 + 3",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 16"
+  },
+  {
+    "name": "Giant Rat",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 7,
+    "hit_dice": "2d6",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 7,
+    "dexterity": 16,
+    "constitution": 11,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 4,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The rat has Advantage on an attack roll against a creature if at least one of the rat’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 feet. Hit: 5 (1d4 + 3) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-rat",
+    "url": "/api/2024/monsters/giant-rat",
+    "image": "/api/images/monsters/giant-rat.png",
+    "hit_points_roll": "2d6",
+    "proficiencies": [
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Giant Scorpion",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 52,
+    "hit_dice": "7d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 16,
+    "dexterity": 13,
+    "constitution": 15,
+    "intelligence": 1,
+    "wisdom": 9,
+    "charisma": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 9
+    },
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The scorpion makes two Claw attacks and one Sting attack."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13) from one of two claws."
+      },
+      {
+        "name": "Sting",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 11 (2d10) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-scorpion",
+    "url": "/api/2024/monsters/giant-scorpion",
+    "image": "/api/images/monsters/giant-scorpion.png",
+    "hit_points_roll": "7d10 + 14",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Giant Seahorse",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 16,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": "5 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 15,
+    "dexterity": 12,
+    "constitution": 11,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The seahorse can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Bludgeoning damage, or 11 (2d8 + 2) Bludgeoning damage if the seahorse moved 20+ feet straight toward the target immediately before the hit.",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Bubble Dash",
+        "desc": "While underwater, the seahorse moves up to half its Swim Speed without provoking Opportunity Attacks."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-seahorse",
+    "url": "/api/2024/monsters/giant-seahorse",
+    "image": "/api/images/monsters/giant-seahorse.png",
+    "hit_points_roll": "3d10",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 11"
+  },
+  {
+    "name": "Giant Shark",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 92,
+    "hit_dice": "8d12",
+    "speed": {
+      "walk": "5 ft.",
+      "swim": "60 ft."
+    },
+    "strength": 23,
+    "dexterity": 11,
+    "constitution": 21,
+    "intelligence": 1,
+    "wisdom": 10,
+    "charisma": 5,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The shark can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The shark makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +9 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 22 (3d10 + 6) Piercing damage.",
+        "damage_dice": "3d10",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-shark",
+    "url": "/api/2024/monsters/giant-shark",
+    "image": "/api/images/monsters/giant-shark.png",
+    "hit_points_roll": "8d12 + 40",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Giant Spider",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 26,
+    "hit_dice": "4d10",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 14,
+    "dexterity": 16,
+    "constitution": 12,
+    "intelligence": 2,
+    "wisdom": 11,
+    "charisma": 4,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Web Walker",
+        "desc": "The spider ignores movement restrictions caused by webs, and it knows the location of any other creature in contact with the same web."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Web (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 13, one creature the spider can see within 60 feet. Failure: The target has the Restrained condition until the web is destroyed (AC 10; HP 5; Vulnerability to Fire damage; Immunity to Poison and Psychic damage)."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-spider",
+    "url": "/api/2024/monsters/giant-spider",
+    "image": "/api/images/monsters/giant-spider.png",
+    "hit_points_roll": "4d10 + 4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Giant Toad",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 39,
+    "hit_dice": "6d10",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 15,
+    "dexterity": 13,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The toad can breathe air and water."
+      },
+      {
+        "name": "Standing Leap",
+        "desc": "The toad’s Long Jump is up to 20 feet and its High Jump is up to 10 feet with or without a running start."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 5 (2d4) Poison damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12).",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Swallow",
+        "desc": "The toad swallows a Medium or smaller target it is grappling. While swallowed, the target isn’t Grappled but has the Blinded and Restrained conditions, and it has Total Cover against attacks and other effects outside the toad. In addition, the target takes 10 (3d6) Acid damage at the end of each of the toad’s turns. The toad can have only one target swallowed at a time, and it can’t use Bite while it has a swallowed target. If the toad dies, a swallowed creature is no longer Restrained and can escape from the corpse using 5 feet of movement, exiting with the Prone condition.",
+        "damage_dice": "3d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-toad",
+    "url": "/api/2024/monsters/giant-toad",
+    "image": "/api/images/monsters/giant-toad.png",
+    "hit_points_roll": "6d10 + 6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Giant Venomous Snake",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "40 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 10,
+    "dexterity": 18,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 3,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 6 (1d4 + 4) Piercing damage plus 4 (1d8) Poison damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-venomous-snake",
+    "url": "/api/2024/monsters/giant-venomous-snake",
+    "image": "/api/images/monsters/giant-venomous-snake.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [],
+    "old_senses": "Blindsight 10 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Giant Vulture",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 25,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 15,
+    "dexterity": 10,
+    "constitution": 16,
+    "intelligence": 6,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 3,
+    "damage_resistances": [
+      "necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "Understands Common but can’t speak",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The vulture has Advantage on an attack roll against a creature if at least one of the vulture’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Gouge",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Piercing damage, and the target has the Poisoned condition until the end of its next turn.",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-vulture",
+    "url": "/api/2024/monsters/giant-vulture",
+    "image": "/api/images/monsters/giant-vulture.png",
+    "hit_points_roll": "3d10 + 9",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Giant Wasp",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "50 ft."
+    },
+    "strength": 10,
+    "dexterity": 14,
+    "constitution": 10,
+    "intelligence": 1,
+    "wisdom": 10,
+    "charisma": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The wasp doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Sting",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 5 (2d4) Poison damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-wasp",
+    "url": "/api/2024/monsters/giant-wasp",
+    "image": "/api/images/monsters/giant-wasp.png",
+    "hit_points_roll": "5d8",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Giant Weasel",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 9,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 11,
+    "dexterity": 17,
+    "constitution": 10,
+    "intelligence": 4,
+    "wisdom": 12,
+    "charisma": 5,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-weasel",
+    "url": "/api/2024/monsters/giant-weasel",
+    "image": "/api/images/monsters/giant-weasel.png",
+    "hit_points_roll": "2d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Giant Wolf Spider",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "40 ft."
+    },
+    "strength": 12,
+    "dexterity": 16,
+    "constitution": 13,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 4,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft., Darkvision 60 ft."
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage plus 5 (2d4) Poison damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "giant-wolf-spider",
+    "url": "/api/2024/monsters/giant-wolf-spider",
+    "image": "/api/images/monsters/giant-wolf-spider.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [],
+    "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
+  },
+  {
+    "name": "Goat",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 4,
+    "hit_dice": "1d8",
+    "speed": {
+      "walk": "40 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 11,
+    "dexterity": 10,
+    "constitution": 11,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 5,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Bludgeoning damage, or 2 (1d4) Bludgeoning damage if the goat moved 20+ feet straight toward the target immediately before the hit.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "goat",
+    "url": "/api/2024/monsters/goat",
+    "image": "/api/images/monsters/goat.png",
+    "hit_points_roll": "1d8",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Hawk",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 1,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 5,
+    "dexterity": 16,
+    "constitution": 8,
+    "intelligence": 2,
+    "wisdom": 14,
+    "charisma": 6,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 16
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Talons",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 1 Slashing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hawk",
+    "url": "/api/2024/monsters/hawk",
+    "image": "/api/images/monsters/hawk.png",
+    "hit_points_roll": "1d4 − 1",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 16"
+  },
+  {
+    "name": "Hippopotamus",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 82,
+    "hit_dice": "11d10",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 21,
+    "dexterity": 7,
+    "constitution": 15,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 4,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The hippopotamus can hold its breath for 10 minutes."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hippopotamus makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 16 (2d10 + 5) Piercing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hippopotamus",
+    "url": "/api/2024/monsters/hippopotamus",
+    "image": "/api/images/monsters/hippopotamus.png",
+    "hit_points_roll": "11d10 + 22",
+    "proficiencies": [
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 13"
+  },
+  {
+    "name": "Hunter Shark",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 45,
+    "hit_dice": "6d10",
+    "speed": {
+      "walk": "5 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 14,
+    "constitution": 15,
+    "intelligence": 1,
+    "wisdom": 10,
+    "charisma": 4,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The shark can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 14 (3d6 + 4) Piercing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hunter-shark",
+    "url": "/api/2024/monsters/hunter-shark",
+    "image": "/api/images/monsters/hunter-shark.png",
+    "hit_points_roll": "6d10 + 12",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Hyena",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 5,
+    "hit_dice": "1d8",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 11,
+    "dexterity": 13,
+    "constitution": 12,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 5,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The hyena has Advantage on an attack roll against a creature if at least one of the hyena’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 3 (1d6) Piercing damage.",
+        "damage_dice": "1d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "hyena",
+    "url": "/api/2024/monsters/hyena",
+    "image": "/api/images/monsters/hyena.png",
+    "hit_points_roll": "1d8 + 1",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Jackal",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 3,
+    "hit_dice": "1d6",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 8,
+    "dexterity": 15,
+    "constitution": 11,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 6,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "90 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 (1d4 – 1) Piercing damage.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "jackal",
+    "url": "/api/2024/monsters/jackal",
+    "image": "/api/images/monsters/jackal.png",
+    "hit_points_roll": "1d6",
+    "proficiencies": [],
+    "old_senses": "Darkvision 90 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Killer Whale",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 90,
+    "hit_dice": "12d12",
+    "speed": {
+      "walk": "5 ft.",
+      "swim": "60 ft."
+    },
+    "strength": 19,
+    "dexterity": 14,
+    "constitution": 13,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "120 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The whale can hold its breath for 30 minutes."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 21 (5d6 + 4) Piercing damage.",
+        "damage_dice": "5d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "killer-whale",
+    "url": "/api/2024/monsters/killer-whale",
+    "image": "/api/images/monsters/killer-whale.png",
+    "hit_points_roll": "12d12 + 12",
+    "proficiencies": [],
+    "old_senses": "Blindsight 120 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Lion",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "4d10",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 17,
+    "dexterity": 15,
+    "constitution": 11,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 8,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The lion has Advantage on an attack roll against a creature if at least one of the lion’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      },
+      {
+        "name": "Running Leap",
+        "desc": "With a 10-foot running start, the lion can Long Jump up to 25 feet."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The lion makes two Rend attacks. It can replace one attack with a use of Roar."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Roar",
+        "desc": "Wisdom Saving Throw: DC 11, one creature within 15 feet. Failure: The target has the Frightened condition until the start of the lion’s next turn."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "lion",
+    "url": "/api/2024/monsters/lion",
+    "image": "/api/images/monsters/lion.png",
+    "hit_points_roll": "4d10",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Lizard",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 2,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "20 ft.",
+      "climb": "20 ft."
+    },
+    "strength": 2,
+    "dexterity": 11,
+    "constitution": 10,
+    "intelligence": 1,
+    "wisdom": 8,
+    "charisma": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 9
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The lizard can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "lizard",
+    "url": "/api/2024/monsters/lizard",
+    "image": "/api/images/monsters/lizard.png",
+    "hit_points_roll": "1d4",
+    "proficiencies": [],
+    "old_senses": "Darkvision 30 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Mammoth",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 126,
+    "hit_dice": "11d12",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 24,
+    "dexterity": 9,
+    "constitution": 21,
+    "intelligence": 3,
+    "wisdom": 11,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The mammoth makes two Gore attacks."
+      },
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 18 (2d10 + 7) Piercing damage. If the target is a Huge or smaller creature and the mammoth moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+        "damage_dice": "2d10",
+        "damage_bonus": 7
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Trample",
+        "desc": "Dexterity Saving Throw: DC 18, one creature within 5 feet that has the Prone condition. Failure: 29 (4d10 + 7) Bludgeoning damage. Success: Half damage."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "mammoth",
+    "url": "/api/2024/monsters/mammoth",
+    "image": "/api/images/monsters/mammoth.png",
+    "hit_points_roll": "11d12 + 55",
+    "proficiencies": [
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 8,
+        "proficiency": {
+          "index": "saving-throw-con",
+          "name": "Saving Throw: CON",
+          "url": "/api/2024/proficiencies/saving-throw-con"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Mastiff",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 5,
+    "hit_dice": "1d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 13,
+    "dexterity": 14,
+    "constitution": 12,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "mastiff",
+    "url": "/api/2024/monsters/mastiff",
+    "image": "/api/images/monsters/mastiff.png",
+    "hit_points_roll": "1d8 + 1",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Mule",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 14,
+    "dexterity": 10,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 5,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Compression",
+        "desc": "The octopus can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Water Breathing",
+        "desc": "The octopus can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Tentacles",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Bludgeoning damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Ink Cloud (1/Day)",
+        "desc": "Trigger: A creature ends its turn within 5 feet of the octopus while underwater. Response: The octopus releases ink that fills a 5-foot Cube centered on itself, and the octopus moves up to its Swim Speed. The Cube is Heavily Obscured for 1 minute or until a strong current or similar effect disperses the ink."
+      }
+    ],
+    "legendary_actions": [],
+    "index": "mule",
+    "url": "/api/2024/monsters/mule",
+    "image": "/api/images/monsters/mule.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Owl",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 1,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "5 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 3,
+    "dexterity": 13,
+    "constitution": 8,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 7,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The owl doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Talons",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 1 Slashing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "owl",
+    "url": "/api/2024/monsters/owl",
+    "image": "/api/images/monsters/owl.png",
+    "hit_points_roll": "1d4 − 1",
+    "proficiencies": [],
+    "old_senses": "Darkvision 120 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Panther",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 13,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": "50 ft.",
+      "climb": "40 ft."
+    },
+    "strength": 14,
+    "dexterity": 16,
+    "constitution": 10,
+    "intelligence": 3,
+    "wisdom": 14,
+    "charisma": 7,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The panther takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "panther",
+    "url": "/api/2024/monsters/panther",
+    "image": "/api/images/monsters/panther.png",
+    "hit_points_roll": "3d8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 14"
+  },
+  {
+    "name": "Piranha",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 1,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "5 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 2,
+    "dexterity": 16,
+    "constitution": 9,
+    "intelligence": 1,
+    "wisdom": 7,
+    "charisma": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The piranha can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "piranha",
+    "url": "/api/2024/monsters/piranha",
+    "image": "/api/images/monsters/piranha.png",
+    "hit_points_roll": "1d4 − 1",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Plesiosaurus",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 68,
+    "hit_dice": "8d10",
+    "speed": {
+      "walk": "20 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 15,
+    "constitution": 16,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 5,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The plesiosaurus can hold its breath for 1 hour."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "plesiosaurus",
+    "url": "/api/2024/monsters/plesiosaurus",
+    "image": "/api/images/monsters/plesiosaurus.png",
+    "hit_points_roll": "8d10 + 24",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 13"
+  },
+  {
+    "name": "Polar Bear",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 42,
+    "hit_dice": "5d10",
+    "speed": {
+      "walk": "40 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 20,
+    "dexterity": 14,
+    "constitution": 16,
+    "intelligence": 2,
+    "wisdom": 13,
+    "charisma": 7,
+    "perception": 5,
+    "damage_resistances": [
+      "cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bear makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 9 (1d8 + 5) Slashing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "polar-bear",
+    "url": "/api/2024/monsters/polar-bear",
+    "image": "/api/images/monsters/polar-bear.png",
+    "hit_points_roll": "5d10 + 15",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Pony",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 15,
+    "dexterity": 10,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 11,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Bludgeoning damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "pony",
+    "url": "/api/2024/monsters/pony",
+    "image": "/api/images/monsters/pony.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Pteranodon",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 13,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "60 ft."
+    },
+    "strength": 12,
+    "dexterity": 15,
+    "constitution": 10,
+    "intelligence": 2,
+    "wisdom": 9,
+    "charisma": 5,
+    "perception": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The pteranodon doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "pteranodon",
+    "url": "/api/2024/monsters/pteranodon",
+    "image": "/api/images/monsters/pteranodon.png",
+    "hit_points_roll": "3d8",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 11"
+  },
+  {
+    "name": "Rat",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 1,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "20 ft.",
+      "climb": "20 ft."
+    },
+    "strength": 2,
+    "dexterity": 11,
+    "constitution": 9,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 4,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Agile",
+        "desc": "The rat doesn’t provoke an Opportunity Attack when it moves out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "rat",
+    "url": "/api/2024/monsters/rat",
+    "image": "/api/images/monsters/rat.png",
+    "hit_points_roll": "1d4 − 1",
+    "proficiencies": [],
+    "old_senses": "Darkvision 30 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Raven",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 2,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "50 ft."
+    },
+    "strength": 2,
+    "dexterity": 14,
+    "constitution": 10,
+    "intelligence": 5,
+    "wisdom": 13,
+    "charisma": 6,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Mimicry",
+        "desc": "The raven can mimic simple sounds it has heard, such as a whisper or chitter. A hearer can discern the sounds are imitations with a successful DC 10 Wisdom (Insight) check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "raven",
+    "url": "/api/2024/monsters/raven",
+    "image": "/api/images/monsters/raven.png",
+    "hit_points_roll": "1d4",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 13"
+  },
+  {
+    "name": "Reef Shark",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "4d8",
+    "speed": {
+      "walk": "5 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 14,
+    "dexterity": 15,
+    "constitution": 13,
+    "intelligence": 1,
+    "wisdom": 10,
+    "charisma": 4,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The shark has Advantage on an attack roll against a creature if at least one of the shark’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      },
+      {
+        "name": "Water Breathing",
+        "desc": "The shark can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Piercing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "reef-shark",
+    "url": "/api/2024/monsters/reef-shark",
+    "image": "/api/images/monsters/reef-shark.png",
+    "hit_points_roll": "4d8 + 4",
+    "proficiencies": [],
+    "old_senses": "Blindsight 30 ft.; Passive Perception 12"
+  },
+  {
+    "name": "Rhinoceros",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 45,
+    "hit_dice": "6d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 21,
+    "dexterity": 8,
+    "constitution": 15,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Piercing damage. If target is a Large or smaller creature and the rhinoceros moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "rhinoceros",
+    "url": "/api/2024/monsters/rhinoceros",
+    "image": "/api/images/monsters/rhinoceros.png",
+    "hit_points_roll": "6d10 + 12",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 11"
+  },
+  {
+    "name": "Riding Horse",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 13,
+    "hit_dice": "2d10",
+    "speed": {
+      "walk": "60 ft."
+    },
+    "strength": 16,
+    "dexterity": 13,
+    "constitution": 12,
+    "intelligence": 2,
+    "wisdom": 11,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "riding-horse",
+    "url": "/api/2024/monsters/riding-horse",
+    "image": "/api/images/monsters/riding-horse.png",
+    "hit_points_roll": "2d10 + 2",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Saber-Toothed Tiger",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 52,
+    "hit_dice": "7d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 18,
+    "dexterity": 17,
+    "constitution": 15,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 8,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Running Leap",
+        "desc": "With a 10-foot running start, the tiger can Long Jump up to 25 feet."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The tiger makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The tiger takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "saber-toothed-tiger",
+    "url": "/api/2024/monsters/saber-toothed-tiger",
+    "image": "/api/images/monsters/saber-toothed-tiger.png",
+    "hit_points_roll": "7d10 + 14",
+    "proficiencies": [
+      {
+        "value": 6,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 5,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  },
+  {
+    "name": "Scorpion",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 1,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "10 ft."
+    },
+    "strength": 2,
+    "dexterity": 11,
+    "constitution": 8,
+    "intelligence": 1,
+    "wisdom": 8,
+    "charisma": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 9
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Sting",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage plus 3 (1d6) Poison damage.",
+        "damage_dice": "1d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "scorpion",
+    "url": "/api/2024/monsters/scorpion",
+    "image": "/api/images/monsters/scorpion.png",
+    "hit_points_roll": "1d4 − 1",
+    "proficiencies": [],
+    "old_senses": "Blindsight 10 ft.; Passive Perception 9"
+  },
+  {
+    "name": "Seahorse",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 1,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "5 ft.",
+      "swim": "20 ft."
+    },
+    "strength": 1,
+    "dexterity": 12,
+    "constitution": 8,
+    "intelligence": 1,
+    "wisdom": 10,
+    "charisma": 2,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 12
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The seahorse can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bubble Dash",
+        "desc": "While underwater, the seahorse moves up to its Swim Speed without provoking Opportunity Attacks."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "seahorse",
+    "url": "/api/2024/monsters/seahorse",
+    "image": "/api/images/monsters/seahorse.png",
+    "hit_points_roll": "1d4 − 1",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 12"
+  },
+  {
+    "name": "Spider",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 1,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "20 ft.",
+      "climb": "20 ft."
+    },
+    "strength": 2,
+    "dexterity": 14,
+    "constitution": 8,
+    "intelligence": 1,
+    "wisdom": 10,
+    "charisma": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Web Walker",
+        "desc": "The spider ignores movement restrictions caused by webs, and the spider knows the location of any other creature in contact with the same web."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage plus 2 (1d4) Poison damage.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "spider",
+    "url": "/api/2024/monsters/spider",
+    "image": "/api/images/monsters/spider.png",
+    "hit_points_roll": "1d4 − 1",
+    "proficiencies": [],
+    "old_senses": "Darkvision 30 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Swarm of Bats",
+    "size": "Large",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 11,
+    "hit_dice": "2d10",
+    "speed": {
+      "walk": "5 ft.",
+      "fly": "30 ft."
+    },
+    "strength": 5,
+    "dexterity": 15,
+    "constitution": 10,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 4,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed",
+      "frightened",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "prone",
+      "restrained",
+      "stunned"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny bat. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bites",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (2d4) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied.",
+        "damage_dice": "2d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "swarm-of-bats",
+    "url": "/api/2024/monsters/swarm-of-bats",
+    "image": "/api/images/monsters/swarm-of-bats.png",
+    "hit_points_roll": "2d10",
+    "proficiencies": [],
+    "old_senses": "Blindsight 60 ft.; Passive Perception 11"
+  },
+  {
+    "name": "Swarm of Insects",
+    "size": "Medium",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": "20 ft."
+    },
+    "strength": 3,
+    "dexterity": 13,
+    "constitution": 14,
+    "intelligence": 1,
+    "wisdom": 7,
+    "charisma": 1,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed",
+      "frightened",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "prone",
+      "restrained",
+      "stunned"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 8
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "If the swarm has a Climb Speed, the swarm can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bites",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Poison damage, or 3 (1d4 + 1) Poison damage if the swarm is Bloodied.",
+        "damage_dice": "2d4",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "swarm-of-insects",
+    "url": "/api/2024/monsters/swarm-of-insects",
+    "image": "/api/images/monsters/swarm-of-insects.png",
+    "hit_points_roll": "3d8 + 6",
+    "proficiencies": [],
+    "old_senses": "Blindsight 30 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Swarm of Piranhas",
+    "size": "Medium",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 28,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "5 ft.",
+      "swim": "40 ft."
+    },
+    "strength": 13,
+    "dexterity": 16,
+    "constitution": 9,
+    "intelligence": 1,
+    "wisdom": 7,
+    "charisma": 2,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed",
+      "frightened",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "prone",
+      "restrained",
+      "stunned"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny piranha. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      },
+      {
+        "name": "Water Breathing",
+        "desc": "The swarm can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bites",
+        "desc": "Melee Attack Roll: +5 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 8 (2d4 + 3) Piercing damage, or 5 (1d4 + 3) Piercing damage if the swarm is Bloodied.",
+        "damage_dice": "2d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "swarm-of-piranhas",
+    "url": "/api/2024/monsters/swarm-of-piranhas",
+    "image": "/api/images/monsters/swarm-of-piranhas.png",
+    "hit_points_roll": "8d8 − 8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 8"
+  },
+  {
+    "name": "Swarm of Rats",
+    "size": "Medium",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 14,
+    "hit_dice": "4d8",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 9,
+    "dexterity": 11,
+    "constitution": 9,
+    "intelligence": 2,
+    "wisdom": 10,
+    "charisma": 3,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed",
+      "frightened",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "prone",
+      "restrained",
+      "stunned"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny rat. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bites",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 5 (2d4) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied.",
+        "damage_dice": "2d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "swarm-of-rats",
+    "url": "/api/2024/monsters/swarm-of-rats",
+    "image": "/api/images/monsters/swarm-of-rats.png",
+    "hit_points_roll": "4d8 − 4",
+    "proficiencies": [
+      {
+        "value": 2,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/2024/proficiencies/saving-throw-dex"
+        }
+      }
+    ],
+    "old_senses": "Darkvision 30 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Swarm of Ravens",
+    "size": "Medium",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "50 ft."
+    },
+    "strength": 6,
+    "dexterity": 14,
+    "constitution": 12,
+    "intelligence": 5,
+    "wisdom": 12,
+    "charisma": 6,
+    "perception": 5,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed",
+      "frightened",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "prone",
+      "restrained",
+      "stunned"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny raven. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Beaks",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Cacophony (Recharge 6)",
+        "desc": "Wisdom Saving Throw: DC 10, one creature in the swarm’s space. Failure: The target has the Deafened condition until the start of the swarm’s next turn. While Deafened, the target also has Disadvantage on ability checks and attack rolls."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "swarm-of-ravens",
+    "url": "/api/2024/monsters/swarm-of-ravens",
+    "image": "/api/images/monsters/swarm-of-ravens.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 15"
+  },
+  {
+    "name": "Swarm of Venomous Snakes",
+    "size": "Medium",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 36,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 8,
+    "dexterity": 18,
+    "constitution": 11,
+    "intelligence": 1,
+    "wisdom": 10,
+    "charisma": 3,
+    "damage_resistances": [
+      "bludgeoning",
+      "piercing",
+      "slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "charmed",
+      "frightened",
+      "grappled",
+      "paralyzed",
+      "petrified",
+      "prone",
+      "restrained",
+      "stunned"
+    ],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny snake. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bites",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Piercing damage—or 6 (1d4 + 4) Piercing damage if the swarm is Bloodied—plus 10 (3d6) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "swarm-of-venomous-snakes",
+    "url": "/api/2024/monsters/swarm-of-venomous-snakes",
+    "image": "/api/images/monsters/swarm-of-venomous-snakes.png",
+    "hit_points_roll": "8d8",
+    "proficiencies": [],
+    "old_senses": "Blindsight 10 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Tiger",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 30,
+    "hit_dice": "4d10",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 17,
+    "dexterity": 16,
+    "constitution": 14,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 8,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The tiger takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "tiger",
+    "url": "/api/2024/monsters/tiger",
+    "image": "/api/images/monsters/tiger.png",
+    "hit_points_roll": "4d10 + 8",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Triceratops",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 114,
+    "hit_dice": "12d12",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 22,
+    "dexterity": 9,
+    "constitution": 17,
+    "intelligence": 2,
+    "wisdom": 11,
+    "charisma": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The triceratops makes two Gore attacks."
+      },
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 19 (2d12 + 6) Piercing damage. If the target is Huge or smaller and the triceratops moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition.",
+        "damage_dice": "2d12",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "triceratops",
+    "url": "/api/2024/monsters/triceratops",
+    "image": "/api/images/monsters/triceratops.png",
+    "hit_points_roll": "12d12 + 36",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 10"
+  },
+  {
+    "name": "Tyrannosaurus Rex",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 136,
+    "hit_dice": "13d12",
+    "speed": {
+      "walk": "50 ft."
+    },
+    "strength": 25,
+    "dexterity": 10,
+    "constitution": 19,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 9,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 14
+    },
+    "languages": "None",
+    "challenge_rating": "8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The tyrannosaurus makes one Bite attack and one Tail attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 33 (4d12 + 7) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 17). While Grappled, the target has the Restrained condition and can’t be targeted by the tyrannosaurus’s Tail.",
+        "damage_dice": "4d12",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +10, reach 15 ft. Hit: 25 (4d8 + 7) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+        "damage_dice": "4d8",
+        "damage_bonus": 7
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "tyrannosaurus-rex",
+    "url": "/api/2024/monsters/tyrannosaurus-rex",
+    "image": "/api/images/monsters/tyrannosaurus-rex.png",
+    "hit_points_roll": "13d12 + 52",
+    "proficiencies": [
+      {
+        "value": 10,
+        "proficiency": {
+          "index": "saving-throw-str",
+          "name": "Saving Throw: STR",
+          "url": "/api/2024/proficiencies/saving-throw-str"
+        }
+      },
+      {
+        "value": 4,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 14"
+  },
+  {
+    "name": "Venomous Snake",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 5,
+    "hit_dice": "2d4",
+    "speed": {
+      "walk": "30 ft.",
+      "swim": "30 ft."
+    },
+    "strength": 2,
+    "dexterity": 15,
+    "constitution": 11,
+    "intelligence": 1,
+    "wisdom": 10,
+    "charisma": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 10
+    },
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage plus 3 (1d6) Poison damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "venomous-snake",
+    "url": "/api/2024/monsters/venomous-snake",
+    "image": "/api/images/monsters/venomous-snake.png",
+    "hit_points_roll": "2d4",
+    "proficiencies": [],
+    "old_senses": "Blindsight 10 ft.; Passive Perception 10"
+  },
+  {
+    "name": "Vulture",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 5,
+    "hit_dice": "1d8",
+    "speed": {
+      "walk": "10 ft.",
+      "fly": "50 ft."
+    },
+    "strength": 7,
+    "dexterity": 10,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 4,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The vulture has Advantage on an attack roll against a creature if at least one of the vulture’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Piercing damage.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "vulture",
+    "url": "/api/2024/monsters/vulture",
+    "image": "/api/images/monsters/vulture.png",
+    "hit_points_roll": "1d8 + 1",
+    "proficiencies": [],
+    "old_senses": "Passive Perception 13"
+  },
+  {
+    "name": "Warhorse",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": "60 ft."
+    },
+    "strength": 18,
+    "dexterity": 12,
+    "constitution": 13,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "passive_perception": 11
+    },
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Bludgeoning damage. If the target is a Large or smaller creature and the horse moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "warhorse",
+    "url": "/api/2024/monsters/warhorse",
+    "image": "/api/images/monsters/warhorse.png",
+    "hit_points_roll": "3d10 + 3",
+    "proficiencies": [
+      {
+        "value": 3,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/2024/proficiencies/saving-throw-wis"
+        }
+      }
+    ],
+    "old_senses": "Passive Perception 11"
+  },
+  {
+    "name": "Weasel",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 1,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": "30 ft.",
+      "climb": "30 ft."
+    },
+    "strength": 3,
+    "dexterity": 16,
+    "constitution": 8,
+    "intelligence": 2,
+    "wisdom": 12,
+    "charisma": 3,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "weasel",
+    "url": "/api/2024/monsters/weasel",
+    "image": "/api/images/monsters/weasel.png",
+    "hit_points_roll": "1d4 − 1",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 13"
+  },
+  {
+    "name": "Wolf",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 11,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": "40 ft."
+    },
+    "strength": 14,
+    "dexterity": 15,
+    "constitution": 12,
+    "intelligence": 3,
+    "wisdom": 12,
+    "charisma": 6,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The wolf has Advantage on attack rolls against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [],
+    "index": "wolf",
+    "url": "/api/2024/monsters/wolf",
+    "image": "/api/images/monsters/wolf.png",
+    "hit_points_roll": "2d8 + 2",
+    "proficiencies": [],
+    "old_senses": "Darkvision 60 ft.; Passive Perception 15"
+  }
+]

--- a/src/2024/en/5e-SRD-Monsters-New.json
+++ b/src/2024/en/5e-SRD-Monsters-New.json
@@ -326,7 +326,7 @@
     "legendary_actions": [],
     "index": "animated-flying-sword",
     "url": "/api/2024/monsters/animated-flying-sword",
-    "image": "/api/images/monsters/animated-flying-sword.png",
+    "image": "/api/images/monsters/animated-flying-sword-NYI.png",
     "hit_points_roll": "4d6",
     "proficiencies": [
       {
@@ -394,7 +394,7 @@
     "legendary_actions": [],
     "index": "animated-rug-of-smothering",
     "url": "/api/2024/monsters/animated-rug-of-smothering",
-    "image": "/api/images/monsters/animated-rug-of-smothering.png",
+    "image": "/api/images/monsters/animated-rug-of-smothering-NYI.png",
     "hit_points_roll": "5d10",
     "proficiencies": [],
     "old_senses": "Blindsight 60 ft.; Passive Perception 6"
@@ -748,7 +748,7 @@
     "legendary_actions": [],
     "index": "azer-sentinel",
     "url": "/api/2024/monsters/azer-sentinel",
-    "image": "/api/images/monsters/azer-sentinel.png",
+    "image": "/api/images/monsters/azer-sentinel-NYI.png",
     "hit_points_roll": "6d8 + 12",
     "proficiencies": [
       {
@@ -3282,7 +3282,7 @@
     "legendary_actions": [],
     "index": "bugbear-stalker",
     "url": "/api/2024/monsters/bugbear-stalker",
-    "image": "/api/images/monsters/bugbear-stalker.png",
+    "image": "/api/images/monsters/bugbear-stalker-NYI.png",
     "hit_points_roll": "10d8 + 20",
     "proficiencies": [
       {
@@ -3358,7 +3358,7 @@
     "legendary_actions": [],
     "index": "bugbear-warrior",
     "url": "/api/2024/monsters/bugbear-warrior",
-    "image": "/api/images/monsters/bugbear-warrior.png",
+    "image": "/api/images/monsters/bugbear-warrior-NYI.png",
     "hit_points_roll": "6d8 + 6",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
@@ -3485,7 +3485,7 @@
     "legendary_actions": [],
     "index": "centaur-trooper",
     "url": "/api/2024/monsters/centaur-trooper",
-    "image": "/api/images/monsters/centaur-trooper.png",
+    "image": "/api/images/monsters/centaur-trooper-NYI.png",
     "hit_points_roll": "6d10 + 12",
     "proficiencies": [],
     "old_senses": "Passive Perception 13"
@@ -4657,7 +4657,7 @@
     "legendary_actions": [],
     "index": "swarm-of-crawling-claws",
     "url": "/api/2024/monsters/swarm-of-crawling-claws",
-    "image": "/api/images/monsters/swarm-of-crawling-claws.png",
+    "image": "/api/images/monsters/swarm-of-crawling-claws-NYI.png",
     "hit_points_roll": "11d8",
     "proficiencies": [],
     "old_senses": "Blindsight 30 ft.; Passive Perception 10"
@@ -4782,7 +4782,7 @@
     "legendary_actions": [],
     "index": "cultist-fanatic",
     "url": "/api/2024/monsters/cultist-fanatic",
-    "image": "/api/images/monsters/cultist-fanatic.png",
+    "image": "/api/images/monsters/cultist-fanatic-NYI.png",
     "hit_points_roll": "8d8 + 8",
     "proficiencies": [
       {
@@ -6403,7 +6403,7 @@
     "legendary_actions": [],
     "index": "shrieker-fungus",
     "url": "/api/2024/monsters/shrieker-fungus",
-    "image": "/api/images/monsters/shrieker-fungus.png",
+    "image": "/api/images/monsters/shrieker-fungus-NYI.png",
     "hit_points_roll": "3d8",
     "proficiencies": [],
     "old_senses": "Blindsight 30 ft.; Passive Perception 6"
@@ -7181,7 +7181,7 @@
     "legendary_actions": [],
     "index": "gnoll-warrior",
     "url": "/api/2024/monsters/gnoll-warrior",
-    "image": "/api/images/monsters/gnoll-warrior.png",
+    "image": "/api/images/monsters/gnoll-warrior-NYI.png",
     "hit_points_roll": "6d8",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
@@ -7234,7 +7234,7 @@
     "legendary_actions": [],
     "index": "goblin-minion",
     "url": "/api/2024/monsters/goblin-minion",
-    "image": "/api/images/monsters/goblin-minion.png",
+    "image": "/api/images/monsters/goblin-minion-NYI.png",
     "hit_points_roll": "2d6",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
@@ -7293,7 +7293,7 @@
     "legendary_actions": [],
     "index": "goblin-warrior",
     "url": "/api/2024/monsters/goblin-warrior",
-    "image": "/api/images/monsters/goblin-warrior.png",
+    "image": "/api/images/monsters/goblin-warrior-NYI.png",
     "hit_points_roll": "3d6",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
@@ -7361,7 +7361,7 @@
     "legendary_actions": [],
     "index": "goblin-boss",
     "url": "/api/2024/monsters/goblin-boss",
-    "image": "/api/images/monsters/goblin-boss.png",
+    "image": "/api/images/monsters/goblin-boss-NYI.png",
     "hit_points_roll": "6d6",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
@@ -8775,7 +8775,7 @@
     "legendary_actions": [],
     "index": "guard-captain",
     "url": "/api/2024/monsters/guard-captain",
-    "image": "/api/images/monsters/guard-captain.png",
+    "image": "/api/images/monsters/guard-captain-NYI.png",
     "hit_points_roll": "10d8 + 30",
     "proficiencies": [],
     "old_senses": "Passive Perception 14"
@@ -8843,7 +8843,7 @@
     "legendary_actions": [],
     "index": "half-dragon",
     "url": "/api/2024/monsters/half-dragon",
-    "image": "/api/images/monsters/half-dragon.png",
+    "image": "/api/images/monsters/half-dragon-NYI.png",
     "hit_points_roll": "14d8 + 42",
     "proficiencies": [
       {
@@ -9259,7 +9259,7 @@
     "legendary_actions": [],
     "index": "hobgoblin-warrior",
     "url": "/api/2024/monsters/hobgoblin-warrior",
-    "image": "/api/images/monsters/hobgoblin-warrior.png",
+    "image": "/api/images/monsters/hobgoblin-warrior-NYI.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
@@ -9322,7 +9322,7 @@
     "legendary_actions": [],
     "index": "hobgoblin-captain",
     "url": "/api/2024/monsters/hobgoblin-captain",
-    "image": "/api/images/monsters/hobgoblin-captain.png",
+    "image": "/api/images/monsters/hobgoblin-captain-NYI.png",
     "hit_points_roll": "9d8 + 18",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
@@ -9847,7 +9847,7 @@
     "legendary_actions": [],
     "index": "incubus",
     "url": "/api/2024/monsters/incubus",
-    "image": "/api/images/monsters/incubus.png",
+    "image": "/api/images/monsters/incubus-NYI.png",
     "hit_points_roll": "12d8 + 12",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
@@ -10155,7 +10155,7 @@
     "legendary_actions": [],
     "index": "kobold-warrior",
     "url": "/api/2024/monsters/kobold-warrior",
-    "image": "/api/images/monsters/kobold-warrior.png",
+    "image": "/api/images/monsters/kobold-warrior-NYI.png",
     "hit_points_roll": "3d6 − 3",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 8"
@@ -11444,7 +11444,7 @@
     "legendary_actions": [],
     "index": "merfolk-skirmisher",
     "url": "/api/2024/monsters/merfolk-skirmisher",
-    "image": "/api/images/monsters/merfolk-skirmisher.png",
+    "image": "/api/images/monsters/merfolk-skirmisher-NYI.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
     "old_senses": "Passive Perception 12"
@@ -11637,7 +11637,7 @@
     "legendary_actions": [],
     "index": "minotaur-of-baphomet",
     "url": "/api/2024/monsters/minotaur-of-baphomet",
-    "image": "/api/images/monsters/minotaur-of-baphomet.png",
+    "image": "/api/images/monsters/minotaur-of-baphomet-NYI.png",
     "hit_points_roll": "10d10 + 30",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 17"
@@ -12763,7 +12763,7 @@
     "legendary_actions": [],
     "index": "pirate",
     "url": "/api/2024/monsters/pirate",
-    "image": "/api/images/monsters/pirate.png",
+    "image": "/api/images/monsters/pirate-NYI.png",
     "hit_points_roll": "6d8 + 6",
     "proficiencies": [
       {
@@ -12843,7 +12843,7 @@
     "legendary_actions": [],
     "index": "pirate-captain",
     "url": "/api/2024/monsters/pirate-captain",
-    "image": "/api/images/monsters/pirate-captain.png",
+    "image": "/api/images/monsters/pirate-captain-NYI.png",
     "hit_points_roll": "13d8 + 26",
     "proficiencies": [
       {
@@ -13181,7 +13181,7 @@
     "legendary_actions": [],
     "index": "priest-acolyte",
     "url": "/api/2024/monsters/priest-acolyte",
-    "image": "/api/images/monsters/priest-acolyte.png",
+    "image": "/api/images/monsters/priest-acolyte-NYI.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
     "old_senses": "Passive Perception 12"
@@ -14288,7 +14288,7 @@
     "legendary_actions": [],
     "index": "sahuagin-warrior",
     "url": "/api/2024/monsters/sahuagin-warrior",
-    "image": "/api/images/monsters/sahuagin-warrior.png",
+    "image": "/api/images/monsters/sahuagin-warrior-NYI.png",
     "hit_points_roll": "4d8 + 4",
     "proficiencies": [],
     "old_senses": "Darkvision 120 ft.; Passive Perception 15"
@@ -15611,7 +15611,7 @@
     "legendary_actions": [],
     "index": "sphinx-of-wonder",
     "url": "/api/2024/monsters/sphinx-of-wonder",
-    "image": "/api/images/monsters/sphinx-of-wonder.png",
+    "image": "/api/images/monsters/sphinx-of-wonder-NYI.png",
     "hit_points_roll": "7d4 + 7",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
@@ -15708,7 +15708,7 @@
     ],
     "index": "sphinx-of-lore",
     "url": "/api/2024/monsters/sphinx-of-lore",
-    "image": "/api/images/monsters/sphinx-of-lore.png",
+    "image": "/api/images/monsters/sphinx-of-lore-NYI.png",
     "hit_points_roll": "20d10 + 60",
     "proficiencies": [],
     "old_senses": "Truesight 120 ft.; Passive Perception 18"
@@ -15817,7 +15817,7 @@
     ],
     "index": "sphinx-of-valor",
     "url": "/api/2024/monsters/sphinx-of-valor",
-    "image": "/api/images/monsters/sphinx-of-valor.png",
+    "image": "/api/images/monsters/sphinx-of-valor-NYI.png",
     "hit_points_roll": "19d10 + 95",
     "proficiencies": [
       {
@@ -16504,7 +16504,7 @@
     "legendary_actions": [],
     "index": "succubus",
     "url": "/api/2024/monsters/succubus",
-    "image": "/api/images/monsters/succubus.png",
+    "image": "/api/images/monsters/succubus-NYI.png",
     "hit_points_roll": "13d8 + 13",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
@@ -16711,7 +16711,7 @@
     "legendary_actions": [],
     "index": "tough",
     "url": "/api/2024/monsters/tough",
-    "image": "/api/images/monsters/tough.png",
+    "image": "/api/images/monsters/tough-NYI.png",
     "hit_points_roll": "5d8 + 10",
     "proficiencies": [],
     "old_senses": "Passive Perception 10"
@@ -16773,7 +16773,7 @@
     "legendary_actions": [],
     "index": "tough-boss",
     "url": "/api/2024/monsters/tough-boss",
-    "image": "/api/images/monsters/tough-boss.png",
+    "image": "/api/images/monsters/tough-boss-NYI.png",
     "hit_points_roll": "11d8 + 33",
     "proficiencies": [
       {
@@ -16993,7 +16993,7 @@
     "legendary_actions": [],
     "index": "troll-limb",
     "url": "/api/2024/monsters/troll-limb",
-    "image": "/api/images/monsters/troll-limb.png",
+    "image": "/api/images/monsters/troll-limb-NYI.png",
     "hit_points_roll": "4d6",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
@@ -17155,7 +17155,7 @@
     "legendary_actions": [],
     "index": "vampire-familiar",
     "url": "/api/2024/monsters/vampire-familiar",
-    "image": "/api/images/monsters/vampire-familiar.png",
+    "image": "/api/images/monsters/vampire-familiar-NYI.png",
     "hit_points_roll": "10d8 + 20",
     "proficiencies": [
       {
@@ -17391,7 +17391,7 @@
     ],
     "index": "vampire",
     "url": "/api/2024/monsters/vampire",
-    "image": "/api/images/monsters/vampire.png",
+    "image": "/api/images/monsters/vampire-NYI.png",
     "hit_points_roll": "23d8 + 92",
     "proficiencies": [
       {
@@ -17581,7 +17581,7 @@
     "legendary_actions": [],
     "index": "warrior-infantry",
     "url": "/api/2024/monsters/warrior-infantry",
-    "image": "/api/images/monsters/warrior-infantry.png",
+    "image": "/api/images/monsters/warrior-infantry-NYI.png",
     "hit_points_roll": "2d8",
     "proficiencies": [],
     "old_senses": "Passive Perception 10"
@@ -17644,7 +17644,7 @@
     "legendary_actions": [],
     "index": "warrior-veteran",
     "url": "/api/2024/monsters/warrior-veteran",
-    "image": "/api/images/monsters/warrior-veteran.png",
+    "image": "/api/images/monsters/warrior-veteran-NYI.png",
     "hit_points_roll": "10d8 + 20",
     "proficiencies": [],
     "old_senses": "Passive Perception 12"
@@ -17805,7 +17805,7 @@
     "legendary_actions": [],
     "index": "werebear",
     "url": "/api/2024/monsters/werebear",
-    "image": "/api/images/monsters/werebear.png",
+    "image": "/api/images/monsters/werebear-NYI.png",
     "hit_points_roll": "18d8 + 54",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 17"
@@ -17882,7 +17882,7 @@
     "legendary_actions": [],
     "index": "wereboar",
     "url": "/api/2024/monsters/wereboar",
-    "image": "/api/images/monsters/wereboar.png",
+    "image": "/api/images/monsters/wereboar-NYI.png",
     "hit_points_roll": "15d8 + 30",
     "proficiencies": [],
     "old_senses": "Passive Perception 12"
@@ -17951,7 +17951,7 @@
     "legendary_actions": [],
     "index": "wererat",
     "url": "/api/2024/monsters/wererat",
-    "image": "/api/images/monsters/wererat.png",
+    "image": "/api/images/monsters/wererat-NYI.png",
     "hit_points_roll": "11d8 + 11",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
@@ -18037,7 +18037,7 @@
     "legendary_actions": [],
     "index": "weretiger",
     "url": "/api/2024/monsters/weretiger",
-    "image": "/api/images/monsters/weretiger.png",
+    "image": "/api/images/monsters/weretiger-NYI.png",
     "hit_points_roll": "16d8 + 48",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
@@ -18120,7 +18120,7 @@
     "legendary_actions": [],
     "index": "werewolf",
     "url": "/api/2024/monsters/werewolf",
-    "image": "/api/images/monsters/werewolf.png",
+    "image": "/api/images/monsters/werewolf-NYI.png",
     "hit_points_roll": "11d8 + 22",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
@@ -19193,7 +19193,7 @@
     "legendary_actions": [],
     "index": "allosaurus",
     "url": "/api/2024/monsters/allosaurus",
-    "image": "/api/images/monsters/allosaurus.png",
+    "image": "/api/images/monsters/allosaurus-NYI.png",
     "hit_points_roll": "6d10 + 18",
     "proficiencies": [],
     "old_senses": "Passive Perception 15"
@@ -19244,7 +19244,7 @@
     "legendary_actions": [],
     "index": "ankylosaurus",
     "url": "/api/2024/monsters/ankylosaurus",
-    "image": "/api/images/monsters/ankylosaurus.png",
+    "image": "/api/images/monsters/ankylosaurus-NYI.png",
     "hit_points_roll": "8d12 + 16",
     "proficiencies": [
       {
@@ -19369,7 +19369,7 @@
     "legendary_actions": [],
     "index": "archelon",
     "url": "/api/2024/monsters/archelon",
-    "image": "/api/images/monsters/archelon.png",
+    "image": "/api/images/monsters/archelon-NYI.png",
     "hit_points_roll": "12d12 + 12",
     "proficiencies": [],
     "old_senses": "Passive Perception 12"
@@ -21622,7 +21622,7 @@
     "legendary_actions": [],
     "index": "giant-seahorse",
     "url": "/api/2024/monsters/giant-seahorse",
-    "image": "/api/images/monsters/giant-seahorse.png",
+    "image": "/api/images/monsters/giant-seahorse-NYI.png",
     "hit_points_roll": "3d10",
     "proficiencies": [],
     "old_senses": "Passive Perception 11"
@@ -21857,7 +21857,7 @@
     "legendary_actions": [],
     "index": "giant-venomous-snake",
     "url": "/api/2024/monsters/giant-venomous-snake",
-    "image": "/api/images/monsters/giant-venomous-snake.png",
+    "image": "/api/images/monsters/giant-venomous-snake-NYI.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
     "old_senses": "Blindsight 10 ft.; Passive Perception 12"
@@ -22234,7 +22234,7 @@
     "legendary_actions": [],
     "index": "hippopotamus",
     "url": "/api/2024/monsters/hippopotamus",
-    "image": "/api/images/monsters/hippopotamus.png",
+    "image": "/api/images/monsters/hippopotamus-NYI.png",
     "hit_points_roll": "11d10 + 22",
     "proficiencies": [
       {
@@ -22930,7 +22930,7 @@
     "legendary_actions": [],
     "index": "piranha",
     "url": "/api/2024/monsters/piranha",
-    "image": "/api/images/monsters/piranha.png",
+    "image": "/api/images/monsters/piranha-NYI.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 8"
@@ -23150,7 +23150,7 @@
     "legendary_actions": [],
     "index": "pteranodon",
     "url": "/api/2024/monsters/pteranodon",
-    "image": "/api/images/monsters/pteranodon.png",
+    "image": "/api/images/monsters/pteranodon-NYI.png",
     "hit_points_roll": "3d8",
     "proficiencies": [],
     "old_senses": "Passive Perception 11"
@@ -23587,7 +23587,7 @@
     "legendary_actions": [],
     "index": "seahorse",
     "url": "/api/2024/monsters/seahorse",
-    "image": "/api/images/monsters/seahorse.png",
+    "image": "/api/images/monsters/seahorse-NYI.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
     "old_senses": "Passive Perception 12"
@@ -23851,7 +23851,7 @@
     "legendary_actions": [],
     "index": "swarm-of-piranhas",
     "url": "/api/2024/monsters/swarm-of-piranhas",
-    "image": "/api/images/monsters/swarm-of-piranhas.png",
+    "image": "/api/images/monsters/swarm-of-piranhas-NYI.png",
     "hit_points_roll": "8d8 − 8",
     "proficiencies": [],
     "old_senses": "Darkvision 60 ft.; Passive Perception 8"
@@ -24064,7 +24064,7 @@
     "legendary_actions": [],
     "index": "swarm-of-venomous-snakes",
     "url": "/api/2024/monsters/swarm-of-venomous-snakes",
-    "image": "/api/images/monsters/swarm-of-venomous-snakes.png",
+    "image": "/api/images/monsters/swarm-of-venomous-snakes-NYI.png",
     "hit_points_roll": "8d8",
     "proficiencies": [],
     "old_senses": "Blindsight 10 ft.; Passive Perception 10"
@@ -24293,7 +24293,7 @@
     "legendary_actions": [],
     "index": "venomous-snake",
     "url": "/api/2024/monsters/venomous-snake",
-    "image": "/api/images/monsters/venomous-snake.png",
+    "image": "/api/images/monsters/venomous-snake-NYI.png",
     "hit_points_roll": "2d4",
     "proficiencies": [],
     "old_senses": "Blindsight 10 ft.; Passive Perception 10"

--- a/src/2024/en/5e-SRD-Monsters-New.json
+++ b/src/2024/en/5e-SRD-Monsters-New.json
@@ -123,6 +123,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Darkvision 120 ft.; Passive Perception 20"
   },
   {
@@ -205,6 +206,7 @@
     "image": "/api/images/monsters/air-elemental.png",
     "hit_points_roll": "12d10 + 24",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -268,6 +270,7 @@
     "image": "/api/images/monsters/animated-armor.png",
     "hit_points_roll": "6d8 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 6"
   },
   {
@@ -338,6 +341,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 60 ft.; Passive Perception 7"
   },
   {
@@ -397,6 +401,7 @@
     "image": "/api/images/monsters/animated-rug-of-smothering-NYI.png",
     "hit_points_roll": "5d10",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 6"
   },
   {
@@ -455,6 +460,7 @@
     "image": "/api/images/monsters/ankheg.png",
     "hit_points_roll": "6d10 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft., Tremorsense 60 ft.;"
   },
   {
@@ -542,6 +548,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Passive Perception 16"
   },
   {
@@ -591,6 +598,7 @@
     "image": "/api/images/monsters/awakened-shrub.png",
     "hit_points_roll": "3d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -643,6 +651,7 @@
     "image": "/api/images/monsters/awakened-tree.png",
     "hit_points_roll": "7d12 + 14",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -690,6 +699,7 @@
     "image": "/api/images/monsters/axe-beak.png",
     "hit_points_roll": "3d10 + 3",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -760,6 +770,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 11"
   },
   {
@@ -873,6 +884,7 @@
         }
       }
     ],
+    "proficiency_bonus": 6,
     "old_senses": "Truesight 120 ft.; Passive Perception 19"
   },
   {
@@ -926,6 +938,7 @@
     "image": "/api/images/monsters/bandit.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -1013,6 +1026,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -1130,6 +1144,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Darkvision 120 ft. (unimpeded by magical"
   },
   {
@@ -1183,6 +1198,7 @@
     "image": "/api/images/monsters/basilisk.png",
     "hit_points_roll": "8d8 + 16",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -1282,6 +1298,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 120 ft. (unimpeded by magical"
   },
   {
@@ -1354,6 +1371,7 @@
     "image": "/api/images/monsters/behir.png",
     "hit_points_roll": "16d12 + 64",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 90 ft.; Passive Perception 16"
   },
   {
@@ -1406,6 +1424,7 @@
     "image": "/api/images/monsters/berserker.png",
     "hit_points_roll": "9d8 + 27",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -1489,6 +1508,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -1572,6 +1592,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
   },
   {
@@ -1690,6 +1711,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -1808,6 +1830,7 @@
         }
       }
     ],
+    "proficiency_bonus": 7,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -1888,6 +1911,7 @@
     "image": "/api/images/monsters/black-pudding.png",
     "hit_points_roll": "8d10 + 24",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 8"
   },
   {
@@ -1942,6 +1966,7 @@
     "image": "/api/images/monsters/blink-dog.png",
     "hit_points_roll": "4d8 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -2020,6 +2045,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -2098,6 +2124,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
   },
   {
@@ -2206,6 +2233,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -2314,6 +2342,7 @@
         }
       }
     ],
+    "proficiency_bonus": 7,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -2421,6 +2450,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Darkvision 120 ft. (unimpeded by magical"
   },
   {
@@ -2499,6 +2529,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -2581,6 +2612,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
   },
   {
@@ -2694,6 +2726,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -2807,6 +2840,7 @@
         }
       }
     ],
+    "proficiency_bonus": 6,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -2894,6 +2928,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -2981,6 +3016,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
   },
   {
@@ -3099,6 +3135,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -3217,6 +3254,7 @@
         }
       }
     ],
+    "proficiency_bonus": 7,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -3302,6 +3340,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
   },
   {
@@ -3361,6 +3400,7 @@
     "image": "/api/images/monsters/bugbear-warrior-NYI.png",
     "hit_points_roll": "6d8 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -3425,6 +3465,7 @@
     "image": "/api/images/monsters/bulette.png",
     "hit_points_roll": "9d10 + 45",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Tremorsense 120 ft.;"
   },
   {
@@ -3488,6 +3529,7 @@
     "image": "/api/images/monsters/centaur-trooper-NYI.png",
     "hit_points_roll": "6d10 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 13"
   },
   {
@@ -3590,6 +3632,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Darkvision 120 ft. (unimpeded by magical"
   },
   {
@@ -3661,6 +3704,7 @@
     "image": "/api/images/monsters/chimera.png",
     "hit_points_roll": "12d10 + 48",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 18"
   },
   {
@@ -3732,6 +3776,7 @@
     "image": "/api/images/monsters/chuul.png",
     "hit_points_roll": "9d10 + 27",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -3821,6 +3866,7 @@
     "image": "/api/images/monsters/clay-golem.png",
     "hit_points_roll": "13d10 + 52",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -3896,6 +3942,7 @@
     "image": "/api/images/monsters/cloaker.png",
     "hit_points_roll": "14d10 + 14",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 12"
   },
   {
@@ -3990,6 +4037,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Passive Perception 21"
   },
   {
@@ -4041,6 +4089,7 @@
     "image": "/api/images/monsters/cockatrice.png",
     "hit_points_roll": "5d6 + 5",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
   },
   {
@@ -4092,6 +4141,7 @@
     "image": "/api/images/monsters/commoner.png",
     "hit_points_roll": "1d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -4170,6 +4220,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -4252,6 +4303,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
   },
   {
@@ -4369,6 +4421,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -4486,6 +4539,7 @@
         }
       }
     ],
+    "proficiency_bonus": 7,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -4587,6 +4641,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Truesight 120 ft.; Passive Perception 15"
   },
   {
@@ -4660,6 +4715,7 @@
     "image": "/api/images/monsters/swarm-of-crawling-claws-NYI.png",
     "hit_points_roll": "11d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 30 ft.; Passive Perception 10"
   },
   {
@@ -4716,6 +4772,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -4794,6 +4851,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -4851,6 +4909,7 @@
     "image": "/api/images/monsters/darkmantle.png",
     "hit_points_roll": "5d6 + 5",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 10"
   },
   {
@@ -4911,6 +4970,7 @@
     "image": "/api/images/monsters/death-dog.png",
     "hit_points_roll": "6d8 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 15"
   },
   {
@@ -5015,6 +5075,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Darkvision 120 ft.; Passive Perception 19"
   },
   {
@@ -5128,6 +5189,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Darkvision 120 ft.; Passive Perception 13"
   },
   {
@@ -5195,6 +5257,7 @@
     "image": "/api/images/monsters/doppelganger.png",
     "hit_points_roll": "8d8 + 16",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
   },
   {
@@ -5283,6 +5346,7 @@
         }
       }
     ],
+    "proficiency_bonus": 6,
     "old_senses": "Darkvision 120 ft.; Passive Perception 11"
   },
   {
@@ -5343,6 +5407,7 @@
     "image": "/api/images/monsters/dretch.png",
     "hit_points_roll": "4d6 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -5421,6 +5486,7 @@
     "image": "/api/images/monsters/drider.png",
     "hit_points_roll": "13d10 + 52",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 16"
   },
   {
@@ -5494,6 +5560,7 @@
     "image": "/api/images/monsters/druid.png",
     "hit_points_roll": "8d8 + 8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 15"
   },
   {
@@ -5579,6 +5646,7 @@
     "image": "/api/images/monsters/dryad.png",
     "hit_points_roll": "5d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -5656,6 +5724,7 @@
     "image": "/api/images/monsters/earth-elemental.png",
     "hit_points_roll": "14d10 + 70",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft., Tremorsense 60 ft.;"
   },
   {
@@ -5759,6 +5828,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Darkvision 120 ft.; Passive Perception 12"
   },
   {
@@ -5868,6 +5938,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Truesight 120 ft.; Passive Perception 16"
   },
   {
@@ -5946,6 +6017,7 @@
     "image": "/api/images/monsters/ettercap.png",
     "hit_points_roll": "8d8 + 8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -6012,6 +6084,7 @@
     "image": "/api/images/monsters/ettin.png",
     "hit_points_roll": "10d10 + 30",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -6097,6 +6170,7 @@
     "image": "/api/images/monsters/fire-elemental.png",
     "hit_points_roll": "11d10 + 33",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -6182,6 +6256,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Passive Perception 16"
   },
   {
@@ -6265,6 +6340,7 @@
     "image": "/api/images/monsters/flesh-golem.png",
     "hit_points_roll": "15d8 + 60",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -6355,6 +6431,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Passive Perception 13"
   },
   {
@@ -6406,6 +6483,7 @@
     "image": "/api/images/monsters/shrieker-fungus-NYI.png",
     "hit_points_roll": "3d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 30 ft.; Passive Perception 6"
   },
   {
@@ -6462,6 +6540,7 @@
     "image": "/api/images/monsters/violet-fungus.png",
     "hit_points_roll": "4d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 30 ft.; Passive Perception 6"
   },
   {
@@ -6526,6 +6605,7 @@
     "image": "/api/images/monsters/gargoyle.png",
     "hit_points_roll": "9d8 + 27",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -6597,6 +6677,7 @@
     "image": "/api/images/monsters/gelatinous-cube.png",
     "hit_points_roll": "6d10 + 30",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 8"
   },
   {
@@ -6673,6 +6754,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -6778,6 +6860,7 @@
     "image": "/api/images/monsters/ghost.png",
     "hit_points_roll": "10d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
   },
   {
@@ -6842,6 +6925,7 @@
     "image": "/api/images/monsters/ghoul.png",
     "hit_points_roll": "5d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -6905,6 +6989,7 @@
     "image": "/api/images/monsters/gibbering-mouther.png",
     "hit_points_roll": "7d8 + 21",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -7030,6 +7115,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Truesight 120 ft.; Passive Perception 17"
   },
   {
@@ -7125,6 +7211,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Passive Perception 11"
   },
   {
@@ -7184,6 +7271,7 @@
     "image": "/api/images/monsters/gnoll-warrior-NYI.png",
     "hit_points_roll": "6d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -7237,6 +7325,7 @@
     "image": "/api/images/monsters/goblin-minion-NYI.png",
     "hit_points_roll": "2d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -7296,6 +7385,7 @@
     "image": "/api/images/monsters/goblin-warrior-NYI.png",
     "hit_points_roll": "3d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -7364,6 +7454,7 @@
     "image": "/api/images/monsters/goblin-boss-NYI.png",
     "hit_points_roll": "6d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -7452,6 +7543,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -7540,6 +7632,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
   },
   {
@@ -7659,6 +7752,7 @@
         }
       }
     ],
+    "proficiency_bonus": 6,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -7779,6 +7873,7 @@
         }
       }
     ],
+    "proficiency_bonus": 7,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -7840,6 +7935,7 @@
     "image": "/api/images/monsters/gorgon.png",
     "hit_points_roll": "12d10 + 48",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 17"
   },
   {
@@ -7911,6 +8007,7 @@
     "image": "/api/images/monsters/gray-ooze.png",
     "hit_points_roll": "3d8 + 9",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 8"
   },
   {
@@ -7996,6 +8093,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -8081,6 +8179,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
   },
   {
@@ -8196,6 +8295,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -8311,6 +8411,7 @@
         }
       }
     ],
+    "proficiency_bonus": 7,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -8387,6 +8488,7 @@
     "image": "/api/images/monsters/green-hag.png",
     "hit_points_roll": "11d8 + 33",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -8446,6 +8548,7 @@
     "image": "/api/images/monsters/grick.png",
     "hit_points_roll": "12d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 12"
   },
   {
@@ -8498,6 +8601,7 @@
     "image": "/api/images/monsters/griffon.png",
     "hit_points_roll": "7d10 + 21",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -8548,6 +8652,7 @@
     "image": "/api/images/monsters/grimlock.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 30 ft.; Passive Perception 13"
   },
   {
@@ -8672,6 +8777,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -8720,6 +8826,7 @@
     "image": "/api/images/monsters/guard.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -8778,6 +8885,7 @@
     "image": "/api/images/monsters/guard-captain-NYI.png",
     "hit_points_roll": "10d8 + 30",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 14"
   },
   {
@@ -8863,6 +8971,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -8919,6 +9028,7 @@
     "image": "/api/images/monsters/harpy.png",
     "hit_points_roll": "7d8 + 7",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -8984,6 +9094,7 @@
     "image": "/api/images/monsters/hell-hound.png",
     "hit_points_roll": "9d8 + 18",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -9087,6 +9198,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Darkvision 120 ft.; Passive Perception 11"
   },
   {
@@ -9145,6 +9257,7 @@
     "image": "/api/images/monsters/hill-giant.png",
     "hit_points_roll": "10d12 + 40",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -9203,6 +9316,7 @@
     "image": "/api/images/monsters/hippogriff.png",
     "hit_points_roll": "4d10 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 15"
   },
   {
@@ -9262,6 +9376,7 @@
     "image": "/api/images/monsters/hobgoblin-warrior-NYI.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -9325,6 +9440,7 @@
     "image": "/api/images/monsters/hobgoblin-captain-NYI.png",
     "hit_points_roll": "9d8 + 18",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -9399,6 +9515,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -9512,6 +9629,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Darkvision 150 ft. (unimpeded by magical"
   },
   {
@@ -9590,6 +9708,7 @@
     "image": "/api/images/monsters/hydra.png",
     "hit_points_roll": "16d12 + 80",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 16"
   },
   {
@@ -9701,6 +9820,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Blindsight 120 ft.; Passive Perception 17"
   },
   {
@@ -9769,6 +9889,7 @@
     "image": "/api/images/monsters/imp.png",
     "hit_points_roll": "6d4 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft. (unimpeded by magical"
   },
   {
@@ -9850,6 +9971,7 @@
     "image": "/api/images/monsters/incubus-NYI.png",
     "hit_points_roll": "12d8 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -9935,6 +10057,7 @@
     "image": "/api/images/monsters/invisible-stalker.png",
     "hit_points_roll": "13d10 + 26",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 18"
   },
   {
@@ -10021,6 +10144,7 @@
     "image": "/api/images/monsters/iron-golem.png",
     "hit_points_roll": "24d10 + 120",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 10"
   },
   {
@@ -10101,6 +10225,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -10158,6 +10283,7 @@
     "image": "/api/images/monsters/kobold-warrior-NYI.png",
     "hit_points_roll": "3d6 − 3",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 8"
   },
   {
@@ -10291,6 +10417,7 @@
         }
       }
     ],
+    "proficiency_bonus": 7,
     "old_senses": "Truesight 120 ft.; Passive Perception 21"
   },
   {
@@ -10365,6 +10492,7 @@
     "image": "/api/images/monsters/lamia.png",
     "hit_points_roll": "13d10 + 26",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 12"
   },
   {
@@ -10425,6 +10553,7 @@
     "image": "/api/images/monsters/lemure.png",
     "hit_points_roll": "2d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft. (unimpeded by magical"
   },
   {
@@ -10574,6 +10703,7 @@
         }
       }
     ],
+    "proficiency_bonus": 7,
     "old_senses": "Truesight 120 ft.; Passive Perception 19"
   },
   {
@@ -10669,6 +10799,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Passive Perception 14"
   },
   {
@@ -10773,6 +10904,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Passive Perception 16"
   },
   {
@@ -10837,6 +10969,7 @@
     "image": "/api/images/monsters/magmin.png",
     "hit_points_roll": "3d6 + 3",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -10896,6 +11029,7 @@
     "image": "/api/images/monsters/manticore.png",
     "hit_points_roll": "8d10 + 24",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
   },
   {
@@ -11020,6 +11154,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Truesight 120 ft.; Passive Perception 18"
   },
   {
@@ -11099,6 +11234,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Darkvision 150 ft.; Passive Perception 14"
   },
   {
@@ -11173,6 +11309,7 @@
     "image": "/api/images/monsters/dust-mephit.png",
     "hit_points_roll": "5d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 12"
   },
   {
@@ -11248,6 +11385,7 @@
     "image": "/api/images/monsters/ice-mephit.png",
     "hit_points_roll": "6d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 12"
   },
   {
@@ -11319,6 +11457,7 @@
     "image": "/api/images/monsters/magma-mephit.png",
     "hit_points_roll": "4d6 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -11395,6 +11534,7 @@
     "image": "/api/images/monsters/steam-mephit.png",
     "hit_points_roll": "5d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -11447,6 +11587,7 @@
     "image": "/api/images/monsters/merfolk-skirmisher-NYI.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -11517,6 +11658,7 @@
     "image": "/api/images/monsters/merrow.png",
     "hit_points_roll": "6d10 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -11585,6 +11727,7 @@
     "image": "/api/images/monsters/mimic.png",
     "hit_points_roll": "9d8 + 18",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
   },
   {
@@ -11640,6 +11783,7 @@
     "image": "/api/images/monsters/minotaur-of-baphomet-NYI.png",
     "hit_points_roll": "10d10 + 30",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 17"
   },
   {
@@ -11716,6 +11860,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
   },
   {
@@ -11853,6 +11998,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Truesight 60 ft.; Passive Perception 19"
   },
   {
@@ -11971,6 +12117,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Truesight 120 ft.; Passive Perception 11"
   },
   {
@@ -12063,6 +12210,7 @@
     "image": "/api/images/monsters/night-hag.png",
     "hit_points_roll": "15d8 + 45",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 15"
   },
   {
@@ -12127,6 +12275,7 @@
     "image": "/api/images/monsters/nightmare.png",
     "hit_points_roll": "8d10 + 24",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 11"
   },
   {
@@ -12179,6 +12328,7 @@
     "image": "/api/images/monsters/noble.png",
     "hit_points_roll": "2d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -12255,6 +12405,7 @@
     "image": "/api/images/monsters/ochre-jelly.png",
     "hit_points_roll": "7d10 + 14",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 8"
   },
   {
@@ -12309,6 +12460,7 @@
     "image": "/api/images/monsters/ogre.png",
     "hit_points_roll": "8d10 + 24",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 8"
   },
   {
@@ -12431,6 +12583,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -12504,6 +12657,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Darkvision 120 ft.; Passive Perception 11"
   },
   {
@@ -12558,6 +12712,7 @@
     "image": "/api/images/monsters/owlbear.png",
     "hit_points_roll": "7d10 + 21",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -12640,6 +12795,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 16"
   },
   {
@@ -12711,6 +12867,7 @@
     "image": "/api/images/monsters/phase-spider.png",
     "hit_points_roll": "7d10 + 7",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -12783,6 +12940,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 11"
   },
   {
@@ -12879,6 +13037,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Passive Perception 15"
   },
   {
@@ -12990,6 +13149,7 @@
         }
       }
     ],
+    "proficiency_bonus": 6,
     "old_senses": "Truesight 120 ft.; Passive Perception 20"
   },
   {
@@ -13119,6 +13279,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Truesight 120 ft.; Passive Perception 21"
   },
   {
@@ -13184,6 +13345,7 @@
     "image": "/api/images/monsters/priest-acolyte-NYI.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -13258,6 +13420,7 @@
     "image": "/api/images/monsters/priest.png",
     "hit_points_roll": "7d8 + 7",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 15"
   },
   {
@@ -13321,6 +13484,7 @@
     "image": "/api/images/monsters/pseudodragon.png",
     "hit_points_roll": "3d4 + 3",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -13406,6 +13570,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Blindsight 30 ft., Tremorsense 60 ft.;"
   },
   {
@@ -13479,6 +13644,7 @@
     "image": "/api/images/monsters/quasit.png",
     "hit_points_roll": "10d4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 10"
   },
   {
@@ -13563,6 +13729,7 @@
     "image": "/api/images/monsters/rakshasa.png",
     "hit_points_roll": "26d8 + 104",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Truesight 60 ft.; Passive Perception 18"
   },
   {
@@ -13641,6 +13808,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -13719,6 +13887,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
   },
   {
@@ -13828,6 +13997,7 @@
         }
       }
     ],
+    "proficiency_bonus": 6,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -13937,6 +14107,7 @@
         }
       }
     ],
+    "proficiency_bonus": 7,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -13998,6 +14169,7 @@
     "image": "/api/images/monsters/remorhaz.png",
     "hit_points_roll": "17d12 + 85",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft., Tremorsense 60 ft.;"
   },
   {
@@ -14079,6 +14251,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Passive Perception 18"
   },
   {
@@ -14146,6 +14319,7 @@
     "image": "/api/images/monsters/roper.png",
     "hit_points_roll": "11d10 + 33",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 16"
   },
   {
@@ -14216,6 +14390,7 @@
     "image": "/api/images/monsters/rust-monster.png",
     "hit_points_roll": "6d8 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
   },
   {
@@ -14291,6 +14466,7 @@
     "image": "/api/images/monsters/sahuagin-warrior-NYI.png",
     "hit_points_roll": "4d8 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 15"
   },
   {
@@ -14363,6 +14539,7 @@
     "image": "/api/images/monsters/salamander.png",
     "hit_points_roll": "12d10 + 24",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -14422,6 +14599,7 @@
     "image": "/api/images/monsters/satyr.png",
     "hit_points_roll": "7d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -14480,6 +14658,7 @@
     "image": "/api/images/monsters/scout.png",
     "hit_points_roll": "3d8 + 3",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 15"
   },
   {
@@ -14551,6 +14730,7 @@
     "image": "/api/images/monsters/sea-hag.png",
     "hit_points_roll": "7d8 + 21",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
   },
   {
@@ -14634,6 +14814,7 @@
     "image": "/api/images/monsters/shadow.png",
     "hit_points_roll": "5d8 + 5",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -14713,6 +14894,7 @@
     "image": "/api/images/monsters/shambling-mound.png",
     "hit_points_roll": "13d10 + 39",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 10"
   },
   {
@@ -14791,6 +14973,7 @@
     "image": "/api/images/monsters/shield-guardian.png",
     "hit_points_roll": "15d10 + 60",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -14872,6 +15055,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -14953,6 +15137,7 @@
         }
       }
     ],
+    "proficiency_bonus": 4,
     "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
   },
   {
@@ -15066,6 +15251,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -15179,6 +15365,7 @@
         }
       }
     ],
+    "proficiency_bonus": 7,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -15240,6 +15427,7 @@
     "image": "/api/images/monsters/skeleton.png",
     "hit_points_roll": "2d8 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -15295,6 +15483,7 @@
     "image": "/api/images/monsters/warhorse-skeleton.png",
     "hit_points_roll": "3d10 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -15356,6 +15545,7 @@
     "image": "/api/images/monsters/minotaur-skeleton.png",
     "hit_points_roll": "6d10 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -15469,6 +15659,7 @@
     "image": "/api/images/monsters/solar.png",
     "hit_points_roll": "22d10 + 176",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Truesight 120 ft.; Passive Perception 24"
   },
   {
@@ -15551,6 +15742,7 @@
     "image": "/api/images/monsters/specter.png",
     "hit_points_roll": "5d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -15614,6 +15806,7 @@
     "image": "/api/images/monsters/sphinx-of-wonder-NYI.png",
     "hit_points_roll": "7d4 + 7",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 11"
   },
   {
@@ -15711,6 +15904,7 @@
     "image": "/api/images/monsters/sphinx-of-lore-NYI.png",
     "hit_points_roll": "20d10 + 60",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Truesight 120 ft.; Passive Perception 18"
   },
   {
@@ -15853,6 +16047,7 @@
         }
       }
     ],
+    "proficiency_bonus": 6,
     "old_senses": "Truesight 120 ft.; Passive Perception 22"
   },
   {
@@ -15965,6 +16160,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Darkvision 60 ft.; Passive Perception 12"
   },
   {
@@ -16026,6 +16222,7 @@
     "image": "/api/images/monsters/sprite.png",
     "hit_points_roll": "4d4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 13"
   },
   {
@@ -16085,6 +16282,7 @@
     "image": "/api/images/monsters/spy.png",
     "hit_points_roll": "6d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 16"
   },
   {
@@ -16134,6 +16332,7 @@
     "image": "/api/images/monsters/stirge.png",
     "hit_points_roll": "2d4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -16223,6 +16422,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -16304,6 +16504,7 @@
     "image": "/api/images/monsters/stone-golem.png",
     "hit_points_roll": "21d10 + 105",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 10"
   },
   {
@@ -16425,6 +16626,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Darkvision 120 ft., Truesight 30 ft.;"
   },
   {
@@ -16507,6 +16709,7 @@
     "image": "/api/images/monsters/succubus-NYI.png",
     "hit_points_roll": "13d8 + 13",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -16656,6 +16859,7 @@
         }
       }
     ],
+    "proficiency_bonus": 9,
     "old_senses": "Blindsight 120 ft.; Passive Perception 19"
   },
   {
@@ -16714,6 +16918,7 @@
     "image": "/api/images/monsters/tough-NYI.png",
     "hit_points_roll": "5d8 + 10",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -16801,6 +17006,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -16872,6 +17078,7 @@
     "image": "/api/images/monsters/treant.png",
     "hit_points_roll": "12d12 + 60",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 13"
   },
   {
@@ -16939,6 +17146,7 @@
     "image": "/api/images/monsters/troll.png",
     "hit_points_roll": "9d10 + 45",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -16996,6 +17204,7 @@
     "image": "/api/images/monsters/troll-limb-NYI.png",
     "hit_points_roll": "4d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 9"
   },
   {
@@ -17090,6 +17299,7 @@
     "image": "/api/images/monsters/unicorn.png",
     "hit_points_roll": "13d10 + 26",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -17175,6 +17385,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -17281,6 +17492,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -17427,6 +17639,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Darkvision 120 ft.; Passive Perception 17"
   },
   {
@@ -17532,6 +17745,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Darkvision 120 ft.; Passive Perception 11"
   },
   {
@@ -17584,6 +17798,7 @@
     "image": "/api/images/monsters/warrior-infantry-NYI.png",
     "hit_points_roll": "2d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -17647,6 +17862,7 @@
     "image": "/api/images/monsters/warrior-veteran-NYI.png",
     "hit_points_roll": "10d8 + 20",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -17729,6 +17945,7 @@
     "image": "/api/images/monsters/water-elemental.png",
     "hit_points_roll": "12d10 + 48",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -17808,6 +18025,7 @@
     "image": "/api/images/monsters/werebear-NYI.png",
     "hit_points_roll": "18d8 + 54",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 17"
   },
   {
@@ -17885,6 +18103,7 @@
     "image": "/api/images/monsters/wereboar-NYI.png",
     "hit_points_roll": "15d8 + 30",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -17954,6 +18173,7 @@
     "image": "/api/images/monsters/wererat-NYI.png",
     "hit_points_roll": "11d8 + 11",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -18040,6 +18260,7 @@
     "image": "/api/images/monsters/weretiger-NYI.png",
     "hit_points_roll": "16d8 + 48",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -18123,6 +18344,7 @@
     "image": "/api/images/monsters/werewolf-NYI.png",
     "hit_points_roll": "11d8 + 22",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -18207,6 +18429,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -18299,6 +18522,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Blindsight 30 ft., Darkvision 120 ft.;"
   },
   {
@@ -18401,6 +18625,7 @@
         }
       }
     ],
+    "proficiency_bonus": 5,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -18503,6 +18728,7 @@
         }
       }
     ],
+    "proficiency_bonus": 6,
     "old_senses": "Blindsight 60 ft., Darkvision 120 ft.;"
   },
   {
@@ -18580,6 +18806,7 @@
     "image": "/api/images/monsters/wight.png",
     "hit_points_roll": "11d8 + 33",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -18675,6 +18902,7 @@
     "image": "/api/images/monsters/will-o-wisp.png",
     "hit_points_roll": "11d4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 12"
   },
   {
@@ -18733,6 +18961,7 @@
     "image": "/api/images/monsters/winter-wolf.png",
     "hit_points_roll": "10d10 + 20",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 15"
   },
   {
@@ -18782,6 +19011,7 @@
     "image": "/api/images/monsters/worg.png",
     "hit_points_roll": "4d10 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -18869,6 +19099,7 @@
     "image": "/api/images/monsters/wraith.png",
     "hit_points_roll": "9d8 + 27",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 12"
   },
   {
@@ -18929,6 +19160,7 @@
     "image": "/api/images/monsters/wyvern.png",
     "hit_points_roll": "15d10 + 45",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 14"
   },
   {
@@ -19008,6 +19240,7 @@
     "image": "/api/images/monsters/xorn.png",
     "hit_points_roll": "8d8 + 48",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft., Tremorsense 60 ft.;"
   },
   {
@@ -19075,6 +19308,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 8"
   },
   {
@@ -19142,6 +19376,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 8"
   },
   {
@@ -19196,6 +19431,7 @@
     "image": "/api/images/monsters/allosaurus-NYI.png",
     "hit_points_roll": "6d10 + 18",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 15"
   },
   {
@@ -19256,6 +19492,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 11"
   },
   {
@@ -19315,6 +19552,7 @@
     "image": "/api/images/monsters/ape.png",
     "hit_points_roll": "3d8 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 13"
   },
   {
@@ -19372,6 +19610,7 @@
     "image": "/api/images/monsters/archelon-NYI.png",
     "hit_points_roll": "12d12 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -19425,6 +19664,7 @@
     "image": "/api/images/monsters/baboon.png",
     "hit_points_roll": "1d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 11"
   },
   {
@@ -19475,6 +19715,7 @@
     "image": "/api/images/monsters/badger.png",
     "hit_points_roll": "1d4 + 3",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 30 ft.; Passive Perception 13"
   },
   {
@@ -19522,6 +19763,7 @@
     "image": "/api/images/monsters/bat.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 11"
   },
   {
@@ -19577,6 +19819,7 @@
     "image": "/api/images/monsters/black-bear.png",
     "hit_points_roll": "3d8 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -19631,6 +19874,7 @@
     "image": "/api/images/monsters/blood-hawk.png",
     "hit_points_roll": "2d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 16"
   },
   {
@@ -19681,6 +19925,7 @@
     "image": "/api/images/monsters/boar.png",
     "hit_points_roll": "2d8 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 9"
   },
   {
@@ -19739,6 +19984,7 @@
     "image": "/api/images/monsters/brown-bear.png",
     "hit_points_roll": "3d10 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -19796,6 +20042,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -19858,6 +20105,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -19913,6 +20161,7 @@
     "image": "/api/images/monsters/constrictor-snake.png",
     "hit_points_roll": "2d10 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 10 ft.; Passive Perception 12"
   },
   {
@@ -19965,6 +20214,7 @@
     "image": "/api/images/monsters/crab.png",
     "hit_points_roll": "1d4 + 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 30 ft.; Passive Perception 9"
   },
   {
@@ -20027,6 +20277,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -20080,6 +20331,7 @@
     "image": "/api/images/monsters/deer.png",
     "hit_points_roll": "1d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -20132,6 +20384,7 @@
     "image": "/api/images/monsters/dire-wolf.png",
     "hit_points_roll": "3d10 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -20179,6 +20432,7 @@
     "image": "/api/images/monsters/draft-horse.png",
     "hit_points_roll": "2d10 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -20228,6 +20482,7 @@
     "image": "/api/images/monsters/eagle.png",
     "hit_points_roll": "1d6 + 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 16"
   },
   {
@@ -20284,6 +20539,7 @@
     "image": "/api/images/monsters/elephant.png",
     "hit_points_roll": "8d12 + 24",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -20333,6 +20589,7 @@
     "image": "/api/images/monsters/elk.png",
     "hit_points_roll": "2d10",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 12"
   },
   {
@@ -20387,6 +20644,7 @@
     "image": "/api/images/monsters/flying-snake.png",
     "hit_points_roll": "2d4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 10 ft.; Passive Perception 11"
   },
   {
@@ -20444,6 +20702,7 @@
     "image": "/api/images/monsters/frog.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 30 ft.; Passive Perception 11"
   },
   {
@@ -20507,6 +20766,7 @@
     "image": "/api/images/monsters/giant-ape.png",
     "hit_points_roll": "16d12 + 64",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 14"
   },
   {
@@ -20559,6 +20819,7 @@
     "image": "/api/images/monsters/giant-badger.png",
     "hit_points_roll": "2d8 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -20608,6 +20869,7 @@
     "image": "/api/images/monsters/giant-bat.png",
     "hit_points_roll": "4d10",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 120 ft.; Passive Perception 11"
   },
   {
@@ -20669,6 +20931,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 8"
   },
   {
@@ -20718,6 +20981,7 @@
     "image": "/api/images/monsters/giant-centipede.png",
     "hit_points_roll": "2d6 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 30 ft.; Passive Perception 8"
   },
   {
@@ -20778,6 +21042,7 @@
     "image": "/api/images/monsters/giant-constrictor-snake.png",
     "hit_points_roll": "8d12 + 8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 10 ft.; Passive Perception 12"
   },
   {
@@ -20830,6 +21095,7 @@
     "image": "/api/images/monsters/giant-crab.png",
     "hit_points_roll": "3d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 30 ft.; Passive Perception 9"
   },
   {
@@ -20893,6 +21159,7 @@
     "image": "/api/images/monsters/giant-crocodile.png",
     "hit_points_roll": "9d12 + 27",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -20949,6 +21216,7 @@
     "image": "/api/images/monsters/giant-eagle.png",
     "hit_points_roll": "4d10 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 16"
   },
   {
@@ -21018,6 +21286,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 90 ft.; Passive Perception 14"
   },
   {
@@ -21072,6 +21341,7 @@
     "image": "/api/images/monsters/giant-fire-beetle.png",
     "hit_points_roll": "1d6 + 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 30 ft.; Passive Perception 8"
   },
   {
@@ -21134,6 +21404,7 @@
     "image": "/api/images/monsters/giant-frog.png",
     "hit_points_roll": "4d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 30 ft.; Passive Perception 12"
   },
   {
@@ -21191,6 +21462,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -21245,6 +21517,7 @@
     "image": "/api/images/monsters/giant-hyena.png",
     "hit_points_roll": "6d10 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -21308,6 +21581,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -21368,6 +21642,7 @@
     "image": "/api/images/monsters/giant-octopus.png",
     "hit_points_roll": "7d10 + 7",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -21447,6 +21722,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 120 ft.; Passive Perception 16"
   },
   {
@@ -21511,6 +21787,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 12"
   },
   {
@@ -21567,6 +21844,7 @@
     "image": "/api/images/monsters/giant-scorpion.png",
     "hit_points_roll": "7d10 + 14",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 9"
   },
   {
@@ -21625,6 +21903,7 @@
     "image": "/api/images/monsters/giant-seahorse-NYI.png",
     "hit_points_roll": "3d10",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 11"
   },
   {
@@ -21684,6 +21963,7 @@
     "image": "/api/images/monsters/giant-shark.png",
     "hit_points_roll": "8d12 + 40",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 13"
   },
   {
@@ -21747,6 +22027,7 @@
     "image": "/api/images/monsters/giant-spider.png",
     "hit_points_roll": "4d10 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -21810,6 +22091,7 @@
     "image": "/api/images/monsters/giant-toad.png",
     "hit_points_roll": "6d10 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 10"
   },
   {
@@ -21860,6 +22142,7 @@
     "image": "/api/images/monsters/giant-venomous-snake-NYI.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 10 ft.; Passive Perception 12"
   },
   {
@@ -21917,6 +22200,7 @@
     "image": "/api/images/monsters/giant-vulture.png",
     "hit_points_roll": "3d10 + 9",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -21970,6 +22254,7 @@
     "image": "/api/images/monsters/giant-wasp.png",
     "hit_points_roll": "5d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -22020,6 +22305,7 @@
     "image": "/api/images/monsters/giant-weasel.png",
     "hit_points_roll": "2d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -22074,6 +22360,7 @@
     "image": "/api/images/monsters/giant-wolf-spider.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 10 ft., Darkvision 60 ft.;"
   },
   {
@@ -22132,6 +22419,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 12"
   },
   {
@@ -22179,6 +22467,7 @@
     "image": "/api/images/monsters/hawk.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 16"
   },
   {
@@ -22246,6 +22535,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 13"
   },
   {
@@ -22301,6 +22591,7 @@
     "image": "/api/images/monsters/hunter-shark.png",
     "hit_points_roll": "6d10 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 12"
   },
   {
@@ -22354,6 +22645,7 @@
     "image": "/api/images/monsters/hyena.png",
     "hit_points_roll": "1d8 + 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -22402,6 +22694,7 @@
     "image": "/api/images/monsters/jackal.png",
     "hit_points_roll": "1d6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 90 ft.; Passive Perception 15"
   },
   {
@@ -22457,6 +22750,7 @@
     "image": "/api/images/monsters/killer-whale.png",
     "hit_points_roll": "12d12 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 120 ft.; Passive Perception 13"
   },
   {
@@ -22523,6 +22817,7 @@
     "image": "/api/images/monsters/lion.png",
     "hit_points_roll": "4d10",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -22575,6 +22870,7 @@
     "image": "/api/images/monsters/lizard.png",
     "hit_points_roll": "1d4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 30 ft.; Passive Perception 9"
   },
   {
@@ -22648,6 +22944,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -22704,6 +23001,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -22773,6 +23071,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -22826,6 +23125,7 @@
     "image": "/api/images/monsters/owl.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 120 ft.; Passive Perception 15"
   },
   {
@@ -22881,6 +23181,7 @@
     "image": "/api/images/monsters/panther.png",
     "hit_points_roll": "3d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 14"
   },
   {
@@ -22933,6 +23234,7 @@
     "image": "/api/images/monsters/piranha-NYI.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 8"
   },
   {
@@ -22987,6 +23289,7 @@
     "image": "/api/images/monsters/plesiosaurus.png",
     "hit_points_roll": "8d10 + 24",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 13"
   },
   {
@@ -23043,6 +23346,7 @@
     "image": "/api/images/monsters/polar-bear.png",
     "hit_points_roll": "5d10 + 15",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -23099,6 +23403,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -23153,6 +23458,7 @@
     "image": "/api/images/monsters/pteranodon-NYI.png",
     "hit_points_roll": "3d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 11"
   },
   {
@@ -23206,6 +23512,7 @@
     "image": "/api/images/monsters/rat.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 30 ft.; Passive Perception 12"
   },
   {
@@ -23258,6 +23565,7 @@
     "image": "/api/images/monsters/raven.png",
     "hit_points_roll": "1d4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 13"
   },
   {
@@ -23317,6 +23625,7 @@
     "image": "/api/images/monsters/reef-shark.png",
     "hit_points_roll": "4d8 + 4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 30 ft.; Passive Perception 12"
   },
   {
@@ -23364,6 +23673,7 @@
     "image": "/api/images/monsters/rhinoceros.png",
     "hit_points_roll": "6d10 + 12",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 11"
   },
   {
@@ -23411,6 +23721,7 @@
     "image": "/api/images/monsters/riding-horse.png",
     "hit_points_roll": "2d10 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -23491,6 +23802,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   },
   {
@@ -23538,6 +23850,7 @@
     "image": "/api/images/monsters/scorpion.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 10 ft.; Passive Perception 9"
   },
   {
@@ -23590,6 +23903,7 @@
     "image": "/api/images/monsters/seahorse-NYI.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 12"
   },
   {
@@ -23647,6 +23961,7 @@
     "image": "/api/images/monsters/spider.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 30 ft.; Passive Perception 10"
   },
   {
@@ -23713,6 +24028,7 @@
     "image": "/api/images/monsters/swarm-of-bats.png",
     "hit_points_roll": "2d10",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 60 ft.; Passive Perception 11"
   },
   {
@@ -23783,6 +24099,7 @@
     "image": "/api/images/monsters/swarm-of-insects.png",
     "hit_points_roll": "3d8 + 6",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 30 ft.; Passive Perception 8"
   },
   {
@@ -23854,6 +24171,7 @@
     "image": "/api/images/monsters/swarm-of-piranhas-NYI.png",
     "hit_points_roll": "8d8 − 8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 8"
   },
   {
@@ -23929,6 +24247,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Darkvision 30 ft.; Passive Perception 10"
   },
   {
@@ -24000,6 +24319,7 @@
     "image": "/api/images/monsters/swarm-of-ravens.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 15"
   },
   {
@@ -24067,6 +24387,7 @@
     "image": "/api/images/monsters/swarm-of-venomous-snakes-NYI.png",
     "hit_points_roll": "8d8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 10 ft.; Passive Perception 10"
   },
   {
@@ -24121,6 +24442,7 @@
     "image": "/api/images/monsters/tiger.png",
     "hit_points_roll": "4d10 + 8",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -24172,6 +24494,7 @@
     "image": "/api/images/monsters/triceratops.png",
     "hit_points_roll": "12d12 + 36",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 10"
   },
   {
@@ -24247,6 +24570,7 @@
         }
       }
     ],
+    "proficiency_bonus": 3,
     "old_senses": "Passive Perception 14"
   },
   {
@@ -24296,6 +24620,7 @@
     "image": "/api/images/monsters/venomous-snake-NYI.png",
     "hit_points_roll": "2d4",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Blindsight 10 ft.; Passive Perception 10"
   },
   {
@@ -24349,6 +24674,7 @@
     "image": "/api/images/monsters/vulture.png",
     "hit_points_roll": "1d8 + 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Passive Perception 13"
   },
   {
@@ -24405,6 +24731,7 @@
         }
       }
     ],
+    "proficiency_bonus": 2,
     "old_senses": "Passive Perception 11"
   },
   {
@@ -24453,6 +24780,7 @@
     "image": "/api/images/monsters/weasel.png",
     "hit_points_roll": "1d4 − 1",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 13"
   },
   {
@@ -24505,6 +24833,7 @@
     "image": "/api/images/monsters/wolf.png",
     "hit_points_roll": "2d8 + 2",
     "proficiencies": [],
+    "proficiency_bonus": 0,
     "old_senses": "Darkvision 60 ft.; Passive Perception 15"
   }
 ]

--- a/src/2024/en/monsters.json
+++ b/src/2024/en/monsters.json
@@ -1,0 +1,22356 @@
+{
+  "_info": "Source file for all monsters in https://topoftheround.com based on D&D SRD 5.2.1 PDF",
+  "aboleth": {
+    "name": "Aboleth",
+    "slug": "aboleth",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "aberration",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 150,
+    "hit_dice": "20d10 + 40",
+    "speed": {
+      "walk": 10,
+      "swim": 40
+    },
+    "strength": 21,
+    "strength_save": 5,
+    "dexterity": 9,
+    "dexterity_save": 3,
+    "constitution": 15,
+    "constitution_save": 6,
+    "intelligence": 18,
+    "intelligence_save": 8,
+    "wisdom": 15,
+    "wisdom_save": 6,
+    "charisma": 18,
+    "charisma_save": 4,
+    "perception": 10,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 20",
+    "languages": "Deep Speech; telepathy 120 ft.",
+    "challenge_rating": "10",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The aboleth can breathe air and water."
+      },
+      {
+        "name": "Eldritch Restoration",
+        "desc": "If destroyed, the aboleth gains a new body in 5d10 days, reviving with all its Hit Points in the Far Realm or another location chosen by the GM."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the aboleth fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Mucus Cloud",
+        "desc": "While underwater, the aboleth is surrounded by mucus. Constitution Saving Throw: DC 14, each creature in a 5-foot Emanation originating from the aboleth at the end of the aboleth’s turn. Failure: The target is cursed. Until the curse ends, the target’s skin becomes slimy, the target can breathe air and water, and it can’t regain Hit Points unless it is underwater. While the cursed creature is outside a body of water, the creature takes 6 (1d12) Acid damage at the end of every 10 minutes unless moisture is applied to its skin before those minutes have passed."
+      },
+      {
+        "name": "Probing Telepathy",
+        "desc": "If a creature the aboleth can see communicates telepathically with the aboleth, the aboleth learns the creature’s greatest desires."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The aboleth makes two Tentacle attacks and uses either Consume Memories or Dominate Mind if available."
+      },
+      {
+        "name": "Tentacle",
+        "desc": "Melee Attack Roll: +9, reach 15 ft. Hit: 12 (2d6 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of four tentacles.",
+        "damage_dice": "2d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Consume Memories",
+        "desc": "Intelligence Saving Throw: DC 16, one creature within 30 feet that is Charmed or Grappled by the aboleth. Failure: 10 (3d6) Psychic damage. Success: Half damage. Failure or Success: The aboleth gains the target’s memories if the target is a Humanoid and is reduced to 0 Hit Points by this action.",
+        "damage_dice": "3d6"
+      },
+      {
+        "name": "Dominate Mind (2/Day)",
+        "desc": "Wisdom Saving Throw: DC 16, one creature the aboleth can see within 30 feet. Failure: The target has the Charmed condition until the aboleth dies or is on a different plane of existence from the target. While Charmed, the target acts as an ally to the aboleth and is under its control while within 60 feet of it. In addition, the aboleth and the target can communicate telepathically with each other over any distance. The target repeats the save whenever it takes damage as well as after every 24 hours it spends at least 1 mile away from the aboleth, ending the effect on itself on a success."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Lash",
+        "desc": "The aboleth makes one Tentacle attack."
+      },
+      {
+        "name": "Psychic Drain",
+        "desc": "If the aboleth has at least one creature Charmed or Grappled, it uses Consume Memories and regains 5 (1d10) Hit Points."
+      }
+    ]
+  },
+  "air-elemental": {
+    "name": "Air Elemental",
+    "slug": "air-elemental",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 90,
+    "hit_dice": "12d10 + 24",
+    "speed": {
+      "walk": 10,
+      "fly": 90,
+      "hover": true
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 20,
+    "dexterity_save": 5,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Lightning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison",
+      "Thunder"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Prone",
+      "Restrained",
+      "Unconscious"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Primordial (Auran)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Air Form",
+        "desc": "The elemental can enter a creature’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The elemental makes two Thunderous Slam attacks."
+      },
+      {
+        "name": "Thunderous Slam",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 14 (2d8 + 5) Thunder damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Whirlwind (Recharge 4–6)",
+        "desc": "Strength Saving Throw: DC 13, one Medium or smaller creature in the elemental’s space. Failure: 24 (4d10 + 2) Thunder damage, and the target is pushed up to 20 feet straight away from the elemental and has the Prone condition. Success: Half damage only. Animated Objects",
+        "damage_dice": "4d10",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "animated-armor": {
+    "name": "Animated Armor",
+    "slug": "animated-armor",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 33,
+    "hit_dice": "6d8 + 6",
+    "speed": {
+      "walk": 25
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 3,
+    "wisdom_save": -4,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison",
+      "Psychic"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Deafened",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned"
+    ],
+    "senses": "Blindsight 60 ft.; Passive Perception 6",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The armor makes two Slam attacks."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "animated-flying-sword": {
+    "name": "Animated Flying Sword",
+    "slug": "animated-flying-sword",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 14,
+    "hit_dice": "4d6",
+    "speed": {
+      "walk": 5,
+      "fly": 50,
+      "hover": true
+    },
+    "strength": 12,
+    "strength_save": 1,
+    "dexterity": 15,
+    "dexterity_save": 4,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 5,
+    "wisdom_save": -3,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison",
+      "Psychic"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Deafened",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned"
+    ],
+    "senses": "Blindsight 60 ft.; Passive Perception 7",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Slash",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "animated-rug-of-smothering": {
+    "name": "Animated Rug of Smothering",
+    "slug": "animated-rug-of-smothering",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 27,
+    "hit_dice": "5d10",
+    "speed": {
+      "walk": 10
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 3,
+    "wisdom_save": -4,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison",
+      "Psychic"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Deafened",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned"
+    ],
+    "senses": "Blindsight 60 ft.; Passive Perception 6",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Smother",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, the rug can give it the Grappled condition (escape DC 13) instead of dealing damage. Until the grapple ends, the target has the Blinded and Restrained conditions, is suffocating, and takes 10 (2d6 + 3) Bludgeoning damage at the start of each of its turns. The rug can smother only one creature at a time. While grappling the target, the rug can’t take this action, the rug halves the damage it takes (round down), and the target takes the same amount of damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "ankheg": {
+    "name": "Ankheg",
+    "slug": "ankheg",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 45,
+    "hit_dice": "6d10 + 12",
+    "speed": {
+      "walk": 30,
+      "burrow": 10
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft., Tremorsense 60 ft.;",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Tunneler",
+        "desc": "The ankheg can burrow through solid rock at half its Burrow Speed and leaves a 10-foot-diameter tunnel in its wake."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the ankheg), reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage plus 3 (1d6) Acid damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13).",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Acid Spray (Recharge 6)",
+        "desc": "Dexterity Saving Throw: DC 12, each creature in a 30-foot-long, 5-foot-wide Line. Failure: 14 (4d6) Acid damage. Success: Half damage.",
+        "damage_dice": "4d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "assassin": {
+    "name": "Assassin",
+    "slug": "assassin",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 97,
+    "hit_dice": "15d8 + 30",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 18,
+    "dexterity_save": 7,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 16,
+    "intelligence_save": 6,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 10,
+    "charisma_save": 0,
+    "perception": 6,
+    "damage_resistances": [
+      "Poison"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 16",
+    "languages": "Common, Thieves’ Cant",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Evasion",
+        "desc": "If the assassin is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the assassin instead takes no damage if it succeeds on the save and only half damage if it fails. It can’t use this trait if it has the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The assassin makes three attacks, using Shortsword or Light Crossbow in any combination."
+      },
+      {
+        "name": "Shortsword",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 7 (1d6 + 4) Piercing damage plus 17 (5d6) Poison damage, and the target has the Poisoned condition until the start of the assassin’s next turn.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Light Crossbow",
+        "desc": "Ranged Attack Roll: +7, range 80/320 ft. Hit: 8 (1d8 + 4) Piercing damage plus 21 (6d6) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Cunning Action",
+        "desc": "The assassin takes the Dash, Disengage, or Hide action. Awakened Plants"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "awakened-shrub": {
+    "name": "Awakened Shrub",
+    "slug": "awakened-shrub",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "plant",
+    "alignment": "neutral",
+    "armor_class": 9,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 10,
+    "hit_dice": "3d6",
+    "speed": {
+      "walk": 20
+    },
+    "strength": 3,
+    "strength_save": -4,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [
+      "Piercing"
+    ],
+    "damage_vulnerabilities": [
+      "Fire"
+    ],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common plus one other language",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rake",
+        "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 Slashing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "awakened-tree": {
+    "name": "Awakened Tree",
+    "slug": "awakened-tree",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "plant",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 59,
+    "hit_dice": "7d12 + 14",
+    "speed": {
+      "walk": 20
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 6,
+    "dexterity_save": -2,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing"
+    ],
+    "damage_vulnerabilities": [
+      "Fire"
+    ],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common plus one other language",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 14 (3d6 + 4) Bludgeoning damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "axe-beak": {
+    "name": "Axe Beak",
+    "slug": "axe-beak",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d10 + 3",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage. Azer",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "azer-sentinel": {
+    "name": "Azer Sentinel",
+    "slug": "azer-sentinel",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "elemental",
+    "alignment": "lawful neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 39,
+    "hit_dice": "6d8 + 12",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 15,
+    "constitution_save": 4,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 10,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Passive Perception 11",
+    "languages": "Primordial (Ignan)",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Fire Aura",
+        "desc": "At the end of each of the azer’s turns, each creature of the azer’s choice in a 5-foot Emanation originating from the azer takes 5 (1d10) Fire damage unless the azer has the Incapacitated condition."
+      },
+      {
+        "name": "Illumination",
+        "desc": "The azer sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Burning Hammer",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Bludgeoning damage plus 3 (1d6) Fire damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "balor": {
+    "name": "Balor",
+    "slug": "balor",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 287,
+    "hit_dice": "23d12 + 138",
+    "speed": {
+      "walk": 40,
+      "fly": 80
+    },
+    "strength": 26,
+    "strength_save": 8,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 22,
+    "constitution_save": 12,
+    "intelligence": 20,
+    "intelligence_save": 5,
+    "wisdom": 16,
+    "wisdom_save": 9,
+    "charisma": 22,
+    "charisma_save": 6,
+    "perception": 9,
+    "damage_resistances": [
+      "Cold",
+      "Lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Frightened",
+      "Poisoned"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 19",
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "19",
+    "special_abilities": [
+      {
+        "name": "Death Throes",
+        "desc": "The balor explodes when it dies. Dexterity Saving Throw: DC 20, each creature in a 30-foot"
+      },
+      {
+        "name": "Emanation originating from the balor",
+        "desc": "Failure: 31 (9d6) Fire damage plus 31 (9d6) Force damage. Success: Half damage. Failure or Success: If the balor dies outside the Abyss, it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Fire Aura",
+        "desc": "At the end of each of the balor’s turns, each creature in a 5-foot Emanation originating from the balor takes 13 (3d8) Fire damage."
+      },
+      {
+        "name": "Legendary Resistance (3/Day)",
+        "desc": "If the balor fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The balor has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The balor makes one Flame Whip attack and one Lightning Blade attack."
+      },
+      {
+        "name": "Flame Whip",
+        "desc": "Melee Attack Roll: +14, reach 30 ft. Hit: 18 (3d6 + 8) Force damage plus 17 (5d6) Fire damage. If the target is a Huge or smaller creature, the balor pulls the target up to 25 feet straight toward itself, and the target has the Prone condition.",
+        "damage_dice": "3d6",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Lightning Blade",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 21 (3d8 + 8) Force damage plus 22 (4d10) Lightning damage, and the target can’t take Reactions until the start of the balor’s next turn.",
+        "damage_dice": "3d8",
+        "damage_bonus": 8
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Teleport",
+        "desc": "The balor teleports itself or a willing demon within 10 feet of itself up to 60 feet to an unoccupied space the balor can see. Bandits"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "bandit": {
+    "name": "Bandit",
+    "slug": "bandit",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 10,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common, Thieves’ Cant",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Scimitar",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Light Crossbow",
+        "desc": "Ranged Attack Roll: +3, range 80/320 ft. Hit: 5 (1d8 + 1) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "bandit-captain": {
+    "name": "Bandit Captain",
+    "slug": "bandit-captain",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 52,
+    "hit_dice": "8d8 + 16",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 15,
+    "strength_save": 4,
+    "dexterity": 16,
+    "dexterity_save": 5,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 14,
+    "charisma_save": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common, Thieves’ Cant",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bandit makes two attacks, using Scimitar and Pistol in any combination."
+      },
+      {
+        "name": "Scimitar",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Pistol",
+        "desc": "Ranged Attack Roll: +5, range 30/90 ft. Hit: 8 (1d10 + 3) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The bandit is hit by a melee attack roll while holding a weapon. Response: The bandit adds 2 to its AC against that attack, possibly causing it to miss."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "barbed-devil": {
+    "name": "Barbed Devil",
+    "slug": "barbed-devil",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 110,
+    "hit_dice": "13d8 + 52",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 16,
+    "strength_save": 6,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 18,
+    "constitution_save": 7,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 14,
+    "wisdom_save": 5,
+    "charisma": 14,
+    "charisma_save": 5,
+    "perception": 8,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft. (unimpeded by magical",
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Barbed Hide",
+        "desc": "At the start of each of its turns, the devil deals 5 (1d10) Piercing damage to any creature it is grappling or any creature grappling it."
+      },
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes one Claws attack and one Tail attack, or it makes two Hurl Flame attacks."
+      },
+      {
+        "name": "Claws",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13) from both claws.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 14 (2d10 + 3) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Hurl Flame",
+        "desc": "Ranged Attack Roll: +5, range 150 ft. Hit: 17 (5d6) Fire damage. If the target is a flammable object that isn’t being worn or carried, it starts burning.",
+        "damage_dice": "5d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "basilisk": {
+    "name": "Basilisk",
+    "slug": "basilisk",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 52,
+    "hit_dice": "8d8 + 16",
+    "speed": {
+      "walk": 20
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Petrifying Gaze (Recharge 4–6)",
+        "desc": "Constitution Saving Throw: DC 12, each creature in a 30-foot Cone. If the basilisk sees its reflection in the Cone, the basilisk must make this save. First Failure: The target has the Restrained condition and repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition instead of the Restrained condition."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "bearded-devil": {
+    "name": "Bearded Devil",
+    "slug": "bearded-devil",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 58,
+    "hit_dice": "9d8 + 18",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 16,
+    "strength_save": 5,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 15,
+    "constitution_save": 4,
+    "intelligence": 9,
+    "intelligence_save": -1,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 14,
+    "charisma_save": 4,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Frightened",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft. (unimpeded by magical",
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes one Beard attack and one Infernal Glaive attack."
+      },
+      {
+        "name": "Beard",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage, and the target has the Poisoned condition until the start of the devil’s next turn. Until this poison ends, the target can’t regain Hit Points.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Infernal Glaive",
+        "desc": "Melee Attack Roll: +5, reach 10 ft. Hit: 8 (1d10 + 3) Slashing damage. If the target is a creature and doesn’t already have an infernal wound, it is subjected to the following effect. Constitution Saving Throw: DC 12. Failure: The target receives an infernal wound. While wounded, the target loses 5 (1d10) Hit",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Points at the start of each of its turns",
+        "desc": "The wound closes after 1 minute, after a spell restores Hit Points to the target, or after the target or a creature within 5 feet of it takes an action to stanch the wound, doing so by succeeding on a DC 12 Wisdom (Medicine) check."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "behir": {
+    "name": "Behir",
+    "slug": "behir",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 168,
+    "hit_dice": "16d12 + 64",
+    "speed": {
+      "walk": 50,
+      "climb": 50
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 12,
+    "charisma_save": 1,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 90 ft.; Passive Perception 16",
+    "languages": "Draconic",
+    "challenge_rating": "11",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The behir makes one Bite attack and uses Constrict."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 19 (2d12 + 6) Piercing damage plus 11 (2d10) Lightning damage.",
+        "damage_dice": "2d12",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 18, one Large or smaller creature the behir can see within 5 feet. Failure: 28 (5d8 + 6) Bludgeoning damage. The target has the Grappled condition (escape DC 16), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "5d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 16, each creature in a 90-foot-long, 5-footwide Line. Failure: 66 (12d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "12d10"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Swallow",
+        "desc": "Dexterity Saving Throw: DC 18, one Large or smaller creature Grappled by the behir (the behir can have only one creature swallowed at a time). Failure: The behir swallows the target, which is no longer Grappled. While swallowed, a creature has the Blinded and Restrained conditions, has Total Cover against attacks and other effects outside the behir, and takes 21 (6d6) Acid damage at the start of each of the behir’s turns. If the behir takes 30 damage or more on a single turn from the swallowed creature, the behir must succeed on a DC 14 Constitution saving throw at the end of that turn or regurgitate the creature, which falls in a space within 10 feet of the behir and has the Prone condition. If the behir dies, a swallowed creature is no longer Restrained and can escape from the corpse by using 15 feet of movement, exiting Prone."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "berserker": {
+    "name": "Berserker",
+    "slug": "berserker",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 67,
+    "hit_dice": "9d8 + 27",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 9,
+    "intelligence_save": -1,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 9,
+    "charisma_save": -1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Bloodied Frenzy",
+        "desc": "While Bloodied, the berserker has Advantage on attack rolls and saving throws."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Greataxe",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 9 (1d12 + 3) Slashing damage. Black Dragons",
+        "damage_dice": "1d12",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "black-dragon-wyrmling": {
+    "name": "Black Dragon Wyrmling",
+    "slug": "black-dragon-wyrmling",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 33,
+    "hit_dice": "6d8 + 6",
+    "speed": {
+      "walk": 30,
+      "fly": 60,
+      "swim": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 14,
+    "dexterity_save": 4,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 13,
+    "charisma_save": 1,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Draconic",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage plus 2 (1d4) Acid damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 11, each creature in a 15-foot-long, 5-footwide Line. Failure: 22 (5d8) Acid damage. Success: Half damage.",
+        "damage_dice": "5d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "young-black-dragon": {
+    "name": "Young Black Dragon",
+    "slug": "young-black-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 127,
+    "hit_dice": "15d10 + 45",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 5,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 11,
+    "wisdom_save": 3,
+    "charisma": 15,
+    "charisma_save": 2,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "7",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 9 (2d4 + 4) Slashing damage plus 3 (1d6) Acid damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 14, each creature in a 30-foot-long, 5-footwide Line. Failure: 49 (14d6) Acid damage. Success: Half damage.",
+        "damage_dice": "14d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "adult-black-dragon": {
+    "name": "Adult Black Dragon",
+    "slug": "adult-black-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 12,
+    "hit_points": 195,
+    "hit_dice": "17d12 + 85",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 14,
+    "dexterity_save": 7,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 13,
+    "wisdom_save": 6,
+    "charisma": 19,
+    "charisma_save": 4,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "14",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Acid Arrow (level 3 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 4 (1d8) Acid damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 18, each creature in a 60-foot-long, 5-footwide Line. Failure: 54 (12d8) Acid damage. Success: Half damage.",
+        "damage_dice": "12d8"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17, +9 to hit with spell attacks):",
+        "attack_bonus": 9
+      },
+      {
+        "name": "At Will",
+        "desc": "Acid Arrow (level 3 version), Detect Magic, Fear"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Speak with Dead, Vitriolic Sphere"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Cloud of Insects",
+        "desc": "Dexterity Saving Throw: DC 17, one creature the dragon can see within 120 feet. Failure: 22 (4d10) Poison damage, and the target has Disadvantage on saving throws to maintain Concentration until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "4d10"
+      },
+      {
+        "name": "Frightful Presence",
+        "desc": "The dragon uses Spellcasting to cast"
+      },
+      {
+        "name": "Fear",
+        "desc": "The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "ancient-black-dragon": {
+    "name": "Ancient Black Dragon",
+    "slug": "ancient-black-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 16,
+    "hit_points": 367,
+    "hit_dice": "21d20 + 147",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 27,
+    "strength_save": 8,
+    "dexterity": 14,
+    "dexterity_save": 9,
+    "constitution": 25,
+    "constitution_save": 7,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 15,
+    "wisdom_save": 9,
+    "charisma": 22,
+    "charisma_save": 6,
+    "perception": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "21",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Acid Arrow (level 4 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +15, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 9 (2d8) Acid damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 22, each creature in a 90-foot-long, 10-footwide Line. Failure: 67 (15d8) Acid damage. Success: Half damage.",
+        "damage_dice": "15d8"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks):",
+        "attack_bonus": 13
+      },
+      {
+        "name": "At Will",
+        "desc": "Acid Arrow (level 4 version), Detect Magic, Fear"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Create Undead, Speak with Dead, Vitriolic Sphere (level 5 version)"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Cloud of Insects",
+        "desc": "Dexterity Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 33 (6d10) Poison damage, and the target has Disadvantage on saving throws to maintain Concentration until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "6d10"
+      },
+      {
+        "name": "Frightful Presence",
+        "desc": "The dragon uses Spellcasting to cast"
+      },
+      {
+        "name": "Fear",
+        "desc": "The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "black-pudding": {
+    "name": "Black Pudding",
+    "slug": "black-pudding",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "ooze",
+    "alignment": "unaligned",
+    "armor_class": 7,
+    "armor_desc": "",
+    "initiative": -3,
+    "hit_points": 68,
+    "hit_dice": "8d10 + 24",
+    "speed": {
+      "walk": 20,
+      "climb": 20
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 5,
+    "dexterity_save": -3,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 6,
+    "wisdom_save": -2,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid",
+      "Cold",
+      "Lightning",
+      "Slashing"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Deafened",
+      "Exhaustion",
+      "Frightened",
+      "Grappled",
+      "Prone",
+      "Restrained"
+    ],
+    "senses": "Blindsight 60 ft.; Passive Perception 8",
+    "languages": "None",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Amorphous",
+        "desc": "The pudding can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Corrosive Form",
+        "desc": "A creature that hits the pudding with a melee attack roll takes 4 (1d8) Acid damage. Nonmagical ammunition is destroyed immediately after hitting the pudding and dealing any damage. Any nonmagical weapon takes a cumulative −1 penalty to attack rolls immediately after dealing damage to the pudding and coming into contact with it. The weapon is destroyed if the penalty reaches −5. The penalty can be removed by casting the Mending spell on the weapon. In 1 minute, the pudding can eat through 2 feet of nonmagical wood or metal."
+      },
+      {
+        "name": "Spider Climb",
+        "desc": "The pudding can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Dissolving Pseudopod",
+        "desc": "Melee Attack Roll: +5, reach 10 ft. Hit: 17 (4d6 + 3) Acid damage. Nonmagical armor worn by the target takes a −1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10. The penalty can be removed by casting the Mending spell on the armor.",
+        "damage_dice": "4d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Split",
+        "desc": "Trigger: While the pudding is Large or Medium and has 10+ Hit Points, it becomes Bloodied or is subjected to Lightning or Slashing damage. Response: The pudding splits into two new Black Puddings. Each new pudding is one size smaller than the original pudding and acts on its Initiative. The original pudding’s Hit Points are divided evenly between the new puddings (round down)."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "blink-dog": {
+    "name": "Blink Dog",
+    "slug": "blink-dog",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "lawful good",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 22,
+    "hit_dice": "4d8 + 4",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 12,
+    "strength_save": 1,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 11,
+    "charisma_save": 0,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "Blink Dog; understands Elvish and Sylvan but",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Teleport (Recharge 4–6)",
+        "desc": "The dog teleports up to 40 feet to an unoccupied space it can see. Blue Dragons"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "blue-dragon-wyrmling": {
+    "name": "Blue Dragon Wyrmling",
+    "slug": "blue-dragon-wyrmling",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 65,
+    "hit_dice": "10d8 + 20",
+    "speed": {
+      "walk": 30,
+      "burrow": 15,
+      "fly": 60
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 10,
+    "dexterity_save": 2,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 15,
+    "charisma_save": 2,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Draconic",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage plus 3 (1d6) Lightning damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 12, each creature in a 30-foot-long, 5-footwide Line. Failure: 21 (6d6) Lightning damage. Success: Half damage.",
+        "damage_dice": "6d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "young-blue-dragon": {
+    "name": "Young Blue Dragon",
+    "slug": "young-blue-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 152,
+    "hit_dice": "16d10 + 64",
+    "speed": {
+      "walk": 40,
+      "burrow": 20,
+      "fly": 80
+    },
+    "strength": 21,
+    "strength_save": 5,
+    "dexterity": 10,
+    "dexterity_save": 4,
+    "constitution": 19,
+    "constitution_save": 4,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 13,
+    "wisdom_save": 5,
+    "charisma": 17,
+    "charisma_save": 3,
+    "perception": 9,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "9",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 12 (2d6 + 5) Slashing damage plus 5 (1d10) Lightning damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 16, each creature in a 60-foot-long, 5-footwide Line. Failure: 55 (10d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "10d10"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "adult-blue-dragon": {
+    "name": "Adult Blue Dragon",
+    "slug": "adult-blue-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 212,
+    "hit_dice": "17d12 + 102",
+    "speed": {
+      "walk": 40,
+      "burrow": 30,
+      "fly": 80
+    },
+    "strength": 25,
+    "strength_save": 7,
+    "dexterity": 10,
+    "dexterity_save": 5,
+    "constitution": 23,
+    "constitution_save": 6,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 15,
+    "wisdom_save": 7,
+    "charisma": 20,
+    "charisma_save": 5,
+    "perception": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "16",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Shatter."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 16 (2d8 + 7) Slashing damage plus 5 (1d10) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 19, each creature in a 90-foot-long, 5-footwide Line. Failure: 60 (11d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "11d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Invisibility, Mage Hand, Shatter"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Scrying, Sending"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Cloaked Flight",
+        "desc": "The dragon uses Spellcasting to cast Invisibility on itself, and it can fly up to half its Fly Speed. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Sonic Boom",
+        "desc": "The dragon uses Spellcasting to cast Shatter. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Tail Swipe",
+        "desc": "The dragon makes one Rend attack."
+      }
+    ]
+  },
+  "ancient-blue-dragon": {
+    "name": "Ancient Blue Dragon",
+    "slug": "ancient-blue-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 481,
+    "hit_dice": "26d20 + 208",
+    "speed": {
+      "walk": 40,
+      "burrow": 40,
+      "fly": 80
+    },
+    "strength": 29,
+    "strength_save": 9,
+    "dexterity": 10,
+    "dexterity_save": 7,
+    "constitution": 27,
+    "constitution_save": 8,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 17,
+    "wisdom_save": 10,
+    "charisma": 25,
+    "charisma_save": 7,
+    "perception": 17,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "23",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Shatter (level 3 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +16, reach 15 ft. Hit: 18 (2d8 + 9) Slashing damage plus 11 (2d10) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 23, each creature in a 120-foot-long, 10-foot-wide Line. Failure: 88 (16d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "16d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Invisibility, Mage Hand, Shatter (level 3 version)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Scrying, Sending"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Cloaked Flight",
+        "desc": "The dragon uses Spellcasting to cast Invisibility on itself, and it can fly up to half its Fly Speed. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Sonic Boom",
+        "desc": "The dragon uses Spellcasting to cast Shatter (level 3 version). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Tail Swipe",
+        "desc": "The dragon makes one Rend attack."
+      }
+    ]
+  },
+  "bone-devil": {
+    "name": "Bone Devil",
+    "slug": "bone-devil",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 161,
+    "hit_dice": "17d10 + 68",
+    "speed": {
+      "walk": 40,
+      "fly": 40
+    },
+    "strength": 18,
+    "strength_save": 8,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 13,
+    "intelligence_save": 5,
+    "wisdom": 14,
+    "wisdom_save": 6,
+    "charisma": 16,
+    "charisma_save": 7,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft. (unimpeded by magical",
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "9",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes two Claw attacks and one Infernal Sting attack."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 13 (2d8 + 4) Slashing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Infernal Sting",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 15 (2d10 + 4) Piercing damage plus 18 (4d8) Poison damage, and the target has the Poisoned condition until the start of the devil’s next turn. While Poisoned, the target can’t regain Hit Points. Brass Dragons",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "brass-dragon-wyrmling": {
+    "name": "Brass Dragon Wyrmling",
+    "slug": "brass-dragon-wyrmling",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "4d8 + 4",
+    "speed": {
+      "walk": 30,
+      "burrow": 15,
+      "fly": 60
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 10,
+    "dexterity_save": 2,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 13,
+    "charisma_save": 1,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Draconic",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 11, each creature in a 20-foot-long, 5-footwide Line. Failure: 14 (4d6) Fire damage. Success: Half damage.",
+        "damage_dice": "4d6"
+      },
+      {
+        "name": "Sleep Breath",
+        "desc": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 1 minute. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "young-brass-dragon": {
+    "name": "Young Brass Dragon",
+    "slug": "young-brass-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 110,
+    "hit_dice": "13d10 + 39",
+    "speed": {
+      "walk": 40,
+      "burrow": 20,
+      "fly": 80
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 3,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 11,
+    "wisdom_save": 3,
+    "charisma": 15,
+    "charisma_save": 2,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace two attacks with a use of Sleep Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 15 (2d10 + 4) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 14, each creature in a 40-foot-long, 5-footwide Line. Failure: 38 (11d6) Fire damage. Success: Half damage.",
+        "damage_dice": "11d6"
+      },
+      {
+        "name": "Sleep Breath",
+        "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 1 minute. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "adult-brass-dragon": {
+    "name": "Adult Brass Dragon",
+    "slug": "adult-brass-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 172,
+    "hit_dice": "15d12 + 75",
+    "speed": {
+      "walk": 40,
+      "burrow": 30,
+      "fly": 80
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 10,
+    "dexterity_save": 5,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 13,
+    "wisdom_save": 6,
+    "charisma": 17,
+    "charisma_save": 3,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Sleep Breath or (B) Spellcasting to cast Scorching Ray."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage plus 4 (1d8) Fire damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 18, each creature in a 60-foot-long, 5-footwide Line. Failure: 45 (10d8) Fire damage. Success: Half damage.",
+        "damage_dice": "10d8"
+      },
+      {
+        "name": "Sleep Breath",
+        "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 10 minutes. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Minor Illusion, Scorching Ray, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Detect Thoughts, Control Weather"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Blazing Light",
+        "desc": "The dragon uses Spellcasting to cast Scorching Ray."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      },
+      {
+        "name": "Scorching Sands",
+        "desc": "Dexterity Saving Throw: DC 16, one creature the dragon can see within 120 feet. Failure: 27 (6d8) Fire damage, and the target’s Speed is halved until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "6d8"
+      }
+    ]
+  },
+  "ancient-brass-dragon": {
+    "name": "Ancient Brass Dragon",
+    "slug": "ancient-brass-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 12,
+    "hit_points": 332,
+    "hit_dice": "19d20 + 133",
+    "speed": {
+      "walk": 40,
+      "burrow": 40,
+      "fly": 80
+    },
+    "strength": 27,
+    "strength_save": 8,
+    "dexterity": 10,
+    "dexterity_save": 6,
+    "constitution": 25,
+    "constitution_save": 7,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 15,
+    "wisdom_save": 8,
+    "charisma": 22,
+    "charisma_save": 6,
+    "perception": 14,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "20",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Sleep Breath or (B) Spellcasting to cast Scorching Ray (level 3 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +14, reach 15 ft. Hit: 19 (2d10 + 8) Slashing damage plus 7 (2d6) Fire damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 21, each creature in a 90-foot-long, 5-footwide Line. Failure: 58 (13d8) Fire damage. Success: Half damage.",
+        "damage_dice": "13d8"
+      },
+      {
+        "name": "Sleep Breath",
+        "desc": "Constitution Saving Throw: DC 21, each creature in a 90-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 10 minutes. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Minor Illusion, Scorching Ray (level 3 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Control Weather, Detect Thoughts"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Blazing Light",
+        "desc": "The dragon uses Spellcasting to cast Scorching Ray (level 3 version)."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      },
+      {
+        "name": "Scorching Sands",
+        "desc": "Dexterity Saving Throw: DC 20, one creature the dragon can see within 120 feet. Failure: 36 (8d8) Fire damage, and the target’s Speed is halved until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn. Bronze Dragons",
+        "damage_dice": "8d8"
+      }
+    ]
+  },
+  "bronze-dragon-wyrmling": {
+    "name": "Bronze Dragon Wyrmling",
+    "slug": "bronze-dragon-wyrmling",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 39,
+    "hit_dice": "6d8 + 12",
+    "speed": {
+      "walk": 30,
+      "fly": 60,
+      "swim": 30
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 10,
+    "dexterity_save": 2,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 15,
+    "charisma_save": 2,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Draconic",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 12, each creature in a 40-foot-long, 5-footwide Line. Failure: 16 (3d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "3d10"
+      },
+      {
+        "name": "Repulsion Breath",
+        "desc": "Strength Saving Throw: DC 12, each creature in a 30-foot Cone. Failure: The target is pushed up to 30 feet straight away from the dragon and has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "young-bronze-dragon": {
+    "name": "Young Bronze Dragon",
+    "slug": "young-bronze-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 142,
+    "hit_dice": "15d10 + 60",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 21,
+    "strength_save": 5,
+    "dexterity": 10,
+    "dexterity_save": 3,
+    "constitution": 19,
+    "constitution_save": 4,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 13,
+    "wisdom_save": 4,
+    "charisma": 17,
+    "charisma_save": 3,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Repulsion Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 15, each creature in a 60-foot-long, 5-footwide Line. Failure: 49 (9d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "9d10"
+      },
+      {
+        "name": "Repulsion Breath",
+        "desc": "Strength Saving Throw: DC 15, each creature in a 30-foot Cone. Failure: The target is pushed up to 40 feet straight away from the dragon and has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "adult-bronze-dragon": {
+    "name": "Adult Bronze Dragon",
+    "slug": "adult-bronze-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 212,
+    "hit_dice": "17d12 + 102",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 25,
+    "strength_save": 7,
+    "dexterity": 10,
+    "dexterity_save": 5,
+    "constitution": 23,
+    "constitution_save": 6,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 15,
+    "wisdom_save": 7,
+    "charisma": 20,
+    "charisma_save": 5,
+    "perception": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "15",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Repulsion Breath or (B) Spellcasting to cast Guiding Bolt (level 2 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 16 (2d8 + 7) Slashing damage plus 5 (1d10) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 19, each creature in a 90-foot-long, 5-footwide Line. Failure: 55 (10d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "10d10"
+      },
+      {
+        "name": "Repulsion Breath",
+        "desc": "Strength Saving Throw: DC 19, each creature in a 30-foot Cone. Failure: The target is pushed up to 60 feet straight away from the dragon and has the Prone condition."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17, +10 to hit with spell attacks):",
+        "attack_bonus": 10
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals, Thaumaturgy"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Detect Thoughts, Water Breathing"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Guiding Light",
+        "desc": "The dragon uses Spellcasting to cast Guiding Bolt (level 2 version)."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      },
+      {
+        "name": "Thunderclap",
+        "desc": "Constitution Saving Throw: DC 17, each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 10 (3d6) Thunder damage, and the target has the Deafened condition until the end of its next turn.",
+        "damage_dice": "3d6"
+      }
+    ]
+  },
+  "ancient-bronze-dragon": {
+    "name": "Ancient Bronze Dragon",
+    "slug": "ancient-bronze-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 444,
+    "hit_dice": "24d20 + 192",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 29,
+    "strength_save": 9,
+    "dexterity": 10,
+    "dexterity_save": 7,
+    "constitution": 27,
+    "constitution_save": 8,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 17,
+    "wisdom_save": 10,
+    "charisma": 25,
+    "charisma_save": 7,
+    "perception": 17,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "22",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Repulsion Breath or (B) Spellcasting to cast Guiding Bolt (level 2 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +16, reach 15 ft. Hit: 18 (2d8 + 9) Slashing damage plus 9 (2d8) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Lightning Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 23, each creature in a 120-foot-long, 10-foot-wide Line. Failure: 82 (15d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "15d10"
+      },
+      {
+        "name": "Repulsion Breath",
+        "desc": "Strength Saving Throw: DC 23, each creature in a 30-foot Cone. Failure: The target is pushed up to 60 feet straight away from the dragon and has the Prone condition."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22, +14 to hit with spell attacks):",
+        "attack_bonus": 14
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals, Thaumaturgy"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Detect Thoughts, Control Water, Scrying, Water Breathing"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Guiding Light",
+        "desc": "The dragon uses Spellcasting to cast Guiding Bolt (level 2 version)."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      },
+      {
+        "name": "Thunderclap",
+        "desc": "Constitution Saving Throw: DC 22, each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 13 (3d8) Thunder damage, and the target has the Deafened condition until the end of its next turn. Bugbears",
+        "damage_dice": "3d8"
+      }
+    ]
+  },
+  "bugbear-stalker": {
+    "name": "Bugbear Stalker",
+    "slug": "bugbear-stalker",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 65,
+    "hit_dice": "10d8 + 20",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 14,
+    "constitution_save": 4,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 12,
+    "wisdom_save": 3,
+    "charisma": 11,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 11",
+    "languages": "Common, Goblin",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Abduct",
+        "desc": "The bugbear needn’t spend extra movement to move a creature it is grappling."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bugbear makes two Javelin or Morningstar attacks."
+      },
+      {
+        "name": "Javelin",
+        "desc": "Melee or Ranged Attack Roll: +5, reach 10 ft. or range 30/120 ft. Hit: 13 (3d6 + 3) Piercing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Morningstar",
+        "desc": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the bugbear), reach 10 ft. Hit: 12 (2d8 + 3) Piercing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Quick Grapple",
+        "desc": "Dexterity Saving Throw: DC 13, one Medium or smaller creature the bugbear can see within 10 feet. Failure: The target has the Grappled condition (escape DC 13)."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "bugbear-warrior": {
+    "name": "Bugbear Warrior",
+    "slug": "bugbear-warrior",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "chaotic evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 33,
+    "hit_dice": "6d8 + 6",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 8,
+    "intelligence_save": -1,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 9,
+    "charisma_save": -1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Common, Goblin",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Abduct",
+        "desc": "The bugbear needn’t spend extra movement to move a creature it is grappling."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Grab",
+        "desc": "Melee Attack Roll: +4, reach 10 ft. Hit: 9 (2d6 + 2) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12).",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Light Hammer",
+        "desc": "Melee or Ranged Attack Roll: +4 (with Advantage if the target is Grappled by the bugbear), reach 10 ft. or range 20/60 ft. Hit: 9 (3d4 + 2) Bludgeoning damage.",
+        "damage_dice": "3d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "bulette": {
+    "name": "Bulette",
+    "slug": "bulette",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 94,
+    "hit_dice": "9d10 + 45",
+    "speed": {
+      "walk": 40,
+      "burrow": 40
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Tremorsense 120 ft.;",
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bulette makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 17 (2d12 + 4) Piercing damage.",
+        "damage_dice": "2d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Deadly Leap",
+        "desc": "The bulette spends 5 feet of movement to jump to a space within 15 feet that contains one or more Large or smaller creatures. Dexterity Saving Throw: DC 15, each creature in the bulette’s destination space. Failure: 19 (3d12) Bludgeoning damage, and the target has the Prone condition. Success: Half damage, and the target is pushed 5 feet straight away from the bulette.",
+        "damage_dice": "3d12"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Leap",
+        "desc": "The bulette jumps up to 30 feet by spending 10 feet of movement. Centaur"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "centaur-trooper": {
+    "name": "Centaur Trooper",
+    "slug": "centaur-trooper",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fey",
+    "alignment": "neutral good",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 45,
+    "hit_dice": "6d10 + 12",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 9,
+    "intelligence_save": -1,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 11,
+    "charisma_save": 0,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 13",
+    "languages": "Elvish, Sylvan",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The centaur makes two attacks, using Pike or Longbow in any combination."
+      },
+      {
+        "name": "Pike",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Longbow",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Trampling Charge (Recharge 5–6)",
+        "desc": "The centaur moves up to its Speed without provoking Opportunity Attacks and can move through the spaces of Medium or smaller creatures. Each creature whose space the centaur enters is targeted once by the following effect. Strength Saving Throw: DC 14. Failure: 7 (1d6 + 4) Bludgeoning damage, and the target has the Prone condition."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "chain-devil": {
+    "name": "Chain Devil",
+    "slug": "chain-devil",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 85,
+    "hit_dice": "10d8 + 40",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 18,
+    "constitution_save": 7,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 12,
+    "wisdom_save": 4,
+    "charisma": 14,
+    "charisma_save": 2,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Cold",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft. (unimpeded by magical",
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes two Chain attacks and uses Conjure Infernal Chain."
+      },
+      {
+        "name": "Chain",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of two chains, and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Conjure Infernal Chain",
+        "desc": "The devil conjures a fiery chain to bind a creature. Dexterity Saving Throw: DC 15, one creature the devil can see within 60 feet. Failure: 9 (2d4 + 4) Fire damage, and the target has the Restrained condition until the end of the devil’s next turn, at which point the chain disappears. If the target is Large or smaller, the devil moves the target up to 30 feet straight toward itself. Success: The chain disappears.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Unnerving Gaze",
+        "desc": "Trigger: A creature the devil can see starts its turn within 30 feet of the devil and can see the devil. Response—Wisdom Saving Throw: DC 15, the triggering creature. Failure: The target has the"
+      },
+      {
+        "name": "Frightened condition until the end of its turn",
+        "desc": "Success: The target is immune to this devil’s Unnerving Gaze for 24 hours."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "chimera": {
+    "name": "Chimera",
+    "slug": "chimera",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 114,
+    "hit_dice": "12d10 + 48",
+    "speed": {
+      "walk": 30,
+      "fly": 60
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 19,
+    "constitution_save": 4,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 10,
+    "charisma_save": 0,
+    "perception": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 18",
+    "languages": "Understands Draconic but can’t speak",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The chimera makes one Ram attack, one Bite attack, and one Claw attack. It can replace the Claw attack with a use of Fire Breath if available."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage, or 18 (4d6 + 4) Piercing damage if the chimera had Advantage on the attack roll.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 7 (1d6 + 4) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 10 (1d12 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+        "damage_dice": "1d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 15, each creature in a 15-foot Cone. Failure: 31 (7d8) Fire damage. Success: Half damage.",
+        "damage_dice": "7d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "chuul": {
+    "name": "Chuul",
+    "slug": "chuul",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "aberration",
+    "alignment": "chaotic evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 76,
+    "hit_dice": "9d10 + 27",
+    "speed": {
+      "walk": 30,
+      "swim": 30
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Understands Deep Speech but can’t speak",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The chuul can breathe air and water."
+      },
+      {
+        "name": "Sense Magic",
+        "desc": "The chuul senses magic within 120 feet of itself. This trait otherwise works like the Detect Magic spell but isn’t itself magical."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The chuul makes two Pincer attacks and uses Paralyzing Tentacles."
+      },
+      {
+        "name": "Pincer",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of two pincers.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Paralyzing Tentacles",
+        "desc": "Constitution Saving Throw: DC 13, one creature Grappled by the chuul. Failure: The target has the Poisoned condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically. While Poisoned, the target has the Paralyzed condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "clay-golem": {
+    "name": "Clay Golem",
+    "slug": "clay-golem",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 123,
+    "hit_dice": "13d10 + 52",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 20,
+    "strength_save": 5,
+    "dexterity": 9,
+    "dexterity_save": -1,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid",
+      "Poison",
+      "Psychic"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "Common plus one other language",
+    "challenge_rating": "9",
+    "special_abilities": [
+      {
+        "name": "Acid Absorption",
+        "desc": "Whenever the golem is subjected to Acid damage, it takes no damage and instead regains a number of Hit Points equal to the Acid damage dealt."
+      },
+      {
+        "name": "Berserk",
+        "desc": "Whenever the golem starts its turn Bloodied, roll 1d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it continues to be berserk until it is destroyed or it is no longer Bloodied."
+      },
+      {
+        "name": "Immutable Form",
+        "desc": "The golem can’t shape-shift."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The golem makes two Slam attacks, or it makes three Slam attacks if it used Hasten this turn."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 10 (1d10 + 5) Bludgeoning damage plus 6 (1d12) Acid damage, and the target’s Hit Point maximum decreases by an amount equal to the Acid damage taken.",
+        "damage_dice": "1d10",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Hasten (Recharge 5–6)",
+        "desc": "The golem takes the Dash and Disengage actions."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "cloaker": {
+    "name": "Cloaker",
+    "slug": "cloaker",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "aberration",
+    "alignment": "chaotic neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 91,
+    "hit_dice": "14d10 + 14",
+    "speed": {
+      "walk": 10,
+      "fly": 40
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 13,
+    "intelligence_save": 1,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Frightened"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 12",
+    "languages": "Deep Speech, Undercommon",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Light Sensitivity",
+        "desc": "While in Bright Light, the cloaker has Disadvantage on attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The cloaker makes one Attach attack and two Tail attacks."
+      },
+      {
+        "name": "Attach",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (3d6 + 3) Piercing damage. If the target is a Large or smaller creature, the cloaker attaches to it. While the cloaker is attached, the target has the Blinded condition, and the cloaker can’t make Attach attacks against other targets. In addition, the cloaker halves the damage it takes (round down), and the target takes the same amount of damage. The cloaker can detach itself by spending 5 feet of movement. The target or a creature within 5 feet of it can take an action to try to detach the cloaker, doing so by succeeding on a DC 14 Strength (Athletics) check.",
+        "damage_dice": "3d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Moan",
+        "desc": "Wisdom Saving Throw: DC 13, each creature in a 60-foot Emanation originating from the cloaker. Failure: The target has the Frightened condition until the end of the cloaker’s next turn. Success: The target is immune to this cloaker’s Moan for the next 24 hours."
+      },
+      {
+        "name": "Phantasms (Recharge after a Short or Long Rest)",
+        "desc": "The cloaker casts the Mirror Image spell, requiring no spell components and using Wisdom as the spellcasting ability. The spell ends early if the cloaker starts or ends its turn in Bright Light."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "cloud-giant": {
+    "name": "Cloud Giant",
+    "slug": "cloud-giant",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 200,
+    "hit_dice": "16d12 + 96",
+    "speed": {
+      "walk": 40,
+      "fly": 20,
+      "hover": true
+    },
+    "strength": 27,
+    "strength_save": 8,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 22,
+    "constitution_save": 10,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 16,
+    "wisdom_save": 7,
+    "charisma": 16,
+    "charisma_save": 3,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 21",
+    "languages": "Common, Giant",
+    "challenge_rating": "9",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Thunderous Mace or Thundercloud in any combination. It can replace one attack with a use of Spellcasting to cast Fog Cloud."
+      },
+      {
+        "name": "Thunderous Mace",
+        "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 21 (3d8 + 8) Bludgeoning damage plus 7 (2d6) Thunder damage.",
+        "damage_dice": "3d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Thundercloud",
+        "desc": "Ranged Attack Roll: +12, range 240 ft. Hit: 18 (3d6 + 8) Thunder damage, and the target has the Incapacitated condition until the end of its next turn.",
+        "damage_dice": "3d6",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The giant casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Fog Cloud, Light"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Control Weather, Gaseous Form, Telekinesis"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Misty Step",
+        "desc": "The giant casts the Misty Step spell, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "cockatrice": {
+    "name": "Cockatrice",
+    "slug": "cockatrice",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 22,
+    "hit_dice": "5d6 + 5",
+    "speed": {
+      "walk": 20,
+      "fly": 40
+    },
+    "strength": 6,
+    "strength_save": -2,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Petrified"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Petrifying Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Piercing damage. If the target is a creature, it is subjected to the following effect. Constitution Saving Throw: DC 11. First Failure: The target has the Restrained condition. The target repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition, instead of the Restrained condition, for 24 hours.",
+        "damage_dice": "1d4",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "commoner": {
+    "name": "Commoner",
+    "slug": "commoner",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 4,
+    "hit_dice": "1d8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 10,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Training",
+        "desc": "The commoner has proficiency in one skill of the GM’s choice and has Advantage whenever it makes an ability check using that skill."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Club",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Bludgeoning damage. Copper Dragons",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "copper-dragon-wyrmling": {
+    "name": "Copper Dragon Wyrmling",
+    "slug": "copper-dragon-wyrmling",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 22,
+    "hit_dice": "4d8 + 4",
+    "speed": {
+      "walk": 30,
+      "climb": 30,
+      "fly": 60
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 12,
+    "dexterity_save": 3,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 13,
+    "charisma_save": 1,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Draconic",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 11, each creature in a 20-foot-long, 5-footwide Line. Failure: 18 (4d8) Acid damage. Success: Half damage.",
+        "damage_dice": "4d8"
+      },
+      {
+        "name": "Slowing Breath",
+        "desc": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "young-copper-dragon": {
+    "name": "Young Copper Dragon",
+    "slug": "young-copper-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 119,
+    "hit_dice": "14d10 + 42",
+    "speed": {
+      "walk": 40,
+      "climb": 40,
+      "fly": 80
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 12,
+    "dexterity_save": 4,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 13,
+    "wisdom_save": 4,
+    "charisma": 15,
+    "charisma_save": 2,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "7",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Slowing Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 15 (2d10 + 4) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 14, each creature in a 40-foot-long, 5-footwide Line. Failure: 40 (9d8) Acid damage. Success: Half damage.",
+        "damage_dice": "9d8"
+      },
+      {
+        "name": "Slowing Breath",
+        "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "adult-copper-dragon": {
+    "name": "Adult Copper Dragon",
+    "slug": "adult-copper-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 11,
+    "hit_points": 184,
+    "hit_dice": "16d12 + 80",
+    "speed": {
+      "walk": 40,
+      "climb": 40,
+      "fly": 80
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 12,
+    "dexterity_save": 6,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 15,
+    "wisdom_save": 7,
+    "charisma": 18,
+    "charisma_save": 4,
+    "perception": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "14",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Slowing Breath or (B) Spellcasting to cast Mind Spike (level 4 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage plus 4 (1d8) Acid damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 18, each creature in an 60-foot-long, 5-footwide Line. Failure: 54 (12d8) Acid damage. Success: Half damage.",
+        "damage_dice": "12d8"
+      },
+      {
+        "name": "Slowing Breath",
+        "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Mind Spike (level 4 version), Minor Illusion, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Greater Restoration, Major Image"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Giggling Magic",
+        "desc": "Charisma Saving Throw: DC 17, one creature the dragon can see within 90 feet. Failure: 24 (7d6) Psychic damage. Until the end of its next turn, the target rolls 1d6 whenever it makes an ability check or attack roll and subtracts the number rolled from the D20 Test. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "7d6"
+      },
+      {
+        "name": "Mind Jolt",
+        "desc": "The dragon uses Spellcasting to cast Mind"
+      },
+      {
+        "name": "Spike (level 4 version)",
+        "desc": "The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "ancient-copper-dragon": {
+    "name": "Ancient Copper Dragon",
+    "slug": "ancient-copper-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "chaotic good",
+    "armor_class": 21,
+    "armor_desc": "",
+    "initiative": 15,
+    "hit_points": 367,
+    "hit_dice": "21d20 + 147",
+    "speed": {
+      "walk": 40,
+      "climb": 40,
+      "fly": 80
+    },
+    "strength": 27,
+    "strength_save": 8,
+    "dexterity": 12,
+    "dexterity_save": 8,
+    "constitution": 25,
+    "constitution_save": 7,
+    "intelligence": 20,
+    "intelligence_save": 5,
+    "wisdom": 17,
+    "wisdom_save": 10,
+    "charisma": 22,
+    "charisma_save": 6,
+    "perception": 17,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "21",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Slowing Breath or (B) Spellcasting to cast Mind Spike (level 5 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +15, reach 15 ft. Hit: 19 (2d10 + 8) Slashing damage plus 9 (2d8) Acid damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Acid Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 22, each creature in an 90-foot-long, 10-footwide Line. Failure: 63 (14d8) Acid damage. Success: Half damage.",
+        "damage_dice": "14d8"
+      },
+      {
+        "name": "Slowing Breath",
+        "desc": "Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both. This effect lasts until the end of its next turn."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Mind Spike (level 5 version), Minor Illusion, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Greater Restoration, Major Image, Project Image"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Giggling Magic",
+        "desc": "Charisma Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 31 (9d6) Psychic damage. Until the end of its next turn, the target rolls 1d8 whenever it makes an ability check or attack roll and subtracts the number rolled from the D20 Test. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "9d6"
+      },
+      {
+        "name": "Mind Jolt",
+        "desc": "The dragon uses Spellcasting to cast Mind"
+      },
+      {
+        "name": "Spike (level 5 version)",
+        "desc": "The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "couatl": {
+    "name": "Couatl",
+    "slug": "couatl",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 60,
+    "hit_dice": "8d8 + 24",
+    "speed": {
+      "walk": 30,
+      "fly": 90
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 20,
+    "dexterity_save": 5,
+    "constitution": 17,
+    "constitution_save": 5,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 20,
+    "wisdom_save": 7,
+    "charisma": 18,
+    "charisma_save": 4,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Psychic",
+      "Radiant"
+    ],
+    "condition_immunities": [],
+    "senses": "Truesight 120 ft.; Passive Perception 15",
+    "languages": "All; telepathy 120 ft.",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Shielded Mind",
+        "desc": "The couatl’s thoughts can’t be read by any means, and other creatures can communicate with it telepathically only if it allows them."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (1d12 + 5) Piercing damage, and the target has the Poisoned condition until the end of the couatl’s next turn.",
+        "damage_dice": "1d12",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 15, one Medium or smaller creature the couatl can see within 5 feet. Failure: 8 (1d6 + 5) Bludgeoning damage. The target has the Grappled condition (escape DC 13), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "1d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The couatl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability (spell save DC 15):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Detect Magic, Detect Thoughts, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Create Food and Water, Dream, Greater Restoration, Scrying, Sleep"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (2/Day)",
+        "desc": "The couatl casts Bless, Lesser Restoration, or Sanctuary, requiring no spell components and using the same spellcasting ability as Spellcasting. Crawling Claw"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "swarm-of-crawling-claws": {
+    "name": "Swarm of Crawling Claws",
+    "slug": "swarm-of-crawling-claws",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "swarm of tiny undead",
+    "alignment": "neutral evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 49,
+    "hit_dice": "11d8",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 4,
+    "charisma_save": -3,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Necrotic",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Grappled",
+      "Incapacitated",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Prone",
+      "Restrained",
+      "Stunned"
+    ],
+    "senses": "Blindsight 30 ft.; Passive Perception 10",
+    "languages": "Understands Common but can’t speak",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny creature. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Swarm of Grasping Hands",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 20 (4d8 + 2) Necrotic damage, or 11 (2d8 + 2) Necrotic damage if the swarm is Bloodied. If the target is a Medium or smaller creature, it has the Prone condition. Cultists",
+        "damage_dice": "4d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "cultist": {
+    "name": "Cultist",
+    "slug": "cultist",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 9,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 10,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Ritual Sickle",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 1 Necrotic damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "cultist-fanatic": {
+    "name": "Cultist Fanatic",
+    "slug": "cultist-fanatic",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 44,
+    "hit_dice": "8d8 + 8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 14,
+    "wisdom_save": 4,
+    "charisma": 13,
+    "charisma_save": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "Common",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Pact Blade",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 7 (2d6) Necrotic damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The cultist casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks):",
+        "attack_bonus": 4
+      },
+      {
+        "name": "At Will",
+        "desc": "Light, Thaumaturgy"
+      },
+      {
+        "name": "2/Day",
+        "desc": "Command"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Hold Person"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Spiritual Weapon (2/Day)",
+        "desc": "The cultist casts the Spiritual Weapon spell, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "darkmantle": {
+    "name": "Darkmantle",
+    "slug": "darkmantle",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "aberration",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 22,
+    "hit_dice": "5d6 + 5",
+    "speed": {
+      "walk": 10,
+      "fly": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Crush",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage, and the darkmantle attaches to the target. If the target is a Medium or smaller creature and the darkmantle had Advantage on the attack roll, it covers the target, which has the Blinded condition and is suffocating while the darkmantle is attached in this way. While attached to a target, the darkmantle can attack only the target but has Advantage on its attack rolls. Its Speed becomes 0, it can’t benefit from any bonus to its Speed, and it moves with the target. A creature can take an action to try to detach the darkmantle from itself, doing so with a successful DC 13 Strength (Athletics) check. On its turn, the darkmantle can detach itself by using 5 feet of movement.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Darkness Aura (1/Day)",
+        "desc": "Magical Darkness fills a 15-foot"
+      },
+      {
+        "name": "Emanation originating from the darkmantle",
+        "desc": "This effect lasts while the darkmantle maintains Concentration on it, up to 10 minutes. Darkvision can’t penetrate this area, and no light can illuminate it."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "death-dog": {
+    "name": "Death Dog",
+    "slug": "death-dog",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 39,
+    "hit_dice": "6d8 + 12",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Blinded",
+      "Charmed",
+      "Deafened",
+      "Frightened",
+      "Stunned",
+      "Unconscious"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The death dog makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage. If the target is a creature, it is subjected to the following effect. Constitution Saving Throw: DC 12. First Failure: The target has the Poisoned condition. While Poisoned, the target’s Hit Point maximum doesn’t return to normal when finishing a Long Rest, and it repeats the save every 24 hours that elapse, ending the effect on itself on a success. Subsequent Failures: The Poisoned target’s Hit Point maximum decreases by 5 (1d10).",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "deva": {
+    "name": "Deva",
+    "slug": "deva",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 229,
+    "hit_dice": "27d8 + 108",
+    "speed": {
+      "walk": 30,
+      "fly": 90,
+      "hover": true
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 18,
+    "dexterity_save": 4,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 17,
+    "intelligence_save": 3,
+    "wisdom": 20,
+    "wisdom_save": 9,
+    "charisma": 20,
+    "charisma_save": 9,
+    "perception": 9,
+    "damage_resistances": [
+      "Radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 19",
+    "languages": "All; telepathy 120 ft.",
+    "challenge_rating": "10",
+    "special_abilities": [
+      {
+        "name": "Exalted Restoration",
+        "desc": "If the deva dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in Mount Celestia."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The deva has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The deva makes two Holy Mace attacks."
+      },
+      {
+        "name": "Holy Mace",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 18 (4d8) Radiant damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The deva casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Commune, Raise Dead"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (2/Day)",
+        "desc": "The deva casts Cure Wounds, Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "djinni": {
+    "name": "Djinni",
+    "slug": "djinni",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 218,
+    "hit_dice": "19d10 + 114",
+    "speed": {
+      "walk": 30,
+      "fly": 90,
+      "hover": true
+    },
+    "strength": 21,
+    "strength_save": 5,
+    "dexterity": 15,
+    "dexterity_save": 6,
+    "constitution": 22,
+    "constitution_save": 6,
+    "intelligence": 15,
+    "intelligence_save": 2,
+    "wisdom": 16,
+    "wisdom_save": 7,
+    "charisma": 20,
+    "charisma_save": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning",
+      "Thunder"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 13",
+    "languages": "Primordial (Auran)",
+    "challenge_rating": "11",
+    "special_abilities": [
+      {
+        "name": "Elemental Restoration",
+        "desc": "If the djinni dies outside the Elemental Plane of Air, its body dissolves into mist, and it gains a new body in 1d4 days, reviving with all its Hit Points somewhere on the Plane of Air."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The djinni has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Wishes",
+        "desc": "The djinni has a 30 percent chance of knowing the Wish spell. If the djinni knows it, the djinni can cast it only on behalf of a non-genie creature who communicates a wish in a way the djinni can understand. If the djinni casts the spell for the creature, the djinni suffers none of the spell’s stress. Once the djinni has cast it three times, the djinni can’t do so again for 365 days."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The djinni makes three attacks, using Storm Blade or Storm Bolt in any combination."
+      },
+      {
+        "name": "Storm Blade",
+        "desc": "Melee Attack Roll: +9, reach 5 feet. Hit: 12 (2d6 + 5) Slashing damage plus 7 (2d6) Lightning damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Storm Bolt",
+        "desc": "Ranged Attack Roll: +9, range 120 feet. Hit: 13 (3d8) Thunder damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "3d8"
+      },
+      {
+        "name": "Create Whirlwind",
+        "desc": "The djinni conjures a whirlwind at a point it can see within 120 feet. The whirlwind fills a 20-foot-radius, 60-foot-high Cylinder centered on that point. The whirlwind lasts until the djinni’s Concentration on it ends. The djinni can move the whirlwind up to 20 feet at the start of each of its turns. Whenever the whirlwind enters a creature’s space or a creature enters the whirlwind, that creature is subjected to the following effect. Strength Saving Throw: DC 17 (a creature makes this save only once per turn, and the djinni is unaffected). Failure: While in the whirlwind, the target has the Restrained condition and moves with the whirlwind. At the start of each of its turns, the Restrained target takes 21 (6d6) Thunder damage. At the end of each of its turns, the target repeats the save, ending the effect on itself on a success.",
+        "damage_dice": "6d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The djinni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Detect Magic"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Create Food and Water (can create wine instead of water), Tongues, Wind Walk"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Creation, Gaseous Form, Invisibility, Major Image, Plane Shift"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "doppelganger": {
+    "name": "Doppelganger",
+    "slug": "doppelganger",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 52,
+    "hit_dice": "8d8 + 16",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 18,
+    "dexterity_save": 4,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 14,
+    "charisma_save": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 11",
+    "languages": "Common plus three other languages",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The doppelganger makes two Slam attacks and uses Unsettling Visage if available."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +6 (with Advantage during the first round of each combat), reach 5 ft. Hit: 11 (2d6 + 4) Bludgeoning damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Read Thoughts",
+        "desc": "The doppelganger casts Detect Thoughts, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 12)."
+      },
+      {
+        "name": "Unsettling Visage (Recharge 6)",
+        "desc": "Wisdom Saving Throw: DC 12, each creature in a 15-foot Emanation originating from the doppelganger that can see the doppelganger. Failure: The target has the Frightened condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The doppelganger shape-shifts into a Medium or Small Humanoid, or it returns to its true form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "dragon-turtle": {
+    "name": "Dragon Turtle",
+    "slug": "dragon-turtle",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "neutral",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 356,
+    "hit_dice": "23d20 + 115",
+    "speed": {
+      "walk": 20,
+      "swim": 50
+    },
+    "strength": 25,
+    "strength_save": 7,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 20,
+    "constitution_save": 11,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 12,
+    "wisdom_save": 7,
+    "charisma": 12,
+    "charisma_save": 1,
+    "damage_resistances": [
+      "Fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 11",
+    "languages": "Draconic, Primordial (Aquan)",
+    "challenge_rating": "17",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Bite attacks. It can replace one attack with a Tail attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +13, reach 15 ft. Hit: 23 (3d10 + 7) Piercing damage plus 7 (2d6) Fire damage. Being underwater doesn’t grant Resistance to this Fire damage.",
+        "damage_dice": "3d10",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +13, reach 15 ft. Hit: 18 (2d10 + 7) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d10",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Steam Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 19, each creature in a 60-foot Cone. Failure: 56 (16d6) Fire damage. Success: Half damage. Failure or Success: Being underwater doesn’t grant Resistance to this Fire damage.",
+        "damage_dice": "16d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "dretch": {
+    "name": "Dretch",
+    "slug": "dretch",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 18,
+    "hit_dice": "4d6 + 4",
+    "speed": {
+      "walk": 20
+    },
+    "strength": 12,
+    "strength_save": 1,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [
+      "Cold",
+      "Fire",
+      "Lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "Abyssal; telepathy 60 ft. (works only with",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Fetid Cloud (1/Day)",
+        "desc": "Constitution Saving Throw: DC 11, each creature in a 10-foot Emanation originating from the dretch. Failure: The target has the Poisoned condition until the end of its next turn. While Poisoned, the creature can take either an action or a Bonus Action on its turn, not both, and it can’t take Reactions."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "drider": {
+    "name": "Drider",
+    "slug": "drider",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 123,
+    "hit_dice": "13d10 + 52",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 19,
+    "dexterity_save": 4,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 13,
+    "intelligence_save": 1,
+    "wisdom": 16,
+    "wisdom_save": 3,
+    "charisma": 12,
+    "charisma_save": 1,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 16",
+    "languages": "Elvish, Undercommon",
+    "challenge_rating": "6",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The drider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Sunlight Sensitivity",
+        "desc": "While in sunlight, the drider has Disadvantage on ability checks and attack rolls."
+      },
+      {
+        "name": "Web Walker",
+        "desc": "The drider ignores movement restrictions caused by webs, and the drider knows the location of any other creature in contact with the same web."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The drider makes three attacks, using Foreleg or Poison Burst in any combination."
+      },
+      {
+        "name": "Foreleg",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 13 (2d8 + 4) Piercing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Poison Burst",
+        "desc": "Ranged Attack Roll: +6, range 120 ft. Hit: 13 (3d6 + 3) Poison damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Magic of the Spider Queen (Recharge 5–6)",
+        "desc": "The drider casts Darkness, Faerie Fire, or Web, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 14)."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "druid": {
+    "name": "Druid",
+    "slug": "druid",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 44,
+    "hit_dice": "8d8 + 8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 16,
+    "wisdom_save": 3,
+    "charisma": 11,
+    "charisma_save": 0,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 15",
+    "languages": "Common, Druidic, Sylvan",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The druid makes two attacks, using Vine Staff or Verdant Wisp in any combination."
+      },
+      {
+        "name": "Vine Staff",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage plus 2 (1d4) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Verdant Wisp",
+        "desc": "Ranged Attack Roll: +5, range 90 ft. Hit: 10 (3d6) Radiant damage.",
+        "damage_dice": "3d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The druid casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Druidcraft, Speak with Animals"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Entangle, Thunderwave"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Animal Messenger, Longstrider, Moonbeam"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "dryad": {
+    "name": "Dryad",
+    "slug": "dryad",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "neutral",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 22,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 15,
+    "wisdom_save": 2,
+    "charisma": 18,
+    "charisma_save": 4,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Elvish, Sylvan",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The dryad has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Speak with Beasts and Plants",
+        "desc": "The dryad can communicate with Beasts and Plants as if they shared a language."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dryad makes one Vine Lash or Thorn Burst attack, and it can use Spellcasting to cast Charm Monster."
+      },
+      {
+        "name": "Vine Lash",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 8 (1d8 + 4) Slashing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Thorn Burst",
+        "desc": "Ranged Attack Roll: +6, range 60 ft. Hit: 7 (1d6 + 4) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dryad casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 14):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Animal Friendship, Charm Monster (lasts 24 hours; ends early if the dryad casts the spell again), Druidcraft"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Entangle, Pass without Trace"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Tree Stride",
+        "desc": "If within 5 feet of a Large or bigger tree, the dryad teleports to an unoccupied space within 5 feet of a second Large or bigger tree that is within 60 feet of the previous tree."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "earth-elemental": {
+    "name": "Earth Elemental",
+    "slug": "earth-elemental",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 147,
+    "hit_dice": "14d10 + 70",
+    "speed": {
+      "walk": 30,
+      "burrow": 30
+    },
+    "strength": 20,
+    "strength_save": 5,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 20,
+    "constitution_save": 5,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Thunder"
+    ],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Unconscious"
+    ],
+    "senses": "Darkvision 60 ft., Tremorsense 60 ft.;",
+    "languages": "Primordial (Terran)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Earth Glide",
+        "desc": "The elemental can burrow through nonmagical, unworked earth and stone. While doing so, the elemental doesn’t disturb the material it moves through."
+      },
+      {
+        "name": "Siege Monster",
+        "desc": "The elemental deals double damage to objects and structures."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The elemental makes two attacks, using Slam or Rock Launch in any combination."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 14 (2d8 + 5) Bludgeoning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Rock Launch",
+        "desc": "Ranged Attack Roll: +8, range 60 ft. Hit: 8 (1d6 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "1d6",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "efreeti": {
+    "name": "Efreeti",
+    "slug": "efreeti",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 212,
+    "hit_dice": "17d10 + 119",
+    "speed": {
+      "walk": 40,
+      "fly": 60,
+      "hover": true
+    },
+    "strength": 22,
+    "strength_save": 6,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 24,
+    "constitution_save": 7,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 15,
+    "wisdom_save": 6,
+    "charisma": 19,
+    "charisma_save": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 12",
+    "languages": "Primordial (Ignan)",
+    "challenge_rating": "11",
+    "special_abilities": [
+      {
+        "name": "Elemental Restoration",
+        "desc": "If the efreeti dies outside the Elemental Plane of Fire, its body dissolves into ash, and it gains a new body in 1d4 days, reviving with all its Hit Points somewhere on the Plane of Fire."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The efreeti has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Wishes",
+        "desc": "The efreeti has a 30 percent chance of knowing the Wish spell. If the efreeti knows it, the efreeti can cast it only on behalf of a non-genie creature who communicates a wish in a way the efreeti can understand. If the efreeti casts the spell for the creature, the efreeti suffers none of the spell’s stress. Once the efreeti has cast it three times, the efreeti can’t do so again for 365 days."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The efreeti makes three attacks, using Heated Blade or Hurl Flame in any combination."
+      },
+      {
+        "name": "Heated Blade",
+        "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 13 (2d6 + 6) Slashing damage plus 13 (2d12) Fire damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Hurl Flame",
+        "desc": "Ranged Attack Roll: +8, range 120 ft. Hit: 24 (7d6) Fire damage.",
+        "damage_dice": "7d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The efreeti casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Elementalism"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Gaseous Form, Invisibility, Major Image, Plane Shift, Tongues, Wall of Fire (level 7 version)"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "erinyes": {
+    "name": "Erinyes",
+    "slug": "erinyes",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 178,
+    "hit_dice": "21d8 + 84",
+    "speed": {
+      "walk": 30,
+      "fly": 60
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 16,
+    "dexterity_save": 7,
+    "constitution": 18,
+    "constitution_save": 8,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 18,
+    "charisma_save": 8,
+    "perception": 6,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 16",
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "12",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the erinyes dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The erinyes has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Magic Rope",
+        "desc": "The erinyes has a magic rope. While bearing it, the erinyes can use the Entangling Rope action. The rope has AC 20, HP 90, and Immunity to Poison and Psychic damage. The rope turns to dust if reduced to 0 Hit Points, if it is 5+ feet away from the erinyes for 1 hour or more, or if the erinyes dies. If the rope is damaged or destroyed, the erinyes can fully restore it when finishing a Short or Long Rest."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The erinyes makes three Withering Sword attacks and can use Entangling Rope."
+      },
+      {
+        "name": "Withering Sword",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage plus 11 (2d10) Necrotic damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Entangling Rope (Requires Magic Rope)",
+        "desc": "Strength Saving Throw: DC 16, one creature the erinyes can see within 120 feet. Failure: 14 (4d6) Force damage, and the target has the Restrained condition until the rope is destroyed, the erinyes uses a Bonus Action to release the target, or the erinyes uses Entangling Rope again.",
+        "damage_dice": "4d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The erinyes is hit by a melee attack roll while holding a weapon. Response: The erinyes adds 4 to its AC against that attack, possibly causing it to miss."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "ettercap": {
+    "name": "Ettercap",
+    "slug": "ettercap",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 44,
+    "hit_dice": "8d8 + 8",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The ettercap can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Web Walker",
+        "desc": "The ettercap ignores movement restrictions caused by webs, and the ettercap knows the location of any other creature in contact with the same web."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ettercap makes one Bite attack and one Claw attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 2 (1d4) Poison damage, and the target has the Poisoned condition until the start of the ettercap’s next turn.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Slashing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Web Strand (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 12, one Large or smaller creature the ettercap can see within 30 feet. Failure: The target has the Restrained condition until the web is destroyed (AC 10; HP 5; Vulnerability to Fire damage; Immunity to Bludgeoning, Poison, and Psychic damage)."
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Reel",
+        "desc": "The ettercap pulls one creature within 30 feet of itself that is Restrained by its Web Strand up to 25 feet straight toward itself."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "ettin": {
+    "name": "Ettin",
+    "slug": "ettin",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "giant",
+    "alignment": "chaotic evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 85,
+    "hit_dice": "10d10 + 30",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 21,
+    "strength_save": 5,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Blinded",
+      "Charmed",
+      "Deafened",
+      "Frightened",
+      "Stunned",
+      "Unconscious"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Giant",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ettin makes one Battleaxe attack and one Morningstar attack."
+      },
+      {
+        "name": "Battleaxe",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Morningstar",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Piercing damage, and the target has Disadvantage on the next attack roll it makes before the end of its next turn.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "fire-elemental": {
+    "name": "Fire Elemental",
+    "slug": "fire-elemental",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 93,
+    "hit_dice": "11d10 + 33",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Prone",
+      "Restrained",
+      "Unconscious"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Primordial (Ignan)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Fire Aura",
+        "desc": "At the end of each of the elemental’s turns, each creature in a 10-foot Emanation originating from the elemental takes 5 (1d10) Fire damage. Creatures and flammable objects in the Emanation start burning."
+      },
+      {
+        "name": "Fire Form",
+        "desc": "The elemental can move through a space as narrow as 1 inch without expending extra movement to do so, and it can enter a creature’s space and stop there. The first time it enters a creature’s space on a turn, that creature takes 5 (1d10) Fire damage."
+      },
+      {
+        "name": "Illumination",
+        "desc": "The elemental sheds Bright Light in a 30foot radius and Dim Light for an additional 30 feet."
+      },
+      {
+        "name": "Water Susceptibility",
+        "desc": "The elemental takes 3 (1d6) Cold damage for every 5 feet the elemental moves in water or for every gallon of water splashed on it."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The elemental makes two Burn attacks."
+      },
+      {
+        "name": "Burn",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Fire damage. If the target is a creature or a flammable object, it starts burning.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "fire-giant": {
+    "name": "Fire Giant",
+    "slug": "fire-giant",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 162,
+    "hit_dice": "13d12 + 78",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 25,
+    "strength_save": 7,
+    "dexterity": 9,
+    "dexterity_save": 3,
+    "constitution": 23,
+    "constitution_save": 10,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 13,
+    "charisma_save": 5,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Passive Perception 16",
+    "languages": "Giant",
+    "challenge_rating": "9",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Flame Sword or Hammer Throw in any combination."
+      },
+      {
+        "name": "Flame Sword",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 21 (4d6 + 7) Slashing damage plus 10 (3d6) Fire damage.",
+        "damage_dice": "4d6",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Hammer Throw",
+        "desc": "Ranged Attack Roll: +11, range 60/240 ft. Hit: 23 (3d10 + 7) Bludgeoning damage plus 4 (1d8) Fire damage, and the target is pushed up to 15 feet straight away from the giant and has Disadvantage on the next attack roll it makes before the end of its next turn.",
+        "damage_dice": "3d10",
+        "damage_bonus": 7
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "flesh-golem": {
+    "name": "Flesh Golem",
+    "slug": "flesh-golem",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "construct",
+    "alignment": "neutral",
+    "armor_class": 9,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 127,
+    "hit_dice": "15d8 + 60",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 9,
+    "dexterity_save": -1,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Understands Common plus one other language",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Aversion to Fire",
+        "desc": "If the golem takes Fire damage, it has Disadvantage on attack rolls and ability checks until the end of its next turn."
+      },
+      {
+        "name": "Berserk",
+        "desc": "Whenever the golem starts its turn Bloodied, roll 1d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it remains so until it is destroyed or it is no longer Bloodied. The golem’s creator, if within 60 feet of the berserk golem, can try to calm it by taking an action to make a DC 15 Charisma (Persuasion) check; the golem must be able to hear its creator. If this check succeeds, the golem ceases being berserk until the start of its next turn, at which point it resumes rolling for the Berserk trait again if it is still Bloodied."
+      },
+      {
+        "name": "Immutable Form",
+        "desc": "The golem can’t shape-shift."
+      },
+      {
+        "name": "Lightning Absorption",
+        "desc": "Whenever the golem is subjected to Lightning damage, it regains a number of Hit Points equal to the Lightning damage dealt."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The golem makes two Slam attacks."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage plus 4 (1d8) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "frost-giant": {
+    "name": "Frost Giant",
+    "slug": "frost-giant",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 149,
+    "hit_dice": "13d12 + 65",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 9,
+    "dexterity_save": -1,
+    "constitution": 21,
+    "constitution_save": 8,
+    "intelligence": 9,
+    "intelligence_save": -1,
+    "wisdom": 10,
+    "wisdom_save": 3,
+    "charisma": 12,
+    "charisma_save": 4,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold"
+    ],
+    "condition_immunities": [],
+    "senses": "Passive Perception 13",
+    "languages": "Giant",
+    "challenge_rating": "8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Frost Axe or Great Bow in any combination."
+      },
+      {
+        "name": "Frost Axe",
+        "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 19 (2d12 + 6) Slashing damage plus 9 (2d8) Cold damage.",
+        "damage_dice": "2d12",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Great Bow",
+        "desc": "Ranged Attack Roll: +9, range 150/600 ft. Hit: 17 (2d10 + 6) Piercing damage plus 7 (2d6) Cold damage, and the target’s Speed decreases by 10 feet until the end of its next turn.",
+        "damage_dice": "2d10",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "War Cry (Recharge 5–6)",
+        "desc": "The giant or one creature of its choice that can see or hear it gains 16 (2d10 + 5) Temporary Hit Points and has Advantage on attack rolls until the start of the giant’s next turn. Fungi"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "shrieker-fungus": {
+    "name": "Shrieker Fungus",
+    "slug": "shrieker-fungus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "plant",
+    "alignment": "unaligned",
+    "armor_class": 5,
+    "armor_desc": "",
+    "initiative": -5,
+    "hit_points": 13,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": 5
+    },
+    "strength": 1,
+    "strength_save": -5,
+    "dexterity": 1,
+    "dexterity_save": -5,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 3,
+    "wisdom_save": -4,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Blinded",
+      "Charmed",
+      "Deafened",
+      "Frightened"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft.; Passive Perception 6",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Shriek",
+        "desc": "Trigger: A creature or a source of Bright Light moves within 30 feet of the shrieker. Response: The shrieker emits a shriek audible within 300 feet of itself for 1 minute or until the shrieker dies."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "violet-fungus": {
+    "name": "Violet Fungus",
+    "slug": "violet-fungus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "plant",
+    "alignment": "unaligned",
+    "armor_class": 5,
+    "armor_desc": "",
+    "initiative": -5,
+    "hit_points": 18,
+    "hit_dice": "4d8",
+    "speed": {
+      "walk": 5
+    },
+    "strength": 3,
+    "strength_save": -4,
+    "dexterity": 1,
+    "dexterity_save": -5,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 3,
+    "wisdom_save": -4,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Blinded",
+      "Charmed",
+      "Deafened",
+      "Frightened"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft.; Passive Perception 6",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The fungus makes two Rotting Touch attacks."
+      },
+      {
+        "name": "Rotting Touch",
+        "desc": "Melee Attack Roll: +2, reach 10 ft. Hit: 4 (1d8) Necrotic damage.",
+        "damage_dice": "1d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "gargoyle": {
+    "name": "Gargoyle",
+    "slug": "gargoyle",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "elemental",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 67,
+    "hit_dice": "9d8 + 27",
+    "speed": {
+      "walk": 30,
+      "fly": 60
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Petrified",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Primordial (Terran)",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The gargoyle doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The gargoyle makes two Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Slashing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "gelatinous-cube": {
+    "name": "Gelatinous Cube",
+    "slug": "gelatinous-cube",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "ooze",
+    "alignment": "unaligned",
+    "armor_class": 6,
+    "armor_desc": "",
+    "initiative": -4,
+    "hit_points": 63,
+    "hit_dice": "6d10 + 30",
+    "speed": {
+      "walk": 15
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 3,
+    "dexterity_save": -4,
+    "constitution": 20,
+    "constitution_save": 5,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 6,
+    "wisdom_save": -2,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid"
+    ],
+    "condition_immunities": [
+      "Blinded",
+      "Charmed",
+      "Deafened",
+      "Exhaustion",
+      "Frightened",
+      "Prone"
+    ],
+    "senses": "Blindsight 60 ft.; Passive Perception 8",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Ooze Cube",
+        "desc": "The cube fills its entire space and is transparent. Other creatures can enter that space, but a creature that does so is subjected to the cube’s Engulf and has Disadvantage on the saving throw. Creatures inside the cube have Total Cover, and the cube can hold one Large creature or up to four Medium or Small creatures inside itself at a time. As an action, a creature within 5 feet of the cube can pull a creature or an object out of the cube by succeeding on a DC 12 Strength (Athletics) check, and the puller takes 10 (3d6) Acid damage."
+      },
+      {
+        "name": "Transparent",
+        "desc": "Even when the cube is in plain sight, a creature must succeed on a DC 15 Wisdom (Perception) check to notice the cube if the creature hasn’t witnessed the cube move or otherwise act."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Pseudopod",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 12 (3d6 + 2) Acid damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Engulf",
+        "desc": "The cube moves up to its Speed without provoking Opportunity Attacks. The cube can move through the spaces of Large or smaller creatures if it has room inside itself to contain them (see the Ooze Cube trait). Dexterity Saving Throw: DC 12, each creature whose space the cube enters for the first time during this move. Failure: 10 (3d6) Acid damage, and the target is engulfed. An engulfed target is suffocating, can’t cast spells with a Verbal component, has the Restrained condition, and takes 10 (3d6) Acid damage at the start of each of the cube’s turns. When the cube moves, the engulfed target moves with it. An engulfed target can try to escape by taking an action to make a DC 12 Strength (Athletics) check. On a successful check, the target escapes and enters the nearest unoccupied space. Success: Half damage, and the target moves to an unoccupied space within 5 feet of the cube. If there is no unoccupied space, the target fails the save instead.",
+        "damage_dice": "3d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "ghast": {
+    "name": "Ghast",
+    "slug": "ghast",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 36,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 2,
+    "charisma": 8,
+    "charisma_save": -1,
+    "damage_resistances": [
+      "Necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Common",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Stench",
+        "desc": "Constitution Saving Throw: DC 10, any creature that starts its turn in a 5-foot Emanation originating from the ghast. Failure: The target has the Poisoned condition until the start of its next turn. Success: The target is immune to this ghast’s Stench for 24 hours."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 9 (2d8) Necrotic damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage. If the target is a non-Undead creature, it is subjected to the following effect. Constitution Saving Throw: DC 10. Failure: The target has the Paralyzed condition until the end of its next turn.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "ghost": {
+    "name": "Ghost",
+    "slug": "ghost",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "neutral",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 45,
+    "hit_dice": "10d8",
+    "speed": {
+      "walk": 5,
+      "fly": 40,
+      "hover": true
+    },
+    "strength": 7,
+    "strength_save": -2,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 17,
+    "charisma_save": 3,
+    "damage_resistances": [
+      "Acid",
+      "Bludgeoning",
+      "Cold",
+      "Fire",
+      "Lightning",
+      ""
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Necrotic",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Prone",
+      "Restrained"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 11",
+    "languages": "Common plus one other language",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Ethereal Sight",
+        "desc": "The ghost can see 60 feet into the Ethereal Plane when it is on the Material Plane."
+      },
+      {
+        "name": "Incorporeal Movement",
+        "desc": "The ghost can move through other creatures and objects as if they were Difficult"
+      },
+      {
+        "name": "Terrain",
+        "desc": "It takes 5 (1d10) Force damage if it ends its turn inside an object."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ghost makes two Withering Touch attacks."
+      },
+      {
+        "name": "Withering Touch",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 19 (3d10 + 3) Necrotic damage.",
+        "damage_dice": "3d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Etherealness",
+        "desc": "The ghost casts the Etherealness spell, requiring no spell components and using Charisma as the spellcasting ability. The ghost is visible on the Material Plane while on the Border Ethereal and vice versa, but it can’t affect or be affected by anything on the other plane."
+      },
+      {
+        "name": "Horrific Visage",
+        "desc": "Wisdom Saving Throw: DC 13, each creature in a 60-foot Cone that can see the ghost and isn’t an Undead. Failure: 10 (2d6 + 3) Psychic damage, and the target has the Frightened condition until the start of the ghost’s next turn. Success: The target is immune to this ghost’s Horrific Visage for 24 hours.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Possession (Recharge 6)",
+        "desc": "Charisma Saving Throw: DC 13, one Humanoid the ghost can see within 5 feet. Failure: The target is possessed by the ghost; the ghost disappears, and the target has the Incapacitated condition and loses control of its body. The ghost now controls the body, but the target retains awareness. The ghost can’t be targeted by any attack, spell, or other effect, except ones that specifically target Undead. The ghost’s game statistics are the same, except it uses the possessed target’s Speed, as well as the target’s Strength, Dexterity, and Constitution modifiers. The possession lasts until the body drops to 0 Hit"
+      },
+      {
+        "name": "Points or the ghost leaves as a Bonus Action",
+        "desc": "When the possession ends, the ghost appears in an unoccupied space within 5 feet of the target, and the target is immune to this ghost’s Possession for 24 hours. Success: The target is immune to this ghost’s Possession for 24 hours."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "ghoul": {
+    "name": "Ghoul",
+    "slug": "ghoul",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Common",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ghoul makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 3 (1d6) Necrotic damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Slashing damage. If the target is a creature that isn’t an Undead or elf, it is subjected to the following effect. Constitution Saving Throw: DC 10. Failure: The target has the Paralyzed condition until the end of its next turn.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "gibbering-mouther": {
+    "name": "Gibbering Mouther",
+    "slug": "gibbering-mouther",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "aberration",
+    "alignment": "chaotic neutral",
+    "armor_class": 9,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 52,
+    "hit_dice": "7d8 + 21",
+    "speed": {
+      "walk": 20,
+      "swim": 20
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Prone"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Aberrant Ground",
+        "desc": "The ground in a 10-foot Emanation originating from the mouther is Difficult Terrain."
+      },
+      {
+        "name": "Gibbering",
+        "desc": "The mouther babbles incoherently while it doesn’t have the Incapacitated condition. Wisdom Saving Throw: DC 10, any creature that starts its turn within 20 feet of the mouther while it is babbling. Failure: The target rolls 1d8 to determine what it does during the current turn: 1–4. The target does nothing. 5–6. The target takes no action or Bonus Action and uses all its movement to move in a random direction. 7–8. The target makes a melee attack against a randomly determined creature within its reach or does nothing if it can’t make such an attack."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 7 (2d6) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition. The target dies if it is reduced to 0 Hit Points by this attack. Its body is then absorbed into the mouther, leaving only equipment behind."
+      },
+      {
+        "name": "Blinding Spittle (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 10, each creature in a 10-foot-radius Sphere centered on a point within 30 feet. Failure: 7 (2d6) Radiant damage, and the target has the Blinded condition until the end of the mouther’s next turn.",
+        "damage_dice": "2d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "glabrezu": {
+    "name": "Glabrezu",
+    "slug": "glabrezu",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 189,
+    "hit_dice": "18d10 + 90",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 20,
+    "strength_save": 9,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 21,
+    "constitution_save": 9,
+    "intelligence": 19,
+    "intelligence_save": 4,
+    "wisdom": 17,
+    "wisdom_save": 7,
+    "charisma": 16,
+    "charisma_save": 7,
+    "perception": 7,
+    "damage_resistances": [
+      "Cold",
+      "Fire",
+      "Lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 17",
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "9",
+    "special_abilities": [
+      {
+        "name": "Demonic Restoration",
+        "desc": "If the glabrezu dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The glabrezu has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The glabrezu makes two Pincer attacks and uses Pummel or Spellcasting."
+      },
+      {
+        "name": "Pincer",
+        "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 15) from one of two pincers.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Pummel",
+        "desc": "Dexterity Saving Throw: DC 17, one creature"
+      },
+      {
+        "name": "Grappled by the glabrezu",
+        "desc": "Failure: 15 (3d6 + 5) Bludgeoning damage. Success: Half damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The glabrezu casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 16):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Darkness, Detect Magic, Dispel Magic"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Confusion, Fly, Power Word Stun"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "gladiator": {
+    "name": "Gladiator",
+    "slug": "gladiator",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 112,
+    "hit_dice": "15d8 + 45",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 18,
+    "strength_save": 7,
+    "dexterity": 15,
+    "dexterity_save": 5,
+    "constitution": 16,
+    "constitution_save": 6,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 12,
+    "wisdom_save": 4,
+    "charisma": 15,
+    "charisma_save": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 11",
+    "languages": "Common",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The gladiator makes three Spear attacks. It can replace one attack with a use of Shield Bash."
+      },
+      {
+        "name": "Spear",
+        "desc": "Melee or Ranged Attack Roll: +7, reach 5 ft. or range 20/60 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Shield Bash",
+        "desc": "Strength Saving Throw: DC 15, one creature within 5 feet that the gladiator can see. Failure: 9 (2d4 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The gladiator is hit by a melee attack roll while holding a weapon. Response: The gladiator adds 3 to its AC against that attack, possibly causing it to miss. Gnoll"
+      }
+    ],
+    "legendary_actions": []
+  },
+  "gnoll-warrior": {
+    "name": "Gnoll Warrior",
+    "slug": "gnoll-warrior",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 27,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Gnoll",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Bone Bow",
+        "desc": "Ranged Attack Roll: +3, range 150/600 ft. Hit: 6 (1d10 + 1) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Rampage (1/Day)",
+        "desc": "Immediately after dealing damage to a creature that is already Bloodied, the gnoll moves up to half its Speed, and it makes one Rend attack. Goblins"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "goblin-minion": {
+    "name": "Goblin Minion",
+    "slug": "goblin-minion",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "fey",
+    "alignment": "chaotic neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 7,
+    "hit_dice": "2d6",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 8,
+    "strength_save": -1,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "Common, Goblin",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Dagger",
+        "desc": "Melee or Ranged Attack Roll: +4, reach 5 ft. or range 20/60 ft. Hit: 4 (1d4 + 2) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The goblin takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "goblin-warrior": {
+    "name": "Goblin Warrior",
+    "slug": "goblin-warrior",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "fey",
+    "alignment": "chaotic neutral",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 10,
+    "hit_dice": "3d6",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 8,
+    "strength_save": -1,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "Common, Goblin",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Scimitar",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage, plus 2 (1d4) Slashing damage if the attack roll had Advantage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Shortbow",
+        "desc": "Ranged Attack Roll: +4, range 80/320 ft. Hit: 5 (1d6 + 2) Piercing damage, plus 2 (1d4) Piercing damage if the attack roll had Advantage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The goblin takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "goblin-boss": {
+    "name": "Goblin Boss",
+    "slug": "goblin-boss",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "fey",
+    "alignment": "chaotic neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 21,
+    "hit_dice": "6d6",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 10,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "Common, Goblin",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The goblin makes two attacks, using Scimitar or Shortbow in any combination."
+      },
+      {
+        "name": "Scimitar",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage, plus 2 (1d4) Slashing damage if the attack roll had Advantage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Shortbow",
+        "desc": "Ranged Attack Roll: +4, range 80/320 ft. Hit: 5 (1d6 + 2) Piercing damage, plus 2 (1d4) Piercing damage if the attack roll had Advantage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The goblin takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": [
+      {
+        "name": "Redirect Attack",
+        "desc": "Trigger: A creature the goblin can see makes an attack roll against it. Response: The goblin chooses a Small or Medium ally within 5 feet of itself. The goblin and that ally swap places, and the ally becomes the target of the attack instead. Gold Dragons"
+      }
+    ],
+    "legendary_actions": []
+  },
+  "gold-dragon-wyrmling": {
+    "name": "Gold Dragon Wyrmling",
+    "slug": "gold-dragon-wyrmling",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 60,
+    "hit_dice": "8d8 + 24",
+    "speed": {
+      "walk": 30,
+      "fly": 60,
+      "swim": 30
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 4,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 16,
+    "charisma_save": 3,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Draconic",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 13, each creature in a 15-foot Cone. Failure: 22 (4d10) Fire damage. Success: Half damage.",
+        "damage_dice": "4d10"
+      },
+      {
+        "name": "Weakening Breath",
+        "desc": "Strength Saving Throw: DC 13, each creature that isn’t currently affected by this breath in a 15-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 2 (1d4) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "young-gold-dragon": {
+    "name": "Young Gold Dragon",
+    "slug": "young-gold-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 178,
+    "hit_dice": "17d10 + 85",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 14,
+    "dexterity_save": 6,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 13,
+    "wisdom_save": 5,
+    "charisma": 20,
+    "charisma_save": 5,
+    "perception": 9,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "10",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Weakening Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 17, each creature in a 30-foot Cone. Failure: 55 (10d10) Fire damage. Success: Half damage.",
+        "damage_dice": "10d10"
+      },
+      {
+        "name": "Weakening Breath",
+        "desc": "Strength Saving Throw: DC 17, each creature that isn’t currently affected by this breath in a 30-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 3 (1d6) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+        "damage_dice": "1d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "adult-gold-dragon": {
+    "name": "Adult Gold Dragon",
+    "slug": "adult-gold-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 243,
+    "hit_dice": "18d12 + 126",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 27,
+    "strength_save": 8,
+    "dexterity": 14,
+    "dexterity_save": 8,
+    "constitution": 25,
+    "constitution_save": 7,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 15,
+    "wisdom_save": 8,
+    "charisma": 24,
+    "charisma_save": 7,
+    "perception": 14,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "17",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Spellcasting to cast Guiding Bolt (level 2 version) or (B) Weakening Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 17 (2d8 + 8) Slashing damage plus 4 (1d8) Fire damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 21, each creature in a 60-foot Cone. Failure: 66 (12d10) Fire damage. Success: Half damage.",
+        "damage_dice": "12d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks):",
+        "attack_bonus": 13
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Flame Strike, Zone of Truth"
+      },
+      {
+        "name": "Weakening Breath",
+        "desc": "Strength Saving Throw: DC 21, each creature that isn’t currently affected by this breath in a 60-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 3 (1d6) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+        "damage_dice": "1d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Banish",
+        "desc": "Charisma Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 10 (3d6) Force damage, and the target has the Incapacitated condition and is transported to a harmless demiplane until the start of the dragon’s next turn, at which point it re appears in an unoccupied space of the dragon’s choice within 120 feet of the dragon. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "3d6"
+      },
+      {
+        "name": "Guiding Light",
+        "desc": "The dragon uses Spellcasting to cast Guiding Bolt (level 2 version)."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "ancient-gold-dragon": {
+    "name": "Ancient Gold Dragon",
+    "slug": "ancient-gold-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 16,
+    "hit_points": 546,
+    "hit_dice": "28d20 + 252",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 30,
+    "strength_save": 10,
+    "dexterity": 14,
+    "dexterity_save": 9,
+    "constitution": 29,
+    "constitution_save": 9,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 17,
+    "wisdom_save": 10,
+    "charisma": 28,
+    "charisma_save": 9,
+    "perception": 17,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "24",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Spellcasting to cast Guiding Bolt (level 4 version) or (B) Weakening Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +17 to hit, reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 9 (2d8) Fire damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 10,
+        "attack_bonus": 17
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 24, each creature in a 90-foot Cone. Failure: 71 (13d10) Fire damage. Success: Half damage.",
+        "damage_dice": "13d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 24, +16 to hit with spell attacks):",
+        "attack_bonus": 16
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Guiding Bolt (level 4 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Flame Strike (level 6 version), Word of Recall, Zone of Truth"
+      },
+      {
+        "name": "Weakening Breath",
+        "desc": "Strength Saving Throw: DC 24, each creature that isn’t currently affected by this breath in a 90-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 5 (1d10) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+        "damage_dice": "1d10"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Banish",
+        "desc": "Charisma Saving Throw: DC 24, one creature the dragon can see within 120 feet. Failure: 24 (7d6) Force damage, and the target has the Incapacitated condition and is transported to a harmless demiplane until the start of the dragon’s next turn, at which point it reappears in an unoccupied space of the dragon’s choice within 120 feet of the dragon. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "7d6"
+      },
+      {
+        "name": "Guiding Light",
+        "desc": "The dragon uses Spellcasting to cast Guiding Bolt (level 4 version)."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "gorgon": {
+    "name": "Gorgon",
+    "slug": "gorgon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 114,
+    "hit_dice": "12d10 + 48",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 20,
+    "strength_save": 5,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Exhaustion",
+      "Petrified"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 17",
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 18 (2d12 + 5) Piercing damage. If the target is a Large or smaller creature and the gorgon moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+        "damage_dice": "2d12",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Petrifying Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 15, each creature in a 30-foot Cone. First Failure: The target has the Restrained condition and repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition instead of the Restrained condition."
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Trample",
+        "desc": "Dexterity Saving Throw: DC 16, one creature within 5 feet that has the Prone condition. Failure: 16 (2d10 + 5) Bludgeoning damage. Success: Half damage."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "gray-ooze": {
+    "name": "Gray Ooze",
+    "slug": "gray-ooze",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "ooze",
+    "alignment": "unaligned",
+    "armor_class": 9,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 22,
+    "hit_dice": "3d8 + 9",
+    "speed": {
+      "walk": 10,
+      "climb": 10
+    },
+    "strength": 12,
+    "strength_save": 1,
+    "dexterity": 6,
+    "dexterity_save": -2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 6,
+    "wisdom_save": -2,
+    "charisma": 2,
+    "charisma_save": -4,
+    "damage_resistances": [
+      "Acid",
+      "Cold",
+      "Fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Blinded",
+      "Charmed",
+      "Deafened",
+      "Exhaustion",
+      "Frightened",
+      "Grappled",
+      "Prone",
+      "Restrained"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft.; Passive Perception 8",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Amorphous",
+        "desc": "The ooze can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Corrosive Form",
+        "desc": "Nonmagical ammunition is destroyed immediately after hitting the ooze and dealing any damage. Any nonmagical weapon takes a cumulative −1 penalty to attack rolls immediately after dealing damage to the ooze and coming into contact with it. The weapon is destroyed if the penalty reaches −5. The penalty can be removed by casting the Mending spell on the weapon. The ooze can eat through 2-inch-thick, nonmagical metal or wood in 1 round."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Pseudopod",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 10 (2d8 + 1) Acid damage. Nonmagical armor worn by the target takes a −1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10. The penalty can be removed by casting the Mending spell on the armor. Green Dragons",
+        "damage_dice": "2d8",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "green-dragon-wyrmling": {
+    "name": "Green Dragon Wyrmling",
+    "slug": "green-dragon-wyrmling",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 38,
+    "hit_dice": "7d8 + 7",
+    "speed": {
+      "walk": 30,
+      "fly": 60,
+      "swim": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 12,
+    "dexterity_save": 3,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 13,
+    "charisma_save": 1,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Draconic",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage plus 3 (1d6) Poison damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Poison Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: 21 (6d6) Poison damage. Success: Half damage.",
+        "damage_dice": "6d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "young-green-dragon": {
+    "name": "Young Green Dragon",
+    "slug": "young-green-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 136,
+    "hit_dice": "16d10 + 48",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 12,
+    "dexterity_save": 4,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 13,
+    "wisdom_save": 4,
+    "charisma": 15,
+    "charisma_save": 2,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Blindsight 30 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Poison Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: 42 (12d6) Poison damage. Success: Half damage.",
+        "damage_dice": "12d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "adult-green-dragon": {
+    "name": "Adult Green Dragon",
+    "slug": "adult-green-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 11,
+    "hit_points": 207,
+    "hit_dice": "18d12 + 90",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 12,
+    "dexterity_save": 6,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 15,
+    "wisdom_save": 7,
+    "charisma": 18,
+    "charisma_save": 4,
+    "perception": 12,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "15",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Mind Spike (level 3 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 15 (2d8 + 6) Slashing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Poison Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: 56 (16d6) Poison damage. Success: Half damage.",
+        "damage_dice": "16d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Mind Spike (level 3 version)"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Geas"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Mind Invasion",
+        "desc": "The dragon uses Spellcasting to cast Mind Spike (level 3 version)."
+      },
+      {
+        "name": "Noxious Miasma",
+        "desc": "Constitution Saving Throw: DC 17, each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 7 (2d6) Poison damage, and the target takes a −2 penalty to AC until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "2d6"
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "ancient-green-dragon": {
+    "name": "Ancient Green Dragon",
+    "slug": "ancient-green-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "lawful evil",
+    "armor_class": 21,
+    "armor_desc": "",
+    "initiative": 15,
+    "hit_points": 402,
+    "hit_dice": "23d20 + 161",
+    "speed": {
+      "walk": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 27,
+    "strength_save": 8,
+    "dexterity": 12,
+    "dexterity_save": 8,
+    "constitution": 25,
+    "constitution_save": 7,
+    "intelligence": 20,
+    "intelligence_save": 5,
+    "wisdom": 17,
+    "wisdom_save": 10,
+    "charisma": 22,
+    "charisma_save": 6,
+    "perception": 17,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "22",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The dragon can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Mind Spike (level 5 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +15, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 10 (3d6) Poison damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Poison Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Failure: 77 (22d6) Poison damage. Success: Half damage.",
+        "damage_dice": "22d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Mind Spike (level 5 version)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Geas, Modify Memory"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Mind Invasion",
+        "desc": "The dragon uses Spellcasting to cast Mind Spike (level 5 version)."
+      },
+      {
+        "name": "Noxious Miasma",
+        "desc": "Constitution Saving Throw: DC 21, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 17 (5d6) Poison damage, and the target takes a −2 penalty to AC until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "5d6"
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "green-hag": {
+    "name": "Green Hag",
+    "slug": "green-hag",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "neutral evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 82,
+    "hit_dice": "11d8 + 33",
+    "speed": {
+      "walk": 30,
+      "swim": 30
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 13,
+    "intelligence_save": 1,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 14,
+    "charisma_save": 2,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Common, Elvish, Sylvan",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The hag can breathe air and water."
+      },
+      {
+        "name": "Coven Magic",
+        "desc": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spellcasting ability (spell save DC 11): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant. The hag must finish a Long Rest before using this trait to cast that spell again."
+      },
+      {
+        "name": "Mimicry",
+        "desc": "The hag can mimic animal sounds and humanoid voices. A creature that hears the sounds can tell they are imitations only with a successful DC 14 Wisdom (Insight) check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hag makes two Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Slashing damage plus 3 (1d6) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The hag casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks):",
+        "attack_bonus": 4
+      },
+      {
+        "name": "At Will",
+        "desc": "Dancing Lights, Disguise Self (24-hour duration), Invisibility (self only, and the hag leaves no tracks while Invisible), Minor Illusion, Ray of Sickness (level 3 version)"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "grick": {
+    "name": "Grick",
+    "slug": "grick",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "aberration",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 54,
+    "hit_dice": "12d8",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The grick makes one Beak attack and one Tentacles attack."
+      },
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Tentacles",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12) from all four tentacles.",
+        "damage_dice": "1d10",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "griffon": {
+    "name": "Griffon",
+    "slug": "griffon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 59,
+    "hit_dice": "7d10 + 21",
+    "speed": {
+      "walk": 30,
+      "fly": 80
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The griffon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 14) from both of the griffon’s front claws."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "grimlock": {
+    "name": "Grimlock",
+    "slug": "grimlock",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "aberration",
+    "alignment": "neutral evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 9,
+    "intelligence_save": -1,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bone Cudgel",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage plus 2 (1d4) Psychic damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "guardian-naga": {
+    "name": "Guardian Naga",
+    "slug": "guardian-naga",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 136,
+    "hit_dice": "16d10 + 48",
+    "speed": {
+      "walk": 40,
+      "climb": 40,
+      "swim": 40
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 18,
+    "dexterity_save": 8,
+    "constitution": 16,
+    "constitution_save": 7,
+    "intelligence": 16,
+    "intelligence_save": 7,
+    "wisdom": 19,
+    "wisdom_save": 8,
+    "charisma": 18,
+    "charisma_save": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Paralyzed",
+      "Poisoned",
+      "Restrained"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Celestial, Common",
+    "challenge_rating": "10",
+    "special_abilities": [
+      {
+        "name": "Celestial Restoration",
+        "desc": "If the naga dies, it returns to life in 1d6 days and regains all its Hit Points unless Dispel Evil and Good is cast on its remains."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The naga makes two Bite attacks. It can replace any attack with a use of Poisonous Spittle."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 17 (2d12 + 4) Piercing damage plus 22 (4d10) Poison damage.",
+        "damage_dice": "2d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Poisonous Spittle",
+        "desc": "Constitution Saving Throw: DC 16, one creature the naga can see within 60 feet. Failure: 31 (7d8) Poison damage, and the target has the Blinded condition until the start of the naga’s next turn. Success: Half damage only.",
+        "damage_dice": "7d8"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The naga casts one of the following spells, requiring no Somatic or Material components and using Wisdom as the spellcasting ability (spell save DC 16):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Thaumaturgy"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Clairvoyance, Cure Wounds (level 6 version), Flame Strike (level 6 version), Geas, True Seeing Guards"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "guard": {
+    "name": "Guard",
+    "slug": "guard",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 10,
+    "charisma_save": 0,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "Common",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Spear",
+        "desc": "Melee or Ranged Attack Roll: +3, reach 5 ft. or range 20/60 ft. Hit: 4 (1d6 + 1) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "guard-captain": {
+    "name": "Guard Captain",
+    "slug": "guard-captain",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 75,
+    "hit_dice": "10d8 + 30",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 13,
+    "charisma_save": 1,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 14",
+    "languages": "Common",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The guard makes two attacks, using Javelin or Longsword in any combination."
+      },
+      {
+        "name": "Javelin",
+        "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 30/120 ft. Hit: 14 (3d6 + 4) Piercing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Longsword",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "half-dragon": {
+    "name": "Half-Dragon",
+    "slug": "half-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "neutral",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 105,
+    "hit_dice": "14d8 + 42",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 5,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 15,
+    "wisdom_save": 5,
+    "charisma": 14,
+    "charisma_save": 2,
+    "perception": 5,
+    "damage_resistances": [
+      "Damage type chosen for the Draconic Origin"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Draconic Origin",
+        "desc": "The half-dragon is related to a type of dragon associated with one of the following damage types (GM’s choice): Acid, Cold, Fire, Lightning, or Poison. This choice affects other aspects of the stat block."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The half-dragon makes two Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 6 (1d4 + 4) Slashing damage plus 7 (2d6) damage of the type chosen for the Draconic Origin trait. Dragon’s Breath (Recharge 5–6). Dexterity Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: 28 (8d6) damage of the type chosen for the Draconic",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Origin trait",
+        "desc": "Success: Half damage."
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Leap",
+        "desc": "The half-dragon jumps up to 30 feet by spending 10 feet of movement."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "harpy": {
+    "name": "Harpy",
+    "slug": "harpy",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 38,
+    "hit_dice": "7d8 + 7",
+    "speed": {
+      "walk": 20,
+      "fly": 40
+    },
+    "strength": 12,
+    "strength_save": 1,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 13,
+    "charisma_save": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Slashing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Luring Song",
+        "desc": "The harpy sings a magical melody, which lasts until the harpy’s Concentration ends on it. Wisdom Saving Throw: DC 11, each Humanoid and Giant in a 300-foot Emanation originating from the harpy when the song starts. Failure: The target has the Charmed condition until the song ends and repeats the save at the end of each of its turns. While Charmed, the target has the Incapacitated condition and ignores the Luring"
+      },
+      {
+        "name": "Song of other harpies",
+        "desc": "If the target is more than 5 feet from the harpy, the target moves on its turn toward the harpy by the most direct route, trying to get within 5 feet of the harpy. It doesn’t avoid Opportunity Attacks; however, before moving into damaging terrain (such as lava or a pit) and whenever it takes damage from a source other than the harpy, the target repeats the save. Success: The target is immune to this harpy’s Luring Song for 24 hours."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hell-hound": {
+    "name": "Hell Hound",
+    "slug": "hell-hound",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 58,
+    "hit_dice": "9d8 + 18",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "Understands Infernal but can’t speak",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The hound has Advantage on an attack roll against a creature if at least one of the hound’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hound makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 3 (1d6) Fire damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 17 (5d6) Fire damage. Success: Half damage.",
+        "damage_dice": "5d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hezrou": {
+    "name": "Hezrou",
+    "slug": "hezrou",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 157,
+    "hit_dice": "15d10 + 75",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 19,
+    "strength_save": 7,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 20,
+    "constitution_save": 8,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 12,
+    "wisdom_save": 4,
+    "charisma": 13,
+    "charisma_save": 1,
+    "damage_resistances": [
+      "Cold",
+      "Fire",
+      "Lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft.; Passive Perception 11",
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Demonic Restoration",
+        "desc": "If the hezrou dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The hezrou has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Stench",
+        "desc": "Constitution Saving Throw: DC 16, any creature that starts its turn in a 10-foot Emanation originating from the hezrou. Failure: The target has the Poisoned condition until the start of its next turn."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hezrou makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 6 (1d4 + 4) Slashing damage plus 9 (2d8) Poison damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Leap",
+        "desc": "The hezrou jumps up to 30 feet by spending 10 feet of movement."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hill-giant": {
+    "name": "Hill Giant",
+    "slug": "hill-giant",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 105,
+    "hit_dice": "10d12 + 40",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 21,
+    "strength_save": 5,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 19,
+    "constitution_save": 4,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 9,
+    "wisdom_save": -1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "Giant",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Tree Club or Trash Lob in any combination."
+      },
+      {
+        "name": "Tree Club",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 18 (3d8 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "3d8",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Trash Lob",
+        "desc": "Ranged Attack Roll: +8, range 60/240 ft. Hit: 16 (2d10 + 5) Bludgeoning damage, and the target has the Poisoned condition until the end of its next turn.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hippogriff": {
+    "name": "Hippogriff",
+    "slug": "hippogriff",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 26,
+    "hit_dice": "4d10 + 4",
+    "speed": {
+      "walk": 40,
+      "fly": 60
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The hippogriff doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hippogriff makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage. Hobgoblins",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hobgoblin-warrior": {
+    "name": "Hobgoblin Warrior",
+    "slug": "hobgoblin-warrior",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 9,
+    "charisma_save": -1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Common, Goblin",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The hobgoblin has Advantage on an attack roll against a creature if at least one of the hobgoblin’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Longsword",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 12 (2d10 + 1) Slashing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Longbow",
+        "desc": "Ranged Attack Roll: +3, range 150/600 ft. Hit: 5 (1d8 + 1) Piercing damage plus 7 (3d4) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hobgoblin-captain": {
+    "name": "Hobgoblin Captain",
+    "slug": "hobgoblin-captain",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 58,
+    "hit_dice": "9d8 + 18",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 13,
+    "charisma_save": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Common, Goblin",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Aura of Authority",
+        "desc": "While in a 10-foot Emanation originating from the hobgoblin, the hobgoblin and its allies have Advantage on attack rolls and saving throws, provided the hobgoblin doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hobgoblin makes two attacks, using Greatsword or Longbow in any combination."
+      },
+      {
+        "name": "Greatsword",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Slashing damage plus 3 (1d6) Poison damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Longbow",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage plus 5 (2d4) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "homunculus": {
+    "name": "Homunculus",
+    "slug": "homunculus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "construct",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 4,
+    "hit_dice": "1d4 + 2",
+    "speed": {
+      "walk": 20,
+      "fly": 40
+    },
+    "strength": 4,
+    "strength_save": -3,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 2,
+    "charisma": 7,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Understands Common plus one other language",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Telepathic Bond",
+        "desc": "While the homunculus is on the same plane of existence as its master, the two of them can communicate telepathically with each other."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage, and the target is subjected to the following effect. Constitution Saving Throw: DC 12. Failure: The target has the Poisoned condition until the end of the homunculus’s next turn. Failure by 5 or More: The target has the Poisoned condition for 1 minute. While Poisoned, the target has the Unconscious condition, which ends early if the target takes any damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "horned-devil": {
+    "name": "Horned Devil",
+    "slug": "horned-devil",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 199,
+    "hit_dice": "19d10 + 95",
+    "speed": {
+      "walk": 30,
+      "fly": 60
+    },
+    "strength": 22,
+    "strength_save": 10,
+    "dexterity": 17,
+    "dexterity_save": 7,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 16,
+    "wisdom_save": 7,
+    "charisma": 18,
+    "charisma_save": 8,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Darkvision 150 ft. (unimpeded by magical",
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "11",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes three attacks, using Searing Fork or Hurl Flame in any combination. It can replace one attack with a use of Infernal Tail."
+      },
+      {
+        "name": "Searing Fork",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (2d8 + 6) Piercing damage plus 9 (2d8) Fire damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Hurl Flame",
+        "desc": "Ranged Attack Roll: +8, range 150 ft. Hit: 26 (5d8 + 4) Fire damage. If the target is a flammable object that isn’t being worn or carried, it starts burning.",
+        "damage_dice": "5d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Infernal Tail",
+        "desc": "Dexterity Saving Throw: DC 17, one creature the devil can see within 10 feet. Failure: 10 (1d8 + 6) Necrotic damage, and the target receives an infernal wound if it doesn’t have one. While wounded, the target loses 10 (3d6) Hit Points at the start of each of its turns. The wound closes after 1 minute, after a spell restores Hit Points to the target, or after the target or a creature within 5 feet of it takes an action to stanch the wound, doing so by succeeding on a DC 17 Wisdom (Medicine) check.",
+        "damage_dice": "1d8",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hydra": {
+    "name": "Hydra",
+    "slug": "hydra",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 184,
+    "hit_dice": "16d12 + 80",
+    "speed": {
+      "walk": 40,
+      "swim": 40
+    },
+    "strength": 20,
+    "strength_save": 5,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 20,
+    "constitution_save": 5,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Blinded",
+      "Charmed",
+      "Deafened",
+      "Frightened",
+      "Stunned",
+      "Unconscious"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 16",
+    "languages": "None",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The hydra can hold its breath for 1 hour."
+      },
+      {
+        "name": "Multiple Heads",
+        "desc": "The hydra has five heads. Whenever the hydra takes 25 damage or more on a single turn, one of its heads dies. The hydra dies if all its heads are dead. At the end of each of its turns when it has at least one living head, the hydra grows two heads for each of its heads that died since its last turn, unless it has taken"
+      },
+      {
+        "name": "Fire damage since its last turn",
+        "desc": "The hydra regains 20 Hit Points when it grows new heads."
+      },
+      {
+        "name": "Reactive Heads",
+        "desc": "For each head the hydra has beyond one, it gets an extra Reaction that can be used only for Opportunity Attacks."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hydra makes as many Bite attacks as it has heads."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 10 (1d10 + 5) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "ice-devil": {
+    "name": "Ice Devil",
+    "slug": "ice-devil",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 228,
+    "hit_dice": "24d10 + 96",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 21,
+    "strength_save": 5,
+    "dexterity": 14,
+    "dexterity_save": 7,
+    "constitution": 18,
+    "constitution_save": 9,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 15,
+    "wisdom_save": 7,
+    "charisma": 18,
+    "charisma_save": 9,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold",
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Blindsight 120 ft.; Passive Perception 17",
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "14",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The devil has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The devil makes three Ice Spear attacks. It can replace one attack with a Tail attack."
+      },
+      {
+        "name": "Ice Spear",
+        "desc": "Melee or Ranged Attack Roll: +10, reach 5 ft. or range 30/120 ft. Hit: 14 (2d8 + 5) Piercing damage plus 10 (3d6) Cold damage. Until the end of its next turn, the target can’t take a Bonus Action or Reaction, its Speed decreases by 10 feet, and it can move or take one action on its turn, not both. Hit or Miss: The spear magically returns to the devil’s hand immediately after a ranged attack.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (3d6 + 5) Bludgeoning damage plus 18 (4d8) Cold damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Ice Wall (Recharge 6)",
+        "desc": "The devil casts Wall of Ice (level 8 version), requiring no spell components and using Intelligence as the spellcasting ability (spell save DC 17)."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "imp": {
+    "name": "Imp",
+    "slug": "imp",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 21,
+    "hit_dice": "6d4 + 6",
+    "speed": {
+      "walk": 20,
+      "fly": 40
+    },
+    "strength": 6,
+    "strength_save": -2,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 14,
+    "charisma_save": 2,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft. (unimpeded by magical",
+    "languages": "Common, Infernal",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The imp has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Sting",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Invisibility",
+        "desc": "The imp casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability."
+      },
+      {
+        "name": "Shape-Shift",
+        "desc": "The imp shape-shifts to resemble a rat (Speed 20 ft.), a raven (20 ft., Fly 60 ft.), or a spider (20 ft., Climb 20 ft.), or it returns to its true form. Its game statistics are the same in each form, except for its Speed. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "incubus": {
+    "name": "Incubus",
+    "slug": "incubus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 66,
+    "hit_dice": "12d8 + 12",
+    "speed": {
+      "walk": 30,
+      "fly": 60
+    },
+    "strength": 8,
+    "strength_save": -1,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 15,
+    "intelligence_save": 2,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 20,
+    "charisma_save": 5,
+    "perception": 5,
+    "damage_resistances": [
+      "Cold",
+      "Fire",
+      "Poison",
+      "Psychic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "Abyssal, Common, Infernal; telepathy 60 ft.",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Succubus Form",
+        "desc": "When the incubus finishes a Long Rest, it can shape-shift into a Succubus, using that stat block instead of this one. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The incubus makes two Restless Touch attacks."
+      },
+      {
+        "name": "Restless Touch",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 15 (3d6 + 5) Psychic damage, and the target is cursed for 24 hours or until the incubus dies. Until the curse ends, the target gains no benefit from finishing Short Rests.",
+        "damage_dice": "3d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The incubus casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Disguise Self, Etherealness"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Dream, Hypnotic Pattern"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nightmare (Recharge 6)",
+        "desc": "Wisdom Saving Throw: DC 15, one creature the incubus can see within 60 feet. Failure: If the target has 20 Hit Points or fewer, it has the Unconscious condition for 1 hour, until it takes damage, or until a creature within 5 feet of it takes an action to wake it. Otherwise, the target takes 18 (4d8) Psychic damage."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "invisible-stalker": {
+    "name": "Invisible Stalker",
+    "slug": "invisible-stalker",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 97,
+    "hit_dice": "13d10 + 26",
+    "speed": {
+      "walk": 50,
+      "fly": 50,
+      "hover": true
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 19,
+    "dexterity_save": 4,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 15,
+    "wisdom_save": 2,
+    "charisma": 11,
+    "charisma_save": 0,
+    "perception": 8,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Prone",
+      "Restrained",
+      "Unconscious"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 18",
+    "languages": "Common, Primordial (Auran)",
+    "challenge_rating": "6",
+    "special_abilities": [
+      {
+        "name": "Air Form",
+        "desc": "The stalker can enter an enemy’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Invisibility",
+        "desc": "The stalker has the Invisible condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The stalker makes three Wind Swipe attacks. It can replace one attack with a use of Vortex."
+      },
+      {
+        "name": "Wind Swipe",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (2d6 + 4) Force damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Vortex",
+        "desc": "Constitution Saving Throw: DC 14, one Large or smaller creature in the stalker’s space. Failure: 7 (1d8 + 3) Thunder damage, and the target has the Grappled condition (escape DC 13). Until the grapple ends, the target can’t cast spells with a Verbal component and takes 7 (2d6) Thunder damage at the start of each of the stalker’s turns.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "iron-golem": {
+    "name": "Iron Golem",
+    "slug": "iron-golem",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 9,
+    "hit_points": 252,
+    "hit_dice": "24d10 + 120",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 24,
+    "strength_save": 7,
+    "dexterity": 9,
+    "dexterity_save": -1,
+    "constitution": 20,
+    "constitution_save": 5,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison",
+      "Psychic"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft.; Passive Perception 10",
+    "languages": "Understands Common plus two other",
+    "challenge_rating": "16",
+    "special_abilities": [
+      {
+        "name": "Fire Absorption",
+        "desc": "Whenever the golem is subjected to Fire damage, it regains a number of Hit Points equal to the Fire damage dealt."
+      },
+      {
+        "name": "Immutable Form",
+        "desc": "The golem can’t shape-shift."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The golem makes two attacks, using Bladed Arm or Fiery Bolt in any combination."
+      },
+      {
+        "name": "Bladed Arm",
+        "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 20 (3d8 + 7) Slashing damage plus 10 (3d6) Fire damage.",
+        "damage_dice": "3d8",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Fiery Bolt",
+        "desc": "Ranged Attack Roll: +10, range 120 ft. Hit: 36 (8d8) Fire damage.",
+        "damage_dice": "8d8"
+      },
+      {
+        "name": "Poison Breath (Recharge 6)",
+        "desc": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: 55 (10d10) Poison damage. Success: Half damage.",
+        "damage_dice": "10d10"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "knight": {
+    "name": "Knight",
+    "slug": "knight",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 52,
+    "hit_dice": "8d8 + 16",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 14,
+    "constitution_save": 4,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 15,
+    "charisma_save": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Frightened"
+    ],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common plus one other language",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The knight makes two attacks, using Greatsword or Heavy Crossbow in any combination."
+      },
+      {
+        "name": "Greatsword",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage plus 4 (1d8) Radiant damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Heavy Crossbow",
+        "desc": "Ranged Attack Roll: +2, range 100/400 ft. Hit: 11 (2d10) Piercing damage plus 4 (1d8) Radiant damage.",
+        "damage_dice": "2d10"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The knight is hit by a melee attack roll while holding a weapon. Response: The knight adds 2 to its AC against that attack, possibly causing it to miss. Kobold"
+      }
+    ],
+    "legendary_actions": []
+  },
+  "kobold-warrior": {
+    "name": "Kobold Warrior",
+    "slug": "kobold-warrior",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "dragon",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 7,
+    "hit_dice": "3d6 − 3",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 7,
+    "strength_save": -2,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 9,
+    "constitution_save": -1,
+    "intelligence": 8,
+    "intelligence_save": -1,
+    "wisdom": 7,
+    "wisdom_save": -2,
+    "charisma": 8,
+    "charisma_save": -1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 8",
+    "languages": "Common, Draconic",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The kobold has Advantage on an attack roll against a creature if at least one of the kobold’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      },
+      {
+        "name": "Sunlight Sensitivity",
+        "desc": "While in sunlight, the kobold has Disadvantage on ability checks and attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Dagger",
+        "desc": "Melee or Ranged Attack Roll: +4, reach 5 ft. or range 20/60 ft. Hit: 4 (1d4 + 2) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "kraken": {
+    "name": "Kraken",
+    "slug": "kraken",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 481,
+    "hit_dice": "26d20 + 208",
+    "speed": {
+      "walk": 30,
+      "swim": 120
+    },
+    "strength": 30,
+    "strength_save": 17,
+    "dexterity": 11,
+    "dexterity_save": 7,
+    "constitution": 26,
+    "constitution_save": 15,
+    "intelligence": 22,
+    "intelligence_save": 6,
+    "wisdom": 18,
+    "wisdom_save": 11,
+    "charisma": 20,
+    "charisma_save": 5,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold",
+      "Lightning"
+    ],
+    "condition_immunities": [
+      "Frightened",
+      "Grappled",
+      "Paralyzed",
+      "Restrained"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 21",
+    "languages": "Understands Abyssal, Celestial, Infernal, and",
+    "challenge_rating": "23",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The kraken can breathe air and water."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the kraken fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Siege Monster",
+        "desc": "The kraken deals double damage to objects and structures."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The kraken makes two Tentacle attacks and uses Fling, Lightning Strike, or Swallow."
+      },
+      {
+        "name": "Tentacle",
+        "desc": "Melee Attack Roll: +17, reach 30 ft. Hit: 24 (4d6 + 10) Bludgeoning damage. The target has the Grappled condition (escape DC 20) from one of ten tentacles, and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "4d6",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Fling",
+        "desc": "The kraken throws a Large or smaller creature Grappled by it to a space it can see within 60 feet of itself that isn’t in the air. Dexterity Saving Throw: DC 25, the creature thrown and each creature in the destination space. Failure: 18 (4d8) Bludgeoning damage, and the target has the Prone condition. Success: Half damage only.",
+        "damage_dice": "4d8"
+      },
+      {
+        "name": "Lightning Strike",
+        "desc": "Dexterity Saving Throw: DC 23, one creature the kraken can see within 120 feet. Failure: 33 (6d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "6d10"
+      },
+      {
+        "name": "Swallow",
+        "desc": "Dexterity Saving Throw: DC 25, one creature Grappled by the kraken (it can have up to four creatures swallowed at a time). Failure: 23 (3d8 + 10) Piercing damage. If the target is Large or smaller, it is swallowed and no longer Grappled. A swallowed creature has the Restrained condition, has Total Cover against attacks and other effects outside the kraken, and takes 24 (7d6) Acid damage at the start of each of its turns. If the kraken takes 50 damage or more on a single turn from a creature inside it, the kraken must succeed on a DC 25 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 10 feet of the kraken with the Prone condition. If the kraken dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse using 15 feet of movement, exiting Prone.",
+        "damage_dice": "3d8",
+        "damage_bonus": 10
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Storm Bolt",
+        "desc": "The kraken uses Lightning Strike."
+      },
+      {
+        "name": "Toxic Ink",
+        "desc": "Constitution Saving Throw: DC 23, each creature in a 15-foot Emanation originating from the kraken while it is underwater. Failure: The target has the Blinded and Poisoned conditions until the end of the kraken’s next turn. The kraken then moves up to its Speed. Failure or Success: The kraken can’t take this action again until the start of its next turn."
+      }
+    ]
+  },
+  "lamia": {
+    "name": "Lamia",
+    "slug": "lamia",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 97,
+    "hit_dice": "13d10 + 26",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 15,
+    "wisdom_save": 2,
+    "charisma": 16,
+    "charisma_save": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 12",
+    "languages": "Abyssal, Common",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The lamia makes two Claw attacks. It can replace one attack with a use of Corrupting Touch."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage plus 7 (2d6) Psychic damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Corrupting Touch",
+        "desc": "Wisdom Saving Throw: DC 13, one creature the lamia can see within 5 feet. Failure: 13 (3d8) Psychic damage, and the target is cursed for 1 hour. Until the curse ends, the target has the Charmed and Poisoned conditions.",
+        "damage_dice": "3d8"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The lamia casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Disguise Self (can appear as a Large or Medium biped), Minor Illusion"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Geas, Major Image, Scrying"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Leap",
+        "desc": "The lamia jumps up to 30 feet by spending 10 feet of movement."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "lemure": {
+    "name": "Lemure",
+    "slug": "lemure",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 9,
+    "armor_desc": "",
+    "initiative": -3,
+    "hit_points": 9,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": 20
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 5,
+    "dexterity_save": -3,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Frightened",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft. (unimpeded by magical",
+    "languages": "Understands Infernal but can’t speak",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Hellish Restoration",
+        "desc": "If the lemure dies in the Nine Hells, it revives with all its Hit Points in 1d10 days unless it is killed by a creature under the effects of a Bless spell or its remains are sprinkled with Holy Water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Vile Slime",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Poison damage.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "lich": {
+    "name": "Lich",
+    "slug": "lich",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "neutral evil",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 17,
+    "hit_points": 315,
+    "hit_dice": "42d8 + 126",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 16,
+    "dexterity_save": 10,
+    "constitution": 16,
+    "constitution_save": 10,
+    "intelligence": 21,
+    "intelligence_save": 12,
+    "wisdom": 14,
+    "wisdom_save": 9,
+    "charisma": 16,
+    "charisma_save": 3,
+    "perception": 9,
+    "damage_resistances": [
+      "Cold",
+      "Lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Necrotic",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Poisoned"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 19",
+    "languages": "All",
+    "challenge_rating": "21",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the lich fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Spirit Jar",
+        "desc": "If destroyed, the lich reforms in 1d10 days if it has a spirit jar, reviving with all its Hit Points. The new body appears in an unoccupied space within the lich’s lair."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The lich makes three attacks, using Eldritch Burst or Paralyzing Touch in any combination."
+      },
+      {
+        "name": "Eldritch Burst",
+        "desc": "Melee or Ranged Attack Roll: +12, reach 5 ft. or range 120 ft. Hit: 31 (4d12 + 5) Force damage.",
+        "damage_dice": "4d12",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Paralyzing Touch",
+        "desc": "Melee Attack Roll: +12, reach 5 ft. Hit: 15 (3d6 + 5) Cold damage, and the target has the Paralyzed condition until the start of the lich’s next turn.",
+        "damage_dice": "3d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The lich casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 20):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Detect Thoughts, Dispel Magic, Fireball (level 5 version), Invisibility, Lightning Bolt (level 5 version), Mage Hand, Prestidigitation"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Animate Dead, Dimension Door, Plane Shift"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Chain Lightning, Finger of Death, Power Word Kill, Scrying"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Protective Magic",
+        "desc": "The lich casts Counterspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "legendary_actions": [
+      {
+        "name": "Deathly Teleport",
+        "desc": "The lich teleports up to 60 feet to an unoccupied space it can see, and each creature within 10 feet of the space it left takes 11 (2d10) Necrotic damage.",
+        "damage_dice": "2d10"
+      },
+      {
+        "name": "Disrupt Life",
+        "desc": "Constitution Saving Throw: DC 20, each creature that isn’t an Undead in a 20-foot Emanation originating from the lich. Failure: 31 (9d6) Necrotic damage. Success: Half damage. Failure or Success: The lich can’t take this action again until the start of its next turn.",
+        "damage_dice": "9d6"
+      },
+      {
+        "name": "Frightening Gaze",
+        "desc": "The lich casts Fear, using the same spellcasting ability as Spellcasting. The lich can’t take this action again until the start of its next turn. Mages"
+      }
+    ]
+  },
+  "mage": {
+    "name": "Mage",
+    "slug": "mage",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 81,
+    "hit_dice": "18d8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 9,
+    "strength_save": -1,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 17,
+    "intelligence_save": 6,
+    "wisdom": 12,
+    "wisdom_save": 4,
+    "charisma": 11,
+    "charisma_save": 0,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 14",
+    "languages": "Common plus three other languages",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The mage makes three Arcane Burst attacks."
+      },
+      {
+        "name": "Arcane Burst",
+        "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 120 ft. Hit: 16 (3d8 + 3) Force damage.",
+        "damage_dice": "3d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The mage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 14):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Light, Mage Armor (included in AC), Mage Hand, Prestidigitation"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Fireball (level 4 version), Invisibility"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Cone of Cold, Fly"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Misty Step (3/Day)",
+        "desc": "The mage casts Misty Step, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": [
+      {
+        "name": "Protective Magic (3/Day)",
+        "desc": "The mage casts Counterspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "archmage": {
+    "name": "Archmage",
+    "slug": "archmage",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 170,
+    "hit_dice": "31d8 + 31",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 20,
+    "intelligence_save": 9,
+    "wisdom": 15,
+    "wisdom_save": 6,
+    "charisma": 16,
+    "charisma_save": 3,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Psychic"
+    ],
+    "condition_immunities": [
+      "Charmed (with Mind Blank)"
+    ],
+    "senses": "Passive Perception 16",
+    "languages": "Common plus five other languages",
+    "challenge_rating": "12",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The archmage has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The archmage makes four Arcane Burst attacks."
+      },
+      {
+        "name": "Arcane Burst",
+        "desc": "Melee or Ranged Attack Roll: +9, reach 5 ft. or range 150 ft. Hit: 27 (4d10 + 5) Force damage.",
+        "damage_dice": "4d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The archmage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 17):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Detect Thoughts, Disguise Self, Invisibility, Light, Mage Armor (included in AC), Mage Hand, Prestidigitation"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Fly, Lightning Bolt (level 7 version)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Cone of Cold (level 9 version), Mind Blank (cast before combat), Scrying, Teleport"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Misty Step (3/Day)",
+        "desc": "The mage casts Misty Step, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": [
+      {
+        "name": "Protective Magic (3/Day)",
+        "desc": "The archmage casts Counterspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "magmin": {
+    "name": "Magmin",
+    "slug": "magmin",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "elemental",
+    "alignment": "chaotic neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 13,
+    "hit_dice": "3d6 + 3",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 7,
+    "strength_save": -2,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 8,
+    "intelligence_save": -1,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 10,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Primordial (Ignan)",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Death Burst",
+        "desc": "The magmin explodes when it dies. Dexterity Saving Throw: DC 11, each creature in a 10-foot"
+      },
+      {
+        "name": "Emanation originating from the magmin",
+        "desc": "Failure: 7 (2d6) Fire damage. Success: Half damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Touch",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Fire damage. If the target is a creature or a flammable object that isn’t being worn or carried, it starts burning.",
+        "damage_dice": "2d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Ignited Illumination",
+        "desc": "The magmin sets itself ablaze or extinguishes its flames. While ablaze, the magmin sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "manticore": {
+    "name": "Manticore",
+    "slug": "manticore",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "lawful evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 68,
+    "hit_dice": "8d10 + 24",
+    "speed": {
+      "walk": 30,
+      "fly": 50
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 11",
+    "languages": "Common",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The manticore makes three attacks, using Rend or Tail Spike in any combination."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tail Spike",
+        "desc": "Ranged Attack Roll: +5, range 100/200 ft. Hit: 7 (1d8 + 3) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "marilith": {
+    "name": "Marilith",
+    "slug": "marilith",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 220,
+    "hit_dice": "21d10 + 105",
+    "speed": {
+      "walk": 40,
+      "climb": 40
+    },
+    "strength": 18,
+    "strength_save": 9,
+    "dexterity": 20,
+    "dexterity_save": 5,
+    "constitution": 20,
+    "constitution_save": 10,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 16,
+    "wisdom_save": 8,
+    "charisma": 20,
+    "charisma_save": 10,
+    "perception": 8,
+    "damage_resistances": [
+      "Cold",
+      "Fire",
+      "Lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 18",
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "16",
+    "special_abilities": [
+      {
+        "name": "Demonic Restoration",
+        "desc": "If the marilith dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The marilith has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Reactive",
+        "desc": "The marilith can take one Reaction on every turn of combat."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The marilith makes six Pact Blade attacks and uses Constrict."
+      },
+      {
+        "name": "Pact Blade",
+        "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 10 (1d10 + 5) Slashing damage plus 7 (2d6) Necrotic damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 17, one Medium or smaller creature the marilith can see within 5 feet. Failure: 15 (2d10 + 4) Bludgeoning damage. The target has the Grappled condition (escape DC 14), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Teleport (Recharge 5–6)",
+        "desc": "The marilith teleports up to 120 feet to an unoccupied space it can see."
+      }
+    ],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The marilith is hit by a melee attack roll while holding a weapon. Response: The marilith adds 5 to its AC against that attack, possibly causing it to miss."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "medusa": {
+    "name": "Medusa",
+    "slug": "medusa",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "lawful evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 127,
+    "hit_dice": "17d8 + 51",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 13,
+    "wisdom_save": 4,
+    "charisma": 15,
+    "charisma_save": 2,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 150 ft.; Passive Perception 14",
+    "languages": "Common plus one other language",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The medusa makes two Claw attacks and one Snake Hair attack, or it makes three Poison Ray attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Snake Hair",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage plus 14 (4d6) Poison damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Poison Ray",
+        "desc": "Ranged Attack Roll: +5, range 150 ft. Hit: 11 (2d8 + 2) Poison damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Petrifying Gaze (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 13, each creature in a 30-foot Cone. If the medusa sees its reflection in the Cone, the medusa must make this save. First Failure: The target has the Restrained condition and repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition instead of the Restrained condition. Mephits"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "dust-mephit": {
+    "name": "Dust Mephit",
+    "slug": "dust-mephit",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "elemental",
+    "alignment": "neutral evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 17,
+    "hit_dice": "5d6",
+    "speed": {
+      "walk": 30,
+      "fly": 30
+    },
+    "strength": 5,
+    "strength_save": -3,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 9,
+    "intelligence_save": -1,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 10,
+    "charisma_save": 0,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Fire"
+    ],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 12",
+    "languages": "Primordial (Auran, Terran)",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Death Burst",
+        "desc": "The mephit explodes when it dies. Dexterity Saving Throw: DC 10, each creature in a 5-foot"
+      },
+      {
+        "name": "Emanation originating from the mephit",
+        "desc": "Failure: 5 (2d4) Bludgeoning damage. Success: Half damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Slashing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Blinding Breath (Recharge 6)",
+        "desc": "Dexterity Saving Throw: DC 10, each creature in a 15-foot Cone. Failure: The target has the Blinded condition until the end of the mephit’s next turn."
+      },
+      {
+        "name": "Sleep (1/Day)",
+        "desc": "The mephit casts the Sleep spell, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 10)."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "ice-mephit": {
+    "name": "Ice Mephit",
+    "slug": "ice-mephit",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "elemental",
+    "alignment": "neutral evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 21,
+    "hit_dice": "6d6",
+    "speed": {
+      "walk": 30,
+      "fly": 30
+    },
+    "strength": 7,
+    "strength_save": -2,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 9,
+    "intelligence_save": -1,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 12,
+    "charisma_save": 1,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Fire"
+    ],
+    "damage_immunities": [
+      "Cold",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 12",
+    "languages": "Primordial (Aquan, Auran)",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Death Burst",
+        "desc": "The mephit explodes when it dies. Constitution Saving Throw: DC 10, each creature in a 5-foot"
+      },
+      {
+        "name": "Emanation originating from the mephit",
+        "desc": "Failure: 5 (2d4) Cold damage. Success: Half damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 2 (1d4) Cold damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Fog Cloud (1/Day)",
+        "desc": "The mephit casts Fog Cloud, requiring no spell components and using Charisma as the spellcasting ability."
+      },
+      {
+        "name": "Frost Breath (Recharge 6)",
+        "desc": "Constitution Saving Throw: DC 10, each creature in a 15-foot Cone. Failure: 7 (3d4) Cold damage. Success: Half damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "magma-mephit": {
+    "name": "Magma Mephit",
+    "slug": "magma-mephit",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "elemental",
+    "alignment": "neutral evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 18,
+    "hit_dice": "4d6 + 4",
+    "speed": {
+      "walk": 30,
+      "fly": 30
+    },
+    "strength": 8,
+    "strength_save": -1,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 10,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Cold"
+    ],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Primordial (Ignan, Terran)",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Death Burst",
+        "desc": "The mephit explodes when it dies. Dexterity Saving Throw: DC 11, each creature in a 5-foot"
+      },
+      {
+        "name": "Emanation originating from the mephit",
+        "desc": "Failure: 7 (2d6) Fire damage. Success: Half damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 3 (1d6) Fire damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Fire Breath (Recharge 6)",
+        "desc": "Dexterity Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: 7 (2d6) Fire damage. Success: Half damage.",
+        "damage_dice": "2d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "steam-mephit": {
+    "name": "Steam Mephit",
+    "slug": "steam-mephit",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "elemental",
+    "alignment": "neutral evil",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 17,
+    "hit_dice": "5d6",
+    "speed": {
+      "walk": 30,
+      "fly": 30
+    },
+    "strength": 5,
+    "strength_save": -3,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 12,
+    "charisma_save": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Primordial (Aquan, Ignan)",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Blurred Form",
+        "desc": "Attack rolls against the mephit are made with Disadvantage unless the mephit has the Incapacitated condition."
+      },
+      {
+        "name": "Death Burst",
+        "desc": "The mephit explodes when it dies. Dexterity Saving Throw: DC 10, each creature in a 5-foot"
+      },
+      {
+        "name": "Emanation originating from the mephit",
+        "desc": "Failure: 5 (2d4) Fire damage. Success: Half damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Slashing damage plus 2 (1d4) Fire damage.",
+        "damage_dice": "1d4"
+      },
+      {
+        "name": "Steam Breath (Recharge 6)",
+        "desc": "Constitution Saving Throw: DC 10, each creature in a 15-foot Cone. Failure: 5 (2d4) Fire damage, and the target’s Speed decreases by 10 feet until the end of the mephit’s next turn. Success:",
+        "damage_dice": "2d4"
+      },
+      {
+        "name": "Half damage only",
+        "desc": "Failure or Success: Being underwater doesn’t grant Resistance to this Fire damage. Merfolk"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "merfolk-skirmisher": {
+    "name": "Merfolk Skirmisher",
+    "slug": "merfolk-skirmisher",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 10,
+      "swim": 40
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 12,
+    "charisma_save": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "Common, Primordial (Aquan)",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The merfolk can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Ocean Spear",
+        "desc": "Melee or Ranged Attack Roll: +2, reach 5 ft. or range 20/60 ft. Hit: 3 (1d6) Piercing damage plus 2 (1d4) Cold damage. If the target is a creature, its Speed decreases by 10 feet until the end of its next turn. Hit or Miss: The spear magically returns to the merfolk’s hand immediately after a ranged attack.",
+        "damage_dice": "1d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "merrow": {
+    "name": "Merrow",
+    "slug": "merrow",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 45,
+    "hit_dice": "6d10 + 12",
+    "speed": {
+      "walk": 10,
+      "swim": 40
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 8,
+    "intelligence_save": -1,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 9,
+    "charisma_save": -1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Abyssal, Primordial (Aquan)",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The merrow can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The merrow makes two attacks, using Bite, Claw, or Harpoon in any combination."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Piercing damage, and the target has the Poisoned condition until the end of the merrow’s next turn.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Slashing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Harpoon",
+        "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 20/60 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature, the merrow pulls the target up to 15 feet straight toward itself.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "mimic": {
+    "name": "Mimic",
+    "slug": "mimic",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 58,
+    "hit_dice": "9d8 + 18",
+    "speed": {
+      "walk": 20
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Acid"
+    ],
+    "condition_immunities": [
+      "Prone"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Adhesive (Object Form Only)",
+        "desc": "The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic has the Grappled condition (escape DC 13). Ability checks made to escape this grapple have Disadvantage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the mimic), reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage—or 12 (2d8 + 3) Piercing damage if the target is Grappled by the mimic—plus 4 (1d8) Acid damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Pseudopod",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage plus 4 (1d8) Acid damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13). Ability checks made to escape this grapple have Disadvantage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The mimic shape-shifts to resemble a Medium or Small object while retaining its game statistics, or it returns to its true blob form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "minotaur-of-baphomet": {
+    "name": "Minotaur of Baphomet",
+    "slug": "minotaur-of-baphomet",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 85,
+    "hit_dice": "10d10 + 30",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 16,
+    "wisdom_save": 3,
+    "charisma": 9,
+    "charisma_save": -1,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 17",
+    "languages": "Abyssal",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Abyssal Glaive",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 10 (1d12 + 4) Slashing damage plus 10 (3d6) Necrotic damage.",
+        "damage_dice": "1d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Gore (Recharge 5–6)",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 18 (4d6 + 4) Piercing damage. If the target is a Large or smaller creature and the minotaur moved 10+ feet straight toward it immediately before the hit, the target takes an extra 10 (3d6) Piercing damage and has the Prone condition. Mummies",
+        "damage_dice": "4d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "mummy": {
+    "name": "Mummy",
+    "slug": "mummy",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small undead",
+    "alignment": "lawful evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 58,
+    "hit_dice": "9d8 + 18",
+    "speed": {
+      "walk": 20
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 12,
+    "wisdom_save": 3,
+    "charisma": 12,
+    "charisma_save": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Fire"
+    ],
+    "damage_immunities": [
+      "Necrotic",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 11",
+    "languages": "Common plus two other languages",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The mummy makes two Rotting Fist attacks and uses Dreadful Glare."
+      },
+      {
+        "name": "Rotting Fist",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Bludgeoning damage plus 10 (3d6) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target can’t regain Hit Points, its Hit Point maximum doesn’t return to normal when finishing a Long Rest, and its Hit Point maximum decreases by 10 (3d6) every 24 hours that elapse. A creature dies and turns to dust if reduced to 0 Hit Points by this attack.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Dreadful Glare",
+        "desc": "Wisdom Saving Throw: DC 11, one creature the mummy can see within 60 feet. Failure: The target has the Frightened condition until the end of the mummy’s next turn. Success: The target is immune to this mummy’s Dreadful Glare for 24 hours."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "mummy-lord": {
+    "name": "Mummy Lord",
+    "slug": "mummy-lord",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small undead",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 187,
+    "hit_dice": "25d8 + 75",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 11,
+    "intelligence_save": 5,
+    "wisdom": 19,
+    "wisdom_save": 9,
+    "charisma": 16,
+    "charisma_save": 3,
+    "perception": 9,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Fire"
+    ],
+    "damage_immunities": [
+      "Necrotic",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Poisoned"
+    ],
+    "senses": "Truesight 60 ft.; Passive Perception 19",
+    "languages": "Common plus three other languages",
+    "challenge_rating": "15",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the mummy fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The mummy has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Undead Restoration",
+        "desc": "If destroyed, the mummy gains a new body in 24 hours if its heart is intact, reviving with all its Hit Points. The new body appears in an unoccupied space within the mummy’s lair. The heart is a Tiny object that has AC 17, HP 10, and Immunity to all damage except Fire."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The mummy makes one Rotting Fist or Channel Negative Energy attack, and it uses Dreadful Glare."
+      },
+      {
+        "name": "Rotting Fist",
+        "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 15 (2d10 + 4) Bludgeoning damage plus 10 (3d6) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target can’t regain Hit Points, it gains no benefit from finishing a Long Rest, and its Hit Point maximum decreases by 10 (3d6) every 24 hours that elapse. A creature dies and turns to dust if reduced to 0 Hit Points by this attack.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Channel Negative Energy",
+        "desc": "Ranged Attack Roll: +9, range 60 ft. Hit: 25 (6d6 + 4) Necrotic damage.",
+        "damage_dice": "6d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Dreadful Glare",
+        "desc": "Wisdom Saving Throw: DC 17, one creature the mummy can see within 60 feet. Failure: 25 (6d6 + 4) Psychic damage, and the target has the Paralyzed condition until the end of the mummy’s next turn.",
+        "damage_dice": "6d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The mummy casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 17, +9 to hit with spell attacks):",
+        "attack_bonus": 9
+      },
+      {
+        "name": "At Will",
+        "desc": "Dispel Magic, Thaumaturgy"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Animate Dead, Harm, Insect Plague (level 7 version)"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Whirlwind of Sand",
+        "desc": "Trigger: The mummy is hit by an attack roll. Response: The mummy adds 2 to its AC against the attack, possibly causing the attack to miss, and the mummy teleports up to 60 feet to an unoccupied space it can see. Each creature of its choice that it can see within 5 feet of its destination space has the Blinded condition until the end of the mummy’s next turn."
+      }
+    ],
+    "legendary_actions": [
+      {
+        "name": "Dread Command",
+        "desc": "The mummy casts Command (level 2 version), using the same spellcasting ability as Spellcasting. The mummy can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Glare",
+        "desc": "The mummy uses Dreadful Glare. The mummy can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Necrotic Strike",
+        "desc": "The mummy makes one Rotting Fist or Channel Negative Energy attack."
+      }
+    ]
+  },
+  "nalfeshnee": {
+    "name": "Nalfeshnee",
+    "slug": "nalfeshnee",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 184,
+    "hit_dice": "16d10 + 96",
+    "speed": {
+      "walk": 20,
+      "fly": 30
+    },
+    "strength": 21,
+    "strength_save": 5,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 22,
+    "constitution_save": 11,
+    "intelligence": 19,
+    "intelligence_save": 9,
+    "wisdom": 12,
+    "wisdom_save": 6,
+    "charisma": 15,
+    "charisma_save": 7,
+    "damage_resistances": [
+      "Cold",
+      "Fire",
+      "Lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Frightened",
+      "Poisoned"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 11",
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Demonic Restoration",
+        "desc": "If the nalfeshnee dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The nalfeshnee has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The nalfeshnee makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage plus 11 (2d10) Force damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Teleport",
+        "desc": "The nalfeshnee teleports up to 120 feet to an unoccupied space it can see."
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Horror Nimbus (Recharge 5–6)",
+        "desc": "Wisdom Saving Throw: DC 15, each creature in a 15-foot Emanation originating from the nalfeshnee. Failure: 28 (8d6) Psychic damage, and the target has the Frightened condition for 1 minute, until it takes damage, or until it ends its turn with the nalfeshnee out of line of sight. Success: The target is immune to this nalfeshnee’s Horror Nimbus for 24 hours."
+      }
+    ],
+    "reactions": [
+      {
+        "name": "Pursuit",
+        "desc": "Trigger: Another creature the nalfeshnee can see ends its move within 120 feet of the nalfeshnee. Response: The nalfeshnee uses Teleport, but its destination space must be within 10 feet of the triggering creature."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "night-hag": {
+    "name": "Night Hag",
+    "slug": "night-hag",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "neutral evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 112,
+    "hit_dice": "15d8 + 45",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 16,
+    "charisma_save": 3,
+    "perception": 5,
+    "damage_resistances": [
+      "Cold",
+      "Fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 15",
+    "languages": "Abyssal, Common, Infernal, Primordial",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Coven Magic",
+        "desc": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spellcasting ability (spell save DC 14): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant. The hag must finish a Long Rest before using this trait to cast that spell again."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The hag has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Soul Bag",
+        "desc": "The hag has a soul bag. While holding or carrying the bag, the hag can use its Nightmare Haunting action. The bag has AC 15, HP 20, and Resistance to all damage. The bag turns to dust if reduced to 0 Hit Points. If the bag is destroyed, any souls the bag is holding are released. The hag can create a new bag after 7 days."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hag makes two Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage. Nightmare Haunting (1/Day; Requires Soul Bag). While on the Ethereal Plane, the hag casts Dream, using the same spellcasting ability as Spellcasting. Only the hag can serve as the spell’s messenger, and the target must be a creature the hag can see on the Material",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Plane",
+        "desc": "The spell fails and is wasted if the target is under the effect of the Protection from Evil and Good spell or within a Magic Circle spell. If the target takes damage from the Dream spell, the target’s Hit Point maximum decreases by an amount equal to that damage. If the spell kills the target, its soul is trapped in the hag’s soul bag, and the target can’t be raised from the dead until its soul is released."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The hag casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 14):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Etherealness, Magic Missile (level 4 version)"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Phantasmal Killer, Plane Shift (self only)"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The hag shape-shifts into a Small or Medium Humanoid, or it returns to its true form. Other than its size, its game statistics are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "nightmare": {
+    "name": "Nightmare",
+    "slug": "nightmare",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "neutral evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 68,
+    "hit_dice": "8d10 + 24",
+    "speed": {
+      "walk": 60,
+      "fly": 90,
+      "hover": true
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 15,
+    "charisma_save": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Passive Perception 11",
+    "languages": "Understands Abyssal, Common, and Infernal",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Confer Fire Resistance",
+        "desc": "The nightmare can grant Resistance to Fire damage to a rider while it is on the nightmare."
+      },
+      {
+        "name": "Illumination",
+        "desc": "The nightmare sheds Bright Light in a 10foot radius and Dim Light for an additional 10 feet."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage plus 10 (3d6) Fire damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Ethereal Stride",
+        "desc": "The nightmare and up to three willing creatures within 5 feet of it teleport to the Ethereal Plane from the Material Plane or vice versa."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "noble": {
+    "name": "Noble",
+    "slug": "noble",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 9,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 16,
+    "charisma_save": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "Common plus two other languages",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rapier",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The noble is hit by a melee attack roll while holding a weapon. Response: The noble adds 2 to its AC against that attack, possibly causing it to miss."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "ochre-jelly": {
+    "name": "Ochre Jelly",
+    "slug": "ochre-jelly",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "ooze",
+    "alignment": "unaligned",
+    "armor_class": 8,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 52,
+    "hit_dice": "7d10 + 14",
+    "speed": {
+      "walk": 20,
+      "climb": 20
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 6,
+    "dexterity_save": -2,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 6,
+    "wisdom_save": -2,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [
+      "Acid"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning",
+      "Slashing"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Deafened",
+      "Exhaustion",
+      "Frightened",
+      "Grappled",
+      "Prone",
+      "Restrained"
+    ],
+    "senses": "Blindsight 60 ft.; Passive Perception 8",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amorphous",
+        "desc": "The jelly can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Spider Climb",
+        "desc": "The jelly can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Pseudopod",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 12 (3d6 + 2) Acid damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Split",
+        "desc": "Trigger: While the jelly is Large or Medium and has 10+ Hit Points, it becomes Bloodied or is subjected to Lightning or Slashing damage. Response: The jelly splits into two new Ochre Jellies. Each new jelly is one size smaller than the original jelly and acts on its Initiative. The original jelly’s Hit Points are divided evenly between the new jellies (round down)."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "ogre": {
+    "name": "Ogre",
+    "slug": "ogre",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "giant",
+    "alignment": "chaotic evil",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 68,
+    "hit_dice": "8d10 + 24",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 7,
+    "wisdom_save": -2,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 8",
+    "languages": "Common, Giant",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Greatclub",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Javelin",
+        "desc": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 30/120 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "oni": {
+    "name": "Oni",
+    "slug": "oni",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 119,
+    "hit_dice": "14d10 + 42",
+    "speed": {
+      "walk": 30,
+      "fly": 30,
+      "hover": true
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 11,
+    "dexterity_save": 3,
+    "constitution": 16,
+    "constitution_save": 6,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 12,
+    "wisdom_save": 4,
+    "charisma": 15,
+    "charisma_save": 5,
+    "perception": 4,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Common, Giant",
+    "challenge_rating": "7",
+    "special_abilities": [
+      {
+        "name": "Regeneration",
+        "desc": "The oni regains 10 Hit Points at the start of each of its turns if it has at least 1 Hit Point."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The oni makes two Claw or Nightmare"
+      },
+      {
+        "name": "Ray attacks",
+        "desc": "It can replace one attack with a use of Spellcasting."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 10 (1d12 + 4) Slashing damage plus 9 (2d8) Necrotic damage.",
+        "damage_dice": "1d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Nightmare Ray",
+        "desc": "Ranged Attack Roll: +5, range 60 ft. Hit: 9 (2d6 + 2) Psychic damage, and the target has the Frightened condition until the start of the oni’s next turn.",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Shape-Shift",
+        "desc": "The oni shape-shifts into a Small or Medium Humanoid or a Large Giant, or it returns to its true form. Other than its size, its game statistics are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The oni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13):"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Charm Person (level 2 version), Darkness, Gaseous Form, Sleep"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Invisibility",
+        "desc": "The oni casts Invisibility on itself, requiring no spell components and using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "otyugh": {
+    "name": "Otyugh",
+    "slug": "otyugh",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "aberration",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 104,
+    "hit_dice": "11d10 + 44",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 19,
+    "constitution_save": 7,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 11",
+    "languages": "Otyugh; telepathy 120 ft. (doesn’t allow the",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The otyugh makes one Bite attack and two Tentacle attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage, and the target has the Poisoned condition. Whenever the Poisoned target finishes a Long Rest, it is subjected to the following effect. Constitution Saving Throw: DC 15. Failure: The target’s Hit Point maximum decreases by 5 (1d10) and doesn’t return to normal until the Poisoned condition ends on the target. Success: The Poisoned condition ends.",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tentacle",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 13) from one of two tentacles.",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tentacle Slam",
+        "desc": "Constitution Saving Throw: DC 14, each creature Grappled by the otyugh. Failure: 16 (3d8 + 3) Bludgeoning damage, and the target has the Stunned condition until the start of the otyugh’s next turn. Success: Half damage only.",
+        "damage_dice": "3d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "owlbear": {
+    "name": "Owlbear",
+    "slug": "owlbear",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 59,
+    "hit_dice": "7d10 + 21",
+    "speed": {
+      "walk": 40,
+      "climb": 40
+    },
+    "strength": 20,
+    "strength_save": 5,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The owlbear makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Slashing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "pegasus": {
+    "name": "Pegasus",
+    "slug": "pegasus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "chaotic good",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 59,
+    "hit_dice": "7d10 + 21",
+    "speed": {
+      "walk": 60,
+      "fly": 90
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 15,
+    "dexterity_save": 4,
+    "constitution": 16,
+    "constitution_save": 5,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 15,
+    "wisdom_save": 4,
+    "charisma": 13,
+    "charisma_save": 3,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 16",
+    "languages": "Understands Celestial, Common, Elvish, and",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 5 (2d4) Radiant damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "phase-spider": {
+    "name": "Phase Spider",
+    "slug": "phase-spider",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 45,
+    "hit_dice": "7d10 + 7",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Ethereal Sight",
+        "desc": "The spider can see 60 feet into the Ethereal Plane while on the Material Plane and vice versa."
+      },
+      {
+        "name": "Spider Climb",
+        "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Web Walker",
+        "desc": "The spider ignores movement restrictions caused by webs, and the spider knows the location of any other creature in contact with the same web."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The spider makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Piercing damage plus 9 (2d8) Poison damage. If this damage reduces the target to 0 Hit Points, the target becomes Stable, and it has the Poisoned condition for 1 hour. While Poisoned, the target also has the Paralyzed condition.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Ethereal Jaunt",
+        "desc": "The spider teleports from the Material Plane to the Ethereal Plane or vice versa. Pirates"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "pirate": {
+    "name": "Pirate",
+    "slug": "pirate",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 33,
+    "hit_dice": "6d8 + 6",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 16,
+    "dexterity_save": 5,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 8,
+    "intelligence_save": -1,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 14,
+    "charisma_save": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 11",
+    "languages": "Common plus one other language",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The pirate makes two Dagger attacks. It can replace one attack with a use of Enthralling Panache."
+      },
+      {
+        "name": "Dagger",
+        "desc": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 20/60 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Enthralling Panache",
+        "desc": "Wisdom Saving Throw: DC 12, one creature the pirate can see within 30 feet. Failure: The target has the Charmed condition until the start of the pirate’s next turn."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "pirate-captain": {
+    "name": "Pirate Captain",
+    "slug": "pirate-captain",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 84,
+    "hit_dice": "13d8 + 26",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 10,
+    "strength_save": 3,
+    "dexterity": 18,
+    "dexterity_save": 7,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 14,
+    "wisdom_save": 5,
+    "charisma": 17,
+    "charisma_save": 6,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 15",
+    "languages": "Common plus one other language",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The pirate makes three attacks, using Rapier or Pistol in any combination."
+      },
+      {
+        "name": "Rapier",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Piercing damage, and the pirate has Advantage on the next attack roll it makes before the end of this turn.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Pistol",
+        "desc": "Ranged Attack Roll: +7, range 30/90 ft. Hit: 15 (2d10 + 4) Piercing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Riposte",
+        "desc": "Trigger: The pirate is hit by a melee attack roll while holding a weapon. Response: The pirate adds 3 to its AC against that attack, possibly causing it to miss. On a miss, the pirate makes one Rapier attack against the triggering creature if within range."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "pit-fiend": {
+    "name": "Pit Fiend",
+    "slug": "pit-fiend",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 21,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 337,
+    "hit_dice": "27d10 + 189",
+    "speed": {
+      "walk": 30,
+      "fly": 60
+    },
+    "strength": 26,
+    "strength_save": 8,
+    "dexterity": 14,
+    "dexterity_save": 8,
+    "constitution": 24,
+    "constitution_save": 7,
+    "intelligence": 22,
+    "intelligence_save": 6,
+    "wisdom": 18,
+    "wisdom_save": 10,
+    "charisma": 24,
+    "charisma_save": 7,
+    "perception": 10,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 20",
+    "languages": "Infernal; telepathy 120 ft.",
+    "challenge_rating": "20",
+    "special_abilities": [
+      {
+        "name": "Diabolical Restoration",
+        "desc": "If the pit fiend dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      },
+      {
+        "name": "Fear Aura",
+        "desc": "The pit fiend emanates an aura in a 20foot Emanation while it doesn’t have the Incapacitated condition. Wisdom Saving Throw: DC 21, any enemy that starts its turn in the aura. Failure: The target has the Frightened condition until the start of its next turn. Success: The target is immune to this pit fiend’s aura for 24 hours."
+      },
+      {
+        "name": "Legendary Resistance (4/Day)",
+        "desc": "If the pit fiend fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The pit fiend has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The pit fiend makes one Bite attack, two Devilish Claw attacks, and one Fiery Mace attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 18 (3d6 + 8) Piercing damage. If the target is a creature, it must make the following saving throw. Constitution Saving Throw: DC 21. Failure: The target has the Poisoned condition. While Poisoned, the target can’t regain Hit Points and takes 21 (6d6) Poison damage at the start of each of its turns, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+        "damage_dice": "3d6",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Devilish Claw",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 26 (4d8 + 8) Necrotic damage.",
+        "damage_dice": "4d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Fiery Mace",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 22 (4d6 + 8) Force damage plus 21 (6d6) Fire damage.",
+        "damage_dice": "4d6",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Hellfire Spellcasting (Recharge 4–6)",
+        "desc": "The pit fiend casts Fireball (level 5 version) twice, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21). It can replace one Fireball with Hold Monster (level 7 version) or Wall of Fire."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "planetar": {
+    "name": "Planetar",
+    "slug": "planetar",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 262,
+    "hit_dice": "21d10 + 147",
+    "speed": {
+      "walk": 40,
+      "fly": 120,
+      "hover": true
+    },
+    "strength": 24,
+    "strength_save": 12,
+    "dexterity": 20,
+    "dexterity_save": 5,
+    "constitution": 24,
+    "constitution_save": 12,
+    "intelligence": 19,
+    "intelligence_save": 4,
+    "wisdom": 22,
+    "wisdom_save": 11,
+    "charisma": 25,
+    "charisma_save": 12,
+    "perception": 11,
+    "damage_resistances": [
+      "Radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened"
+    ],
+    "condition_immunities": [],
+    "senses": "Truesight 120 ft.; Passive Perception 21",
+    "languages": "All; telepathy 120 ft.",
+    "challenge_rating": "16",
+    "special_abilities": [
+      {
+        "name": "Divine Awareness",
+        "desc": "The planetar knows if it hears a lie."
+      },
+      {
+        "name": "Exalted Restoration",
+        "desc": "If the planetar dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in Mount Celestia."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The planetar has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The planetar makes three Radiant Sword attacks or uses Holy Burst twice."
+      },
+      {
+        "name": "Radiant Sword",
+        "desc": "Melee Attack Roll: +12, reach 10 ft. Hit: 14 (2d6 + 7) Slashing damage plus 18 (4d8) Radiant damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Holy Burst",
+        "desc": "Dexterity Saving Throw: DC 20, each enemy in a 20-foot-radius Sphere centered on a point the planetar can see within 120 feet. Failure: 24 (7d6) Radiant damage. Success: Half damage.",
+        "damage_dice": "7d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The planetar casts one of the following spells, requiring no Material components and using Charisma as spellcasting ability (spell save DC 20):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Commune, Control Weather, Dispel Evil and Good, Raise Dead"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (2/Day)",
+        "desc": "The planetar casts Cure Wounds, Invisibility, Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting. Priests"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "priest-acolyte": {
+    "name": "Priest Acolyte",
+    "slug": "priest-acolyte",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 11,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "Common",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Mace",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage plus 2 (1d4) Radiant damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Radiant Flame",
+        "desc": "Ranged Attack Roll: +4, range 60 ft. Hit: 7 (2d6) Radiant damage.",
+        "damage_dice": "2d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The priest casts one of the following spells, using Wisdom as the spellcasting ability:"
+      },
+      {
+        "name": "At Will",
+        "desc": "Light, Thaumaturgy"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (1/Day)",
+        "desc": "The priest casts Bless, Healing Word, or Sanctuary, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "priest": {
+    "name": "Priest",
+    "slug": "priest",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 38,
+    "hit_dice": "7d8 + 7",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 13,
+    "intelligence_save": 1,
+    "wisdom": 16,
+    "wisdom_save": 3,
+    "charisma": 13,
+    "charisma_save": 1,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 15",
+    "languages": "Common plus one other language",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The priest makes two attacks, using Mace or Radiant Flame in any combination."
+      },
+      {
+        "name": "Mace",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage plus 5 (2d4) Radiant damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Radiant Flame",
+        "desc": "Ranged Attack Roll: +5, range 60 ft. Hit: 11 (2d10) Radiant damage.",
+        "damage_dice": "2d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The priest casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Light, Thaumaturgy"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Spirit Guardians"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (3/Day)",
+        "desc": "The priest casts Bless, Dispel Magic, Healing Word, or Lesser Restoration, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "pseudodragon": {
+    "name": "Pseudodragon",
+    "slug": "pseudodragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "dragon",
+    "alignment": "neutral good",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 10,
+    "hit_dice": "3d4 + 3",
+    "speed": {
+      "walk": 15,
+      "fly": 60
+    },
+    "strength": 6,
+    "strength_save": -2,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 10,
+    "charisma_save": 0,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Understands Common and Draconic but can’t",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The pseudodragon has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The pseudodragon makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Sting",
+        "desc": "Constitution Saving Throw: DC 12, one creature the pseudodragon can see within 5 feet. Failure: 5 (2d4) Poison damage, and the target has the Poisoned condition for 1 hour. Failure by 5 or More: While Poisoned, the target also has the Unconscious condition, which ends early if the target takes damage or a creature within 5 feet of it takes an action to wake it.",
+        "damage_dice": "2d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "purple-worm": {
+    "name": "Purple Worm",
+    "slug": "purple-worm",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 247,
+    "hit_dice": "15d20 + 90",
+    "speed": {
+      "walk": 50,
+      "burrow": 50
+    },
+    "strength": 28,
+    "strength_save": 9,
+    "dexterity": 7,
+    "dexterity_save": -2,
+    "constitution": 22,
+    "constitution_save": 11,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 8,
+    "wisdom_save": 4,
+    "charisma": 4,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft., Tremorsense 60 ft.;",
+    "languages": "None",
+    "challenge_rating": "15",
+    "special_abilities": [
+      {
+        "name": "Tunneler",
+        "desc": "The worm can burrow through solid rock at half its Burrow Speed and leaves a 10-foot-diameter tunnel in its wake."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The worm makes one Bite attack and one Tail Stinger attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 22 (3d8 + 9) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 19), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "3d8",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Tail Stinger",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 16 (2d6 + 9) Piercing damage plus 35 (10d6) Poison damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 9
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Swallow",
+        "desc": "Strength Saving Throw: DC 19, one Large or smaller creature Grappled by the worm (it can have up to three creatures swallowed at a time). Failure: The target is swallowed by the worm, and the Grappled condition ends. A swallowed creature has the Blinded and Restrained conditions, has Total Cover against attacks and other effects outside the worm, and takes 17 (5d6) Acid damage at the start of each of the worm’s turns. If the worm takes 30 damage or more on a single turn from a creature inside it, the worm must succeed on a DC 21 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 5 feet of the worm and has the Prone condition. If the worm dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse using 20 feet of movement, exiting Prone."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "quasit": {
+    "name": "Quasit",
+    "slug": "quasit",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 25,
+    "hit_dice": "10d4",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 5,
+    "strength_save": -3,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 10,
+    "charisma_save": 0,
+    "damage_resistances": [
+      "Cold",
+      "Fire",
+      "Lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft.; Passive Perception 10",
+    "languages": "Abyssal, Common",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The quasit has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage, and the target has the Poisoned condition until the start of the quasit’s next turn.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Invisibility",
+        "desc": "The quasit casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability."
+      },
+      {
+        "name": "Scare (1/Day)",
+        "desc": "Wisdom Saving Throw: DC 10, one creature within 20 feet. Failure: The target has the Frightened condition. At the end of each of its turns, the target repeats the save, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      },
+      {
+        "name": "Shape-Shift",
+        "desc": "The quasit shape-shifts to resemble a bat (Speed 10 ft., Fly 40 ft.), a centipede (40 ft., Climb 40 ft.), or a toad (40 ft., Swim 40 ft.), or it returns to its true form. Its game statistics are the same in each form, except for its Speed. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "rakshasa": {
+    "name": "Rakshasa",
+    "slug": "rakshasa",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 8,
+    "hit_points": 221,
+    "hit_dice": "26d8 + 104",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 13,
+    "intelligence_save": 1,
+    "wisdom": 16,
+    "wisdom_save": 3,
+    "charisma": 20,
+    "charisma_save": 5,
+    "perception": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Piercing damage from weapons wielded by"
+    ],
+    "damage_immunities": [
+      "Charmed",
+      "Frightened"
+    ],
+    "condition_immunities": [],
+    "senses": "Truesight 60 ft.; Passive Perception 18",
+    "languages": "Common, Infernal",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Greater Magic Resistance",
+        "desc": "The rakshasa automatically succeeds on saving throws against spells and other magical effects, and the attack rolls of spells automatically miss it. Without the rakshasa’s permission, no spell can observe the rakshasa remotely or detect its thoughts, creature type, or alignment."
+      },
+      {
+        "name": "Fiendish Restoration",
+        "desc": "If the rakshasa dies outside the Nine Hells, its body turns to ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Nine Hells."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The rakshasa makes three Cursed Touch attacks."
+      },
+      {
+        "name": "Cursed Touch",
+        "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 12 (2d6 + 5) Slashing damage plus 19 (3d12) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target gains no benefit from finishing a Short or Long Rest.",
+        "damage_dice": "2d6",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Baleful Command (Recharge 5–6)",
+        "desc": "Wisdom Saving Throw: DC 18, each enemy in a 30-foot Emanation originating from the rakshasa. Failure: 28 (8d6) Psychic damage, and the target has the Frightened and Incapacitated conditions until the start of the rakshasa’s next turn.",
+        "damage_dice": "8d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The rakshasa casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Detect Thoughts, Disguise Self, Mage Hand, Minor Illusion"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Fly, Invisibility, Major Image, Plane Shift Red Dragons"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "red-dragon-wyrmling": {
+    "name": "Red Dragon Wyrmling",
+    "slug": "red-dragon-wyrmling",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 75,
+    "hit_dice": "10d8 + 30",
+    "speed": {
+      "walk": 30,
+      "climb": 30,
+      "fly": 60
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 2,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 15,
+    "charisma_save": 2,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Draconic",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Slashing damage plus 3 (1d6) Fire damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 13, each creature in a 15-foot Cone. Failure: 24 (7d6) Fire damage. Success: Half damage.",
+        "damage_dice": "7d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "young-red-dragon": {
+    "name": "Young Red Dragon",
+    "slug": "young-red-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 178,
+    "hit_dice": "17d10 + 85",
+    "speed": {
+      "walk": 40,
+      "climb": 40,
+      "fly": 80
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 10,
+    "dexterity_save": 4,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 11,
+    "wisdom_save": 4,
+    "charisma": 19,
+    "charisma_save": 4,
+    "perception": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "10",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 3 (1d6) Fire damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 17, each creature in a 30-foot Cone. Failure: 56 (16d6) Fire damage. Success: Half damage.",
+        "damage_dice": "16d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "adult-red-dragon": {
+    "name": "Adult Red Dragon",
+    "slug": "adult-red-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 12,
+    "hit_points": 256,
+    "hit_dice": "19d12 + 133",
+    "speed": {
+      "walk": 40,
+      "climb": 40,
+      "fly": 80
+    },
+    "strength": 27,
+    "strength_save": 8,
+    "dexterity": 10,
+    "dexterity_save": 6,
+    "constitution": 25,
+    "constitution_save": 7,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 13,
+    "wisdom_save": 7,
+    "charisma": 23,
+    "charisma_save": 6,
+    "perception": 13,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "17",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Scorching Ray."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 13 (1d10 + 8) Slashing damage plus 5 (2d4) Fire damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 21, each creature in a 60-foot Cone. Failure: 59 (17d6) Fire damage. Success: Half damage.",
+        "damage_dice": "17d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20, +12 to hit with spell attacks):",
+        "attack_bonus": 12
+      },
+      {
+        "name": "At Will",
+        "desc": "Command (level 2 version), Detect Magic, Scorching Ray"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Fireball"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Commanding Presence",
+        "desc": "The dragon uses Spellcasting to cast Command (level 2 version). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Fiery Rays",
+        "desc": "The dragon uses Spellcasting to cast Scorching Ray. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "ancient-red-dragon": {
+    "name": "Ancient Red Dragon",
+    "slug": "ancient-red-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 507,
+    "hit_dice": "26d20 + 234",
+    "speed": {
+      "walk": 40,
+      "climb": 40,
+      "fly": 80
+    },
+    "strength": 30,
+    "strength_save": 10,
+    "dexterity": 10,
+    "dexterity_save": 7,
+    "constitution": 29,
+    "constitution_save": 9,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 15,
+    "wisdom_save": 9,
+    "charisma": 27,
+    "charisma_save": 8,
+    "perception": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "24",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Scorching Ray (level 3 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +17, reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 10 (3d6) Fire damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Fire Breath (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 24, each creature in a 90-foot Cone. Failure: 91 (26d6) Fire damage. Success: Half damage.",
+        "damage_dice": "26d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks):",
+        "attack_bonus": 15
+      },
+      {
+        "name": "At Will",
+        "desc": "Command (level 2 version), Detect Magic, Scorching Ray (level 3 version)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Fireball (level 6 version), Scrying"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Commanding Presence",
+        "desc": "The dragon uses Spellcasting to cast Command (level 2 version). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Fiery Rays",
+        "desc": "The dragon uses Spellcasting to cast Scorching Ray (level 3 version). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "remorhaz": {
+    "name": "Remorhaz",
+    "slug": "remorhaz",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 195,
+    "hit_dice": "17d12 + 85",
+    "speed": {
+      "walk": 40,
+      "burrow": 30
+    },
+    "strength": 24,
+    "strength_save": 7,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 4,
+    "intelligence_save": -3,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold",
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft., Tremorsense 60 ft.;",
+    "languages": "None",
+    "challenge_rating": "11",
+    "special_abilities": [
+      {
+        "name": "Heat Aura",
+        "desc": "At the end of each of the remorhaz’s turns, each creature in a 5-foot Emanation originating from the remorhaz takes 16 (3d10) Fire damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 18 (2d10 + 7) Piercing damage plus 14 (4d6) Fire damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 17), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "2d10",
+        "damage_bonus": 7
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Swallow",
+        "desc": "Strength Saving Throw: DC 19, one Large or smaller creature Grappled by the remorhaz (it can have up to two creatures swallowed at a time). Failure: The target is swallowed by the remorhaz, and the Grappled condition ends. A swallowed creature has the Blinded and Restrained conditions, it has Total Cover against attacks and other effects outside the remorhaz, and it takes 10 (3d6) Acid damage plus 10 (3d6) Fire damage at the start of each of the remorhaz’s turns. If the remorhaz takes 30 damage or more on a single turn from a creature inside it, the remorhaz must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 5 feet of the remorhaz and has the Prone condition. If the remorhaz dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse by using 15 feet of movement, exiting Prone."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "roc": {
+    "name": "Roc",
+    "slug": "roc",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 8,
+    "hit_points": 248,
+    "hit_dice": "16d20 + 80",
+    "speed": {
+      "walk": 20,
+      "fly": 120
+    },
+    "strength": 28,
+    "strength_save": 9,
+    "dexterity": 10,
+    "dexterity_save": 4,
+    "constitution": 20,
+    "constitution_save": 5,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 4,
+    "charisma": 9,
+    "charisma_save": -1,
+    "perception": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 18",
+    "languages": "None",
+    "challenge_rating": "11",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The roc makes two Beak attacks. It can replace one attack with a Talons attack."
+      },
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +13, reach 10 ft. Hit: 28 (3d12 + 9) Piercing damage.",
+        "damage_dice": "3d12",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Talons",
+        "desc": "Melee Attack Roll: +13, reach 5 ft. Hit: 23 (4d6 + 9) Slashing damage. If the target is a Huge or smaller creature, it has the Grappled condition (escape DC 19) from both talons, and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "4d6",
+        "damage_bonus": 9
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Swoop (Recharge 5–6)",
+        "desc": "If the roc has a creature Grappled, the roc flies up to half its Fly Speed without provoking Opportunity Attacks and drops that creature."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "roper": {
+    "name": "Roper",
+    "slug": "roper",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "aberration",
+    "alignment": "neutral evil",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 93,
+    "hit_dice": "11d10 + 33",
+    "speed": {
+      "walk": 10,
+      "climb": 20
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 16,
+    "wisdom_save": 3,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 16",
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The roper can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The roper makes two Tentacle attacks, uses Reel, and makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 17 (3d8 + 4) Piercing damage.",
+        "damage_dice": "3d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Tentacle",
+        "desc": "Melee Attack Roll: +7, reach 60 ft. Hit: The target has the Grappled condition (escape DC 14) from one of six tentacles, and the target has the Poisoned condition until the grapple ends. The tentacle can be damaged, freeing a creature it has Grappled when destroyed (AC 20, HP 10, Immunity to Poison and Psychic damage). Damaging the tentacle deals no damage to the roper, and a destroyed tentacle regrows at the start of the roper’s next turn."
+      },
+      {
+        "name": "Reel",
+        "desc": "The roper pulls each creature Grappled by it up to 30 feet straight toward it."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "rust-monster": {
+    "name": "Rust Monster",
+    "slug": "rust-monster",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 33,
+    "hit_dice": "6d8 + 6",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Iron Scent",
+        "desc": "The rust monster can pinpoint the location of ferrous metal within 30 feet of itself."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The rust monster makes one Bite attack and uses Antennae twice."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 1
+      },
+      {
+        "name": "Antennae",
+        "desc": "The rust monster targets one nonmagical metal object—armor or a weapon—worn or carried by a creature within 5 feet of itself. Dexterity Saving Throw: DC 11, the creature with the object. Failure: The object takes a −1 penalty to the AC it offers (armor) or to its attack rolls (weapon). Armor is destroyed if the penalty reduces its AC to 10, and a weapon is destroyed if its penalty reaches −5. The penalty can be removed by casting the Mending spell on the armor or weapon."
+      },
+      {
+        "name": "Destroy Metal",
+        "desc": "The rust monster touches a nonmagical metal object within 5 feet of itself that isn’t being worn or carried. The touch destroys a 1-foot Cube of the object."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Reflexive Antennae",
+        "desc": "Trigger: An attack roll hits the rust monster. Response: The rust monster uses Antennae. Sahuagin"
+      }
+    ],
+    "legendary_actions": []
+  },
+  "sahuagin-warrior": {
+    "name": "Sahuagin Warrior",
+    "slug": "sahuagin-warrior",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "lawful evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 22,
+    "hit_dice": "4d8 + 4",
+    "speed": {
+      "walk": 30,
+      "swim": 40
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 9,
+    "charisma_save": -1,
+    "perception": 5,
+    "damage_resistances": [
+      "Acid",
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 15",
+    "languages": "Sahuagin",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Blood Frenzy",
+        "desc": "The sahuagin has Advantage on attack rolls against any creature that doesn’t have all its Hit Points."
+      },
+      {
+        "name": "Limited Amphibiousness",
+        "desc": "The sahuagin can breathe air and water, but it must be submerged at least once every 4 hours to avoid suffocating outside water."
+      },
+      {
+        "name": "Shark Telepathy",
+        "desc": "The sahuagin can magically control sharks within 120 feet of itself, using a special telepathy."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The sahuagin makes two Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Aquatic Charge",
+        "desc": "The sahuagin swims up to its Swim Speed straight toward an enemy it can see."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "salamander": {
+    "name": "Salamander",
+    "slug": "salamander",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 90,
+    "hit_dice": "12d10 + 24",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 12,
+    "charisma_save": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Cold"
+    ],
+    "damage_immunities": [
+      "Fire"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Primordial (Ignan)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Fire Aura",
+        "desc": "At the end of each of the salamander’s turns, each creature of the salamander’s choice in a 5-foot Emanation originating from the salamander takes 7 (2d6) Fire damage."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The salamander makes two Flame"
+      },
+      {
+        "name": "Spear attacks",
+        "desc": "It can replace one attack with a use of Constrict."
+      },
+      {
+        "name": "Flame Spear",
+        "desc": "Melee or Ranged Attack Roll: +7, reach 5 ft. or range 20/60 ft. Hit: 13 (2d8 + 4) Piercing damage plus 7 (2d6) Fire damage. Hit or Miss: The spear magically returns to the salamander’s hand immediately after a ranged attack.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 15, one Large or smaller creature the salamander can see within 10 feet. Failure: 11 (2d6 + 4) Bludgeoning damage plus 7 (2d6) Fire damage. The target has the Grappled condition (escape DC 14), and it has the Restrained condition until the grapple ends.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "satyr": {
+    "name": "Satyr",
+    "slug": "satyr",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "chaotic neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 31,
+    "hit_dice": "7d8",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 12,
+    "strength_save": 1,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 14,
+    "charisma_save": 2,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "Common, Elvish, Sylvan",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The satyr has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, the satyr pushes the target up to 10 feet straight away from itself.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Mockery",
+        "desc": "Wisdom Saving Throw: DC 12, one creature the satyr can see within 90 feet. Failure: 5 (1d6 + 2) Psychic damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "scout": {
+    "name": "Scout",
+    "slug": "scout",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 16,
+    "hit_dice": "3d8 + 3",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 11,
+    "charisma_save": 0,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 15",
+    "languages": "Common plus one other language",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The scout makes two attacks, using Shortsword and Longbow in any combination."
+      },
+      {
+        "name": "Shortsword",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Longbow",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "sea-hag": {
+    "name": "Sea Hag",
+    "slug": "sea-hag",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fey",
+    "alignment": "chaotic evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 52,
+    "hit_dice": "7d8 + 21",
+    "speed": {
+      "walk": 30,
+      "swim": 40
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 13,
+    "charisma_save": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 11",
+    "languages": "Common, Giant, Primordial (Aquan)",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The hag can breathe air and water."
+      },
+      {
+        "name": "Coven Magic",
+        "desc": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spellcasting ability (spell save DC 11): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant. The hag must finish a Long Rest before using this trait to cast that spell again."
+      },
+      {
+        "name": "Vile Appearance",
+        "desc": "Wisdom Saving Throw: DC 11, any Beast or Humanoid that starts its turn within 30 feet of the hag and can see the hag’s true form. Failure: The target has the Frightened condition until the start of its next turn. Success: The target is immune to this hag’s Vile Appearance for 24 hours."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Death Glare (Recharge 5–6)",
+        "desc": "Wisdom Saving Throw: DC 11, one Frightened creature the hag can see within 30 feet. Failure: If the target has 20 Hit Points or fewer, it drops to 0 Hit Points. Otherwise, the target takes 13 (3d8) Psychic damage.",
+        "damage_dice": "3d8"
+      },
+      {
+        "name": "Illusory Appearance",
+        "desc": "The hag casts Disguise Self, using Constitution as the spellcasting ability (spell save DC 13). The spell’s duration is 24 hours."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "shadow": {
+    "name": "Shadow",
+    "slug": "shadow",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 27,
+    "hit_dice": "5d8 + 5",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 6,
+    "strength_save": -2,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 8,
+    "charisma_save": -1,
+    "damage_resistances": [
+      "Acid",
+      "Cold",
+      "Fire",
+      "Lightning",
+      "Thunder"
+    ],
+    "damage_vulnerabilities": [
+      "Radiant"
+    ],
+    "damage_immunities": [
+      "Necrotic",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Frightened",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Prone",
+      "Restrained",
+      "Unconscious"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Amorphous",
+        "desc": "The shadow can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Sunlight Weakness",
+        "desc": "While in sunlight, the shadow has Disadvantage on D20 Tests."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Draining Swipe",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Necrotic damage, and the target’s Strength score decreases by 1d4. The target dies if this reduces that score to 0. If a Humanoid is slain by this attack, a Shadow rises from the corpse 1d4 hours later.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shadow Stealth",
+        "desc": "While in Dim Light or Darkness, the shadow takes the Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "shambling-mound": {
+    "name": "Shambling Mound",
+    "slug": "shambling-mound",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "plant",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 110,
+    "hit_dice": "13d10 + 39",
+    "speed": {
+      "walk": 30,
+      "swim": 20
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [
+      "Cold",
+      "Fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning"
+    ],
+    "condition_immunities": [
+      "Deafened",
+      "Exhaustion"
+    ],
+    "senses": "Blindsight 60 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Lightning Absorption",
+        "desc": "Whenever the shambling mound is subjected to Lightning damage, it regains a number of Hit Points equal to the Lightning damage dealt."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The shambling mound makes three"
+      },
+      {
+        "name": "Charged Tendril attacks",
+        "desc": "It can replace one attack with a use of Engulf."
+      },
+      {
+        "name": "Charged Tendril",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 5 (2d4) Lightning damage. If the target is a Medium or smaller creature, the shambling mound pulls the target 5 feet straight toward itself.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Engulf",
+        "desc": "Strength Saving Throw: DC 15, one Medium or smaller creature within 5 feet. Failure: The target is pulled into the shambling mound’s space and has the"
+      },
+      {
+        "name": "Grappled condition (escape DC 14)",
+        "desc": "Until the grapple ends, the target has the Blinded and Restrained conditions, and it takes 10 (3d6) Lightning damage at the start of each of its turns. When the shambling mound moves, the Grappled target moves with it, costing it no extra movement. The shambling mound can have only one creature Grappled by this action at a time.",
+        "damage_dice": "3d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "shield-guardian": {
+    "name": "Shield Guardian",
+    "slug": "shield-guardian",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 142,
+    "hit_dice": "15d10 + 60",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned"
+    ],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Understands commands given in any language",
+    "challenge_rating": "7",
+    "special_abilities": [
+      {
+        "name": "Bound",
+        "desc": "The guardian is magically bound to an amulet. While the guardian and its amulet are on the same plane of existence, the amulet’s wearer can telepathically call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. If the guardian is within 60 feet of the amulet’s wearer, half of any damage the wearer takes (round up) is transferred to the guardian."
+      },
+      {
+        "name": "Regeneration",
+        "desc": "The guardian regains 10 Hit Points at the start of each of its turns if it has at least 1 Hit Point."
+      },
+      {
+        "name": "Spell Storing",
+        "desc": "A spellcaster who wears the guardian’s amulet can cause the guardian to store one spell of level 4 or lower. To do so, the wearer must cast the spell on the guardian while within 5 feet of it. The spell has no effect but is stored within the guardian. Any previously stored spell is lost when a new spell is stored. The guardian can cast the spell stored with any parameters set by the original caster, requiring no spell components and using the caster’s spellcasting ability. The stored spell is then lost."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The guardian makes two Fist attacks."
+      },
+      {
+        "name": "Fist",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Bludgeoning damage plus 7 (2d6) Force damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Protection",
+        "desc": "Trigger: An attack roll hits the wearer of the guardian’s amulet while the wearer is within 5 feet of the guardian. Response: The wearer gains a +5 bonus to AC, including against the triggering attack and possibly causing it to miss, until the start of the guardian’s next turn. Silver Dragons"
+      }
+    ],
+    "legendary_actions": []
+  },
+  "silver-dragon-wyrmling": {
+    "name": "Silver Dragon Wyrmling",
+    "slug": "silver-dragon-wyrmling",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 45,
+    "hit_dice": "6d8 + 18",
+    "speed": {
+      "walk": 30,
+      "fly": 60
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 2,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 11,
+    "wisdom_save": 2,
+    "charisma": 15,
+    "charisma_save": 2,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Draconic",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 13, each creature in a 15-foot Cone. Failure: 18 (4d8) Cold damage. Success: Half damage.",
+        "damage_dice": "4d8"
+      },
+      {
+        "name": "Paralyzing Breath",
+        "desc": "Constitution Saving Throw: DC 13, each creature in a 15-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "young-silver-dragon": {
+    "name": "Young Silver Dragon",
+    "slug": "young-silver-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 168,
+    "hit_dice": "16d10 + 80",
+    "speed": {
+      "walk": 40,
+      "fly": 80
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 10,
+    "dexterity_save": 4,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 11,
+    "wisdom_save": 4,
+    "charisma": 19,
+    "charisma_save": 4,
+    "perception": 8,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "9",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of Paralyzing Breath."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (2d8 + 6) Slashing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 17, each creature in a 30-foot Cone. Failure: 49 (11d8) Cold damage. Success: Half damage.",
+        "damage_dice": "11d8"
+      },
+      {
+        "name": "Paralyzing Breath",
+        "desc": "Constitution Saving Throw: DC 17, each creature in a 30-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "adult-silver-dragon": {
+    "name": "Adult Silver Dragon",
+    "slug": "adult-silver-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 216,
+    "hit_dice": "16d12 + 112",
+    "speed": {
+      "walk": 40,
+      "fly": 80
+    },
+    "strength": 27,
+    "strength_save": 8,
+    "dexterity": 10,
+    "dexterity_save": 5,
+    "constitution": 25,
+    "constitution_save": 7,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 13,
+    "wisdom_save": 6,
+    "charisma": 22,
+    "charisma_save": 6,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "16",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Paralyzing Breath or (B) Spellcasting to cast Ice Knife."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +13, reach 10 ft. Hit: 17 (2d8 + 8) Slashing damage plus 4 (1d8) Cold damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 20, each creature in a 60-foot Cone. Failure: 54 (12d8) Cold damage. Success: Half damage.",
+        "damage_dice": "12d8"
+      },
+      {
+        "name": "Paralyzing Breath",
+        "desc": "Constitution Saving Throw: DC 20, each creature in a 60-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 19, +11 to hit with spell attacks):",
+        "attack_bonus": 11
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Hold Monster, Ice Knife, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Ice Storm (level 5 version), Zone of Truth"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Chill",
+        "desc": "The dragon uses Spellcasting to cast Hold Monster. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Cold Gale",
+        "desc": "Dexterity Saving Throw: DC 19, each creature in a 60-foot-long, 10-foot-wide Line. Failure: 14 (4d6) Cold damage, and the target is pushed up to 30 feet straight away from the dragon. Success: Half damage only. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "4d6"
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "ancient-silver-dragon": {
+    "name": "Ancient Silver Dragon",
+    "slug": "ancient-silver-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "lawful good",
+    "armor_class": 22,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 468,
+    "hit_dice": "24d20 + 216",
+    "speed": {
+      "walk": 40,
+      "fly": 80
+    },
+    "strength": 30,
+    "strength_save": 10,
+    "dexterity": 10,
+    "dexterity_save": 7,
+    "constitution": 29,
+    "constitution_save": 9,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 15,
+    "wisdom_save": 9,
+    "charisma": 26,
+    "charisma_save": 8,
+    "perception": 16,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "23",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Paralyzing Breath or (B) Spellcasting to cast Ice Knife (level 2 version)."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +17, reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 9 (2d8) Cold damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 24, each creature in a 90-foot Cone. Failure: 67 (15d8) Cold damage. Success: Half damage.",
+        "damage_dice": "15d8"
+      },
+      {
+        "name": "Paralyzing Breath",
+        "desc": "Constitution Saving Throw: DC 24, each creature in a 90-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks):",
+        "attack_bonus": 15
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Hold Monster, Ice Knife (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell)"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Control Weather, Ice Storm (level 7 version), Teleport, Zone of Truth"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Chill",
+        "desc": "The dragon uses Spellcasting to cast Hold Monster. The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Cold Gale",
+        "desc": "Dexterity Saving Throw: DC 23, each creature in a 60-foot-long, 10-foot-wide Line. Failure: 14 (4d6) Cold damage, and the target is pushed up to 30 feet straight away from the dragon. Success: Half damage only. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "4d6"
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack. Skeletons"
+      }
+    ]
+  },
+  "skeleton": {
+    "name": "Skeleton",
+    "slug": "skeleton",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "lawful evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 13,
+    "hit_dice": "2d8 + 4",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Bludgeoning"
+    ],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "Understands Common plus one other language",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Shortsword",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Shortbow",
+        "desc": "Ranged Attack Roll: +5, range 80/320 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "warhorse-skeleton": {
+    "name": "Warhorse Skeleton",
+    "slug": "warhorse-skeleton",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "undead",
+    "alignment": "lawful evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 22,
+    "hit_dice": "3d10 + 6",
+    "speed": {
+      "walk": 60
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Bludgeoning"
+    ],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage. If the target is a Large or smaller creature and the skeleton moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "minotaur-skeleton": {
+    "name": "Minotaur Skeleton",
+    "slug": "minotaur-skeleton",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "undead",
+    "alignment": "lawful evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 45,
+    "hit_dice": "6d10 + 12",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [
+      "Bludgeoning"
+    ],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "Understands Abyssal but can’t speak",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature and the skeleton moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Bludgeoning damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "solar": {
+    "name": "Solar",
+    "slug": "solar",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 21,
+    "armor_desc": "",
+    "initiative": 20,
+    "hit_points": 297,
+    "hit_dice": "22d10 + 176",
+    "speed": {
+      "walk": 50,
+      "fly": 150,
+      "hover": true
+    },
+    "strength": 26,
+    "strength_save": 8,
+    "dexterity": 22,
+    "dexterity_save": 6,
+    "constitution": 26,
+    "constitution_save": 8,
+    "intelligence": 25,
+    "intelligence_save": 7,
+    "wisdom": 25,
+    "wisdom_save": 7,
+    "charisma": 30,
+    "charisma_save": 10,
+    "perception": 14,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison",
+      "Radiant"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Poisoned"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 24",
+    "languages": "All; telepathy 120 ft.",
+    "challenge_rating": "21",
+    "special_abilities": [
+      {
+        "name": "Divine Awareness",
+        "desc": "The solar knows if it hears a lie."
+      },
+      {
+        "name": "Exalted Restoration",
+        "desc": "If the solar dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in Mount Celestia."
+      },
+      {
+        "name": "Legendary Resistance (4/Day)",
+        "desc": "If the solar fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The solar has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The solar makes two Flying Sword attacks. It can replace one attack with a use of Slaying Bow."
+      },
+      {
+        "name": "Flying Sword",
+        "desc": "Melee or Ranged Attack Roll: +15, reach 10 ft. or range 120 ft. Hit: 22 (4d6 + 8) Slashing damage plus 36 (8d8) Radiant damage. Hit or Miss: The sword magically returns to the solar’s hand or hovers within 5 feet of the solar immediately after a ranged attack.",
+        "damage_dice": "4d6",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Slaying Bow",
+        "desc": "Dexterity Saving Throw: DC 21, one creature the solar can see within 600 feet. Failure: If the creature has 100 Hit Points or fewer, it dies. It otherwise takes 24 (4d8 + 6) Piercing damage plus 36 (8d8) Radiant damage.",
+        "damage_dice": "4d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The solar casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 25):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Commune, Control Weather, Dispel Evil and Good, Resurrection"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Divine Aid (3/Day)",
+        "desc": "The solar casts Cure Wounds (level 2 version), Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Blinding Gaze",
+        "desc": "Constitution Saving Throw: DC 25, one creature the solar can see within 120 feet. Failure: The target has the Blinded condition for 1 minute. Failure or Success: The solar can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Radiant Teleport",
+        "desc": "The solar teleports up to 60 feet to an unoccupied space it can see. Dexterity Saving Throw: DC 25, each creature in a 10-foot Emanation originating from the solar at its destination space. Failure: 11 (2d10) Radiant damage. Success: Half damage.",
+        "damage_dice": "2d10"
+      }
+    ]
+  },
+  "specter": {
+    "name": "Specter",
+    "slug": "specter",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": 30,
+      "fly": 50,
+      "hover": true
+    },
+    "strength": 1,
+    "strength_save": -5,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 11,
+    "charisma_save": 0,
+    "damage_resistances": [
+      "Acid",
+      "Bludgeoning",
+      "Cold",
+      "Fire",
+      "Lightning",
+      ""
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Necrotic",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Prone",
+      "Restrained",
+      "Unconscious"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Understands Common plus one other language",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Incorporeal Movement",
+        "desc": "The specter can move through other creatures and objects as if they were Difficult"
+      },
+      {
+        "name": "Terrain",
+        "desc": "It takes 5 (1d10) Force damage if it ends its turn inside an object."
+      },
+      {
+        "name": "Sunlight Sensitivity",
+        "desc": "While in sunlight, the specter has Disadvantage on ability checks and attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Life Drain",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d6) Necrotic damage. If the target is a creature, its Hit Point maximum decreases by an amount equal to the damage taken. Sphinxes",
+        "damage_dice": "2d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "sphinx-of-wonder": {
+    "name": "Sphinx of Wonder",
+    "slug": "sphinx-of-wonder",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 24,
+    "hit_dice": "7d4 + 7",
+    "speed": {
+      "walk": 20,
+      "fly": 40
+    },
+    "strength": 6,
+    "strength_save": -2,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 15,
+    "intelligence_save": 2,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 11,
+    "charisma_save": 0,
+    "damage_resistances": [
+      "Necrotic",
+      "Psychic",
+      "Radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 11",
+    "languages": "Celestial, Common",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Magic Resistance",
+        "desc": "The sphinx has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage plus 7 (2d6) Radiant damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Burst of Ingenuity (2/Day)",
+        "desc": "Trigger: The sphinx or another creature within 30 feet makes an ability check or a saving throw. Response: The sphinx adds 2 to the roll."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "sphinx-of-lore": {
+    "name": "Sphinx of Lore",
+    "slug": "sphinx-of-lore",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 170,
+    "hit_dice": "20d10 + 60",
+    "speed": {
+      "walk": 40,
+      "fly": 60
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 18,
+    "intelligence_save": 4,
+    "wisdom": 18,
+    "wisdom_save": 4,
+    "charisma": 18,
+    "charisma_save": 4,
+    "perception": 8,
+    "damage_resistances": [
+      "Necrotic",
+      "Radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Psychic"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Frightened"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 18",
+    "languages": "Celestial, Common",
+    "challenge_rating": "11",
+    "special_abilities": [
+      {
+        "name": "Inscrutable",
+        "desc": "No magic can observe the sphinx remotely or detect its thoughts without its permission. Wisdom (Insight) checks made to ascertain its intentions or sincerity are made with Disadvantage."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the sphinx fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The sphinx makes three Claw attacks."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 14 (3d6 + 4) Slashing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Mind-Rending Roar (Recharge 5–6)",
+        "desc": "Wisdom Saving Throw: DC 16, each enemy in a 300-foot Emanation originating from the sphinx. Failure: 35 (10d6) Psychic damage, and the target has the Incapacitated condition until the start of the sphinx’s next turn.",
+        "damage_dice": "10d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The sphinx casts one of the following spells, requiring no Material components and using Intelligence as the spellcasting ability (spell save DC 16):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Identify, Mage Hand, Minor Illusion, Prestidigitation"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Dispel Magic, Legend Lore, Locate Object, Plane Shift, Remove Curse, Tongues"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Arcane Prowl",
+        "desc": "The sphinx can teleport up to 30 feet to an unoccupied space it can see, and it makes one Claw attack."
+      },
+      {
+        "name": "Weight of Years",
+        "desc": "Constitution Saving Throw: DC 16, one creature the sphinx can see within 120 feet. Failure: The target gains 1 Exhaustion level. While the target has any Exhaustion levels, it appears 3d10 years older. Failure or Success: The sphinx can’t take this action again until the start of its next turn."
+      }
+    ]
+  },
+  "sphinx-of-valor": {
+    "name": "Sphinx of Valor",
+    "slug": "sphinx-of-valor",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 12,
+    "hit_points": 199,
+    "hit_dice": "19d10 + 95",
+    "speed": {
+      "walk": 40,
+      "fly": 60
+    },
+    "strength": 22,
+    "strength_save": 6,
+    "dexterity": 10,
+    "dexterity_save": 6,
+    "constitution": 20,
+    "constitution_save": 11,
+    "intelligence": 16,
+    "intelligence_save": 9,
+    "wisdom": 23,
+    "wisdom_save": 12,
+    "charisma": 18,
+    "charisma_save": 4,
+    "perception": 12,
+    "damage_resistances": [
+      "Necrotic",
+      "Radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Psychic"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Frightened"
+    ],
+    "senses": "Truesight 120 ft.; Passive Perception 22",
+    "languages": "Celestial, Common",
+    "challenge_rating": "17",
+    "special_abilities": [
+      {
+        "name": "Inscrutable",
+        "desc": "No magic can observe the sphinx remotely or detect its thoughts without its permission. Wisdom (Insight) checks made to ascertain its intentions or sincerity are made with Disadvantage."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the sphinx fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The sphinx makes two Claw attacks and uses Roar."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +12, reach 5 ft. Hit: 20 (4d6 + 6) Slashing damage.",
+        "damage_dice": "4d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Roar (3/Day)",
+        "desc": "The sphinx emits a magical roar. Whenever it roars, the roar has a different effect, as detailed below (the sequence resets when it takes a Long Rest):"
+      },
+      {
+        "name": "First Roar",
+        "desc": "Wisdom Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: The target has the Frightened condition for 1 minute."
+      },
+      {
+        "name": "Second Roar",
+        "desc": "Wisdom Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: The target has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically."
+      },
+      {
+        "name": "Third Roar",
+        "desc": "Constitution Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: 44 (8d10) Thunder damage, and the target has the Prone condition. Success: Half damage only.",
+        "damage_dice": "8d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The sphinx casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 20):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Thaumaturgy"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Detect Magic, Dispel Magic, Greater Restoration, Heroes’ Feast, Zone of Truth"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Arcane Prowl",
+        "desc": "The sphinx can teleport up to 30 feet to an unoccupied space it can see, and it makes one Claw attack."
+      },
+      {
+        "name": "Weight of Years",
+        "desc": "Constitution Saving Throw: DC 16, one creature the sphinx can see within 120 feet. Failure: The target gains 1 Exhaustion level. While the target has any Exhaustion levels, it appears 3d10 years older. Failure or Success: The sphinx can’t take this action again until the start of its next turn."
+      }
+    ]
+  },
+  "spirit-naga": {
+    "name": "Spirit Naga",
+    "slug": "spirit-naga",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 135,
+    "hit_dice": "18d10 + 36",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 17,
+    "dexterity_save": 6,
+    "constitution": 14,
+    "constitution_save": 5,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 15,
+    "wisdom_save": 5,
+    "charisma": 16,
+    "charisma_save": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 12",
+    "languages": "Abyssal, Common",
+    "challenge_rating": "8",
+    "special_abilities": [
+      {
+        "name": "Fiendish Restoration",
+        "desc": "If it dies, the naga returns to life in 1d6 days and regains all its Hit Points. Only a Wish spell can prevent this trait from functioning."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The naga makes three attacks, using Bite or Necrotic Ray in any combination."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 7 (1d6 + 4) Piercing damage plus 14 (4d6) Poison damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Necrotic Ray",
+        "desc": "Ranged Attack Roll: +6, range 60 ft. Hit: 21 (6d6) Necrotic damage.",
+        "damage_dice": "6d6"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The naga casts one of the following spells, requiring no Somatic or Material components and using Intelligence as the spellcasting ability (spell save DC 14):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Mage Hand, Minor Illusion, Water Breathing"
+      },
+      {
+        "name": "2/Day Each",
+        "desc": "Detect Thoughts, Dimension Door, Hold Person (level 3 version), Lightning Bolt (level 4 version)"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "sprite": {
+    "name": "Sprite",
+    "slug": "sprite",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "fey",
+    "alignment": "neutral good",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 10,
+    "hit_dice": "4d4",
+    "speed": {
+      "walk": 10,
+      "fly": 40
+    },
+    "strength": 3,
+    "strength_save": -4,
+    "dexterity": 18,
+    "dexterity_save": 4,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 14,
+    "intelligence_save": 2,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 11,
+    "charisma_save": 0,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 13",
+    "languages": "Common, Elvish, Sylvan",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Needle Sword",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Enchanting Bow",
+        "desc": "Ranged Attack Roll: +6, range 40/160 ft. Hit: 1 Piercing damage, and the target has the Charmed condition until the start of the sprite’s next turn."
+      },
+      {
+        "name": "Heart Sight",
+        "desc": "Charisma Saving Throw: DC 10, one creature within 5 feet the sprite can see (Celestials, Fiends, and Undead automatically fail the save). Failure: The sprite knows the target’s emotions and alignment."
+      },
+      {
+        "name": "Invisibility",
+        "desc": "The sprite casts Invisibility on itself, requiring no spell components and using Charisma as the spellcasting ability."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "spy": {
+    "name": "Spy",
+    "slug": "spy",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 27,
+    "hit_dice": "6d8",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 16,
+    "charisma_save": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 16",
+    "languages": "Common plus one other language",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Shortsword",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Hand Crossbow",
+        "desc": "Ranged Attack Roll: +4, range 30/120 ft. Hit: 5 (1d6 + 2) Piercing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Cunning Action",
+        "desc": "The spy takes the Dash, Disengage, or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "stirge": {
+    "name": "Stirge",
+    "slug": "stirge",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 5,
+    "hit_dice": "2d4",
+    "speed": {
+      "walk": 10,
+      "fly": 40
+    },
+    "strength": 4,
+    "strength_save": -3,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Proboscis",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage, and the stirge attaches to the target. While attached, the stirge can’t make Proboscis attacks, and the target takes 5 (2d4) Necrotic damage at the start of each of the stirge’s turns. The stirge can detach itself by spending 5 feet of its movement. The target or a creature within 5 feet of it can detach the stirge as an action.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "stone-giant": {
+    "name": "Stone Giant",
+    "slug": "stone-giant",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 126,
+    "hit_dice": "11d12 + 55",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 15,
+    "dexterity_save": 5,
+    "constitution": 20,
+    "constitution_save": 8,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 12,
+    "wisdom_save": 4,
+    "charisma": 9,
+    "charisma_save": -1,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Giant",
+    "challenge_rating": "7",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Stone Club or Boulder in any combination."
+      },
+      {
+        "name": "Stone Club",
+        "desc": "Melee Attack Roll: +9, reach 15 ft. Hit: 22 (3d10 + 6) Bludgeoning damage.",
+        "damage_dice": "3d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Boulder",
+        "desc": "Ranged Attack Roll: +9, range 60/240 ft. Hit: 15 (2d8 + 6) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Deflect Missile (Recharge 5–6)",
+        "desc": "Trigger: The giant is hit by a ranged attack roll and takes Bludgeoning, Piercing, or Slashing damage from it. Response: The giant reduces the damage it takes from the attack by 11 (1d10 + 6), and if that damage is reduced to 0, the giant can redirect some of the attack’s force. Dexterity Saving Throw: DC 17, one creature the giant can see within 60 feet. Failure: 11 (1d10 + 6) Force damage."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "stone-golem": {
+    "name": "Stone Golem",
+    "slug": "stone-golem",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "construct",
+    "alignment": "unaligned",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 220,
+    "hit_dice": "21d10 + 105",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 22,
+    "strength_save": 6,
+    "dexterity": 9,
+    "dexterity_save": -1,
+    "constitution": 20,
+    "constitution_save": 5,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison",
+      "Psychic"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Frightened",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft.; Passive Perception 10",
+    "languages": "Understands Common plus two other",
+    "challenge_rating": "10",
+    "special_abilities": [
+      {
+        "name": "Immutable Form",
+        "desc": "The golem can’t shape-shift."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The golem has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The golem makes two attacks, using Slam or Force Bolt in any combination."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 15 (2d8 + 6) Bludgeoning damage plus 9 (2d8) Force damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Force Bolt",
+        "desc": "Ranged Attack Roll: +9, range 120 ft. Hit: 22 (4d10) Force damage.",
+        "damage_dice": "4d10"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Slow (Recharge 5–6)",
+        "desc": "The golem casts the Slow spell, requiring no spell components and using Constitution as the spellcasting ability (spell save DC 17)."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "storm-giant": {
+    "name": "Storm Giant",
+    "slug": "storm-giant",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "giant",
+    "alignment": "chaotic good",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 7,
+    "hit_points": 230,
+    "hit_dice": "20d12 + 100",
+    "speed": {
+      "walk": 50,
+      "fly": 25,
+      "hover": true,
+      "swim": 50
+    },
+    "strength": 29,
+    "strength_save": 14,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 20,
+    "constitution_save": 10,
+    "intelligence": 16,
+    "intelligence_save": 3,
+    "wisdom": 20,
+    "wisdom_save": 10,
+    "charisma": 18,
+    "charisma_save": 9,
+    "perception": 10,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning",
+      "Thunder"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft., Truesight 30 ft.;",
+    "languages": "Common, Giant",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The giant can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The giant makes two attacks, using Storm Sword or Thunderbolt in any combination."
+      },
+      {
+        "name": "Storm Sword",
+        "desc": "Melee Attack Roll: +14, reach 10 ft. Hit: 23 (4d6 + 9) Slashing damage plus 13 (3d8) Lightning damage.",
+        "damage_dice": "4d6",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Thunderbolt",
+        "desc": "Ranged Attack Roll: +14, range 500 ft. Hit: 22 (2d12 + 9) Lightning damage, and the target has the Blinded and Deafened conditions until the start of the giant’s next turn.",
+        "damage_dice": "2d12",
+        "damage_bonus": 9
+      },
+      {
+        "name": "Lightning Storm (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 18, each creature in a 10-foot-radius, 40-foot-high Cylinder originating from a point the giant can see within 500 feet. Failure: 55 (10d10) Lightning damage. Success: Half damage.",
+        "damage_dice": "10d10"
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The giant casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 18):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Magic, Light"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Control Weather"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "succubus": {
+    "name": "Succubus",
+    "slug": "succubus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "fiend",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 71,
+    "hit_dice": "13d8 + 13",
+    "speed": {
+      "walk": 30,
+      "fly": 60
+    },
+    "strength": 8,
+    "strength_save": -1,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 15,
+    "intelligence_save": 2,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 20,
+    "charisma_save": 5,
+    "perception": 5,
+    "damage_resistances": [
+      "Cold",
+      "Fire",
+      "Poison",
+      "Psychic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "Abyssal, Common, Infernal; telepathy 60 ft.",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Incubus Form",
+        "desc": "When the succubus finishes a Long Rest, it can shape-shift into an Incubus, using that stat block instead of this one."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The succubus makes one Fiendish Touch attack and uses Charm or Draining Kiss."
+      },
+      {
+        "name": "Fiendish Touch",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 16 (2d10 + 5) Psychic damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Charm",
+        "desc": "The succubus casts Dominate Person (level 8 version), requiring no spell components and using Charisma as the spellcasting ability (spell save DC 15)."
+      },
+      {
+        "name": "Draining Kiss",
+        "desc": "Constitution Saving Throw: DC 15, one creature Charmed by the succubus within 5 feet. Failure: 13 (3d8) Psychic damage. Success: Half damage. Failure or Success: The target’s Hit Point maximum decreases by an amount equal to the damage taken.",
+        "damage_dice": "3d8"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The succubus shape-shifts into a Medium or Small Humanoid, or it returns to its true form. Its game statistics are the same in each form, except its Fly"
+      },
+      {
+        "name": "Speed is available only in its true form",
+        "desc": "Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "tarrasque": {
+    "name": "Tarrasque",
+    "slug": "tarrasque",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 25,
+    "armor_desc": "",
+    "initiative": 18,
+    "hit_points": 697,
+    "hit_dice": "34d20 + 340",
+    "speed": {
+      "walk": 60,
+      "burrow": 40,
+      "climb": 60
+    },
+    "strength": 30,
+    "strength_save": 10,
+    "dexterity": 11,
+    "dexterity_save": 9,
+    "constitution": 30,
+    "constitution_save": 10,
+    "intelligence": 3,
+    "intelligence_save": 5,
+    "wisdom": 11,
+    "wisdom_save": 9,
+    "charisma": 11,
+    "charisma_save": 9,
+    "perception": 9,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Fire",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Deafened",
+      "Frightened",
+      "Paralyzed",
+      "Poisoned"
+    ],
+    "senses": "Blindsight 120 ft.; Passive Perception 19",
+    "languages": "None",
+    "challenge_rating": "30",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (6/Day)",
+        "desc": "If the tarrasque fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The tarrasque has Advantage on saving throws against spells and other magical effects."
+      },
+      {
+        "name": "Reflective Carapace",
+        "desc": "If the tarrasque is targeted by a Magic Missile spell or a spell that requires a ranged attack roll, roll 1d6. On a 1–5, the tarrasque is unaffected. On a 6, the tarrasque is unaffected and reflects the spell, turning the caster into the target."
+      },
+      {
+        "name": "Siege Monster",
+        "desc": "The tarrasque deals double damage to objects and structures."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The tarrasque makes one Bite attack and three other attacks, using Claw or Tail in any combination."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +19, reach 15 ft. Hit: 36 (4d12 + 10) Piercing damage, and the target has the Grappled condition (escape DC 20). Until the grapple ends, the target has the Restrained condition and can’t teleport.",
+        "damage_dice": "4d12",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +19, reach 15 ft. Hit: 28 (4d8 + 10) Slashing damage.",
+        "damage_dice": "4d8",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +19, reach 30 ft. Hit: 23 (3d8 + 10) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+        "damage_dice": "3d8",
+        "damage_bonus": 10
+      },
+      {
+        "name": "Thunderous Bellow (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 27, each creature and each object that isn’t being worn or carried in a 150-foot Cone. Failure: 78 (12d12) Thunder damage, and the target has the Deafened and Frightened conditions until the end of its next turn. Success: Half damage only.",
+        "damage_dice": "12d12"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Swallow",
+        "desc": "Strength Saving Throw: DC 27, one Large or smaller creature Grappled by the tarrasque (it can have up to six creatures swallowed at a time). Failure: The target is swallowed, and the Grappled condition ends. A swallowed creature has the Blinded and Restrained conditions and can’t teleport, it has Total Cover against attacks and other effects outside the tarrasque, and it takes 56 (16d6) Acid damage at the start of each of the tarrasque’s turns. If the tarrasque takes 60 damage or more on a single turn from a creature inside it, the tarrasque must succeed on a DC 20 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 10 feet of the tarrasque and has the Prone condition. If the tarrasque dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse using 20 feet of movement, exiting Prone."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Onslaught",
+        "desc": "The tarrasque moves up to half its Speed, and it makes one Claw or Tail attack."
+      },
+      {
+        "name": "World-Shaking Movement",
+        "desc": "The tarrasque moves up to its Speed. At the end of this movement, the tarrasque creates an instantaneous shock wave in a 60-foot Emanation originating from itself. Creatures in that area lose Concentration and, if Medium or smaller, have the Prone condition. The tarrasque can’t take this action again until the start of its next turn. Toughs"
+      }
+    ]
+  },
+  "tough": {
+    "name": "Tough",
+    "slug": "tough",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 32,
+    "hit_dice": "5d8 + 10",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 11,
+    "charisma_save": 0,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The tough has Advantage on an attack roll against a creature if at least one of the tough’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Mace",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Heavy Crossbow",
+        "desc": "Ranged Attack Roll: +3, range 100/400 ft. Hit: 6 (1d10 + 1) Piercing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "tough-boss": {
+    "name": "Tough Boss",
+    "slug": "tough-boss",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 82,
+    "hit_dice": "11d8 + 33",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 17,
+    "strength_save": 5,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 16,
+    "constitution_save": 5,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 11,
+    "charisma_save": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common plus one other language",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The tough has Advantage on an attack roll against a creature if at least one of the tough’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The tough makes two attacks, using Warhammer or Heavy Crossbow in any combination."
+      },
+      {
+        "name": "Warhammer",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Bludgeoning damage. If the target is a Large or smaller creature, the tough pushes the target up to 10 feet straight away from itself.",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Heavy Crossbow",
+        "desc": "Ranged Attack Roll: +4, range 100/400 ft. Hit: 13 (2d10 + 2) Piercing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "treant": {
+    "name": "Treant",
+    "slug": "treant",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "plant",
+    "alignment": "chaotic good",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 138,
+    "hit_dice": "12d12 + 60",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 16,
+    "wisdom_save": 3,
+    "charisma": 12,
+    "charisma_save": 1,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing"
+    ],
+    "damage_vulnerabilities": [
+      "Fire"
+    ],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 13",
+    "languages": "Common, Druidic, Elvish, Sylvan",
+    "challenge_rating": "9",
+    "special_abilities": [
+      {
+        "name": "Siege Monster",
+        "desc": "The treant deals double damage to objects and structures."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The treant makes two Slam attacks."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +10, reach 5 ft. Hit: 16 (3d6 + 6) Bludgeoning damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Hail of Bark",
+        "desc": "Ranged Attack Roll: +10, range 180 ft. Hit: 28 (4d10 + 6) Piercing damage.",
+        "damage_dice": "4d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Animate Trees (1/Day)",
+        "desc": "The treant magically animates up to two trees it can see within 60 feet of itself. Each tree uses the Treant stat block, except it has Intelligence and Charisma scores of 1, it can’t speak, and it lacks this action. The tree takes its turn immediately after the treant on the same Initiative count, and it obeys the treant. A tree remains animate for 1 day or until it dies, the treant dies, or it is more than 120 feet from the treant. The tree then takes root if possible."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "troll": {
+    "name": "Troll",
+    "slug": "troll",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "giant",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 94,
+    "hit_dice": "9d10 + 45",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 20,
+    "constitution_save": 5,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 9,
+    "wisdom_save": -1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "Giant",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Loathsome Limbs (4/Day)",
+        "desc": "If the troll ends any turn Bloodied and took 15+ Slashing damage during that turn, one of the troll’s limbs is severed, falls into the troll’s space, and becomes a Troll Limb. The limb acts immediately after the troll’s turn. The troll has 1 Exhaustion level for each missing limb, and it grows replacement limbs the next time it regains Hit Points."
+      },
+      {
+        "name": "Regeneration",
+        "desc": "The troll regains 15 Hit Points at the start of each of its turns. If the troll takes Acid or Fire damage, this trait doesn’t function on the troll’s next turn. The troll dies only if it starts its turn with 0 Hit Points and doesn’t regenerate."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The troll makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Charge",
+        "desc": "The troll moves up to half its Speed straight toward an enemy it can see."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "troll-limb": {
+    "name": "Troll Limb",
+    "slug": "troll-limb",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "giant",
+    "alignment": "chaotic evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 14,
+    "hit_dice": "4d6",
+    "speed": {
+      "walk": 20
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 9,
+    "wisdom_save": -1,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 9",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Regeneration",
+        "desc": "The limb regains 5 Hit Points at the start of each of its turns. If the limb takes Acid or Fire damage, this trait doesn’t function on the limb’s next turn. The limb dies only if it starts its turn with 0 Hit Points and doesn’t regenerate."
+      },
+      {
+        "name": "Troll Spawn",
+        "desc": "The limb uncannily has the same senses as a whole troll. If the limb isn’t destroyed within 24 hours, roll 1d12. On a 12, the limb turns into a Troll. Otherwise, the limb withers away."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Slashing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "unicorn": {
+    "name": "Unicorn",
+    "slug": "unicorn",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "lawful good",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 8,
+    "hit_points": 97,
+    "hit_dice": "13d10 + 26",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 17,
+    "wisdom_save": 3,
+    "charisma": 16,
+    "charisma_save": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Paralyzed",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "Celestial, Elvish, Sylvan; telepathy 120 ft.",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day)",
+        "desc": "If the unicorn fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The unicorn has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The unicorn makes one Hooves attack and one Radiant Horn attack."
+      },
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 11 (2d6 + 4) Bludgeoning damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Radiant Horn",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 9 (1d10 + 4) Radiant damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The unicorn casts one of the following spells, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 14):"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Druidcraft"
+      },
+      {
+        "name": "1/Day Each",
+        "desc": "Calm Emotions, Dispel Evil and Good, Entangle, Pass without Trace, Word of Recall"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Charging Horn",
+        "desc": "The unicorn moves up to half its Speed without provoking Opportunity Attacks, and it makes one Radiant Horn attack."
+      },
+      {
+        "name": "Shimmering Shield",
+        "desc": "The unicorn targets itself or one creature it can see within 60 feet of itself. The target gains 10 (3d6) Temporary Hit Points, and its AC increases by 2 until the end of the unicorn’s next turn. The unicorn can’t take this action again until the start of its next turn. Vampires"
+      }
+    ]
+  },
+  "vampire-familiar": {
+    "name": "Vampire Familiar",
+    "slug": "vampire-familiar",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 65,
+    "hit_dice": "10d8 + 20",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 16,
+    "dexterity_save": 5,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 2,
+    "charisma": 14,
+    "charisma_save": 2,
+    "perception": 4,
+    "damage_resistances": [
+      "Necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed (except from its vampire master)"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Common plus one other language",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Vampiric Connection",
+        "desc": "While the familiar and its vampire master are on the same plane of existence, the vampire can communicate with the familiar telepathically, and the vampire can perceive through the familiar’s senses."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The familiar makes two Umbral Dagger attacks."
+      },
+      {
+        "name": "Umbral Dagger",
+        "desc": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 20/60 ft. Hit: 5 (1d4 + 3) Piercing damage plus 7 (3d4) Necrotic damage. If the target is reduced to 0 Hit Points by this attack, the target becomes Stable but has the Poisoned condition for 1 hour. While it has the Poisoned condition, the target has the Paralyzed condition.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Deathless Agility",
+        "desc": "The familiar takes the Dash or Disengage action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "vampire-spawn": {
+    "name": "Vampire Spawn",
+    "slug": "vampire-spawn",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small undead",
+    "alignment": "neutral evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 90,
+    "hit_dice": "12d8 + 36",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 16,
+    "dexterity_save": 6,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 3,
+    "charisma": 12,
+    "charisma_save": 1,
+    "perception": 3,
+    "damage_resistances": [
+      "Necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "Common plus one other language",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The vampire can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Vampire Weakness",
+        "desc": "The vampire has these weaknesses:"
+      },
+      {
+        "name": "Forbiddance",
+        "desc": "The vampire can’t enter a residence without an invitation from an occupant."
+      },
+      {
+        "name": "Running Water",
+        "desc": "The vampire takes 20 Acid damage if it ends its turn in running water."
+      },
+      {
+        "name": "Stake to the Heart",
+        "desc": "The vampire is destroyed if a weapon that deals Piercing damage is driven into the vampire’s heart while the vampire has the Incapacitated condition."
+      },
+      {
+        "name": "Sunlight",
+        "desc": "The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Disadvantage on attack rolls and ability checks."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The vampire makes two Claw attacks and uses Bite."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (2d4 + 3) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 13) from one of two claws."
+      },
+      {
+        "name": "Bite",
+        "desc": "Constitution Saving Throw: DC 14, one creature within 5 feet that is willing or that has the Grappled, Incapacitated, or Restrained condition. Failure: 5 (1d4 + 3) Piercing damage plus 10 (3d6) Necrotic damage. The target’s Hit Point maximum decreases by an amount equal to the Necrotic damage taken, and the vampire regains Hit Points equal to that amount.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Deathless Agility",
+        "desc": "The vampire takes the Dash or Disengage action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "vampire": {
+    "name": "Vampire",
+    "slug": "vampire",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small undead",
+    "alignment": "lawful evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 14,
+    "hit_points": 195,
+    "hit_dice": "23d8 + 92",
+    "speed": {
+      "walk": 40,
+      "climb": 40
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 18,
+    "dexterity_save": 9,
+    "constitution": 18,
+    "constitution_save": 9,
+    "intelligence": 17,
+    "intelligence_save": 3,
+    "wisdom": 15,
+    "wisdom_save": 7,
+    "charisma": 18,
+    "charisma_save": 9,
+    "perception": 7,
+    "damage_resistances": [
+      "Necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 17",
+    "languages": "Common plus two other languages",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the vampire fails a saving throw, it can choose to succeed instead."
+      },
+      {
+        "name": "Misty Escape",
+        "desc": "If the vampire drops to 0 Hit Points outside its resting place, the vampire uses Shape-Shift to become mist (no action required). If it can’t use ShapeShift, it is destroyed. While it has 0 Hit Points in mist form, it can’t return to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it returns to its vampire form and has the Paralyzed condition until it regains any Hit Points, and it regains 1 Hit Point after spending 1 hour there."
+      },
+      {
+        "name": "Spider Climb",
+        "desc": "The vampire can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Vampire Weakness",
+        "desc": "The vampire has these weaknesses:"
+      },
+      {
+        "name": "Forbiddance",
+        "desc": "The vampire can’t enter a residence without an invitation from an occupant."
+      },
+      {
+        "name": "Running Water",
+        "desc": "The vampire takes 20 Acid damage if it ends its turn in running water."
+      },
+      {
+        "name": "Stake to the Heart",
+        "desc": "If a weapon that deals Piercing damage is driven into the vampire’s heart while the vampire has the Incapacitated condition in its resting place, the vampire has the Paralyzed condition until the weapon is removed."
+      },
+      {
+        "name": "Sunlight",
+        "desc": "The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Disadvantage on attack rolls and ability checks."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack (Vampire Form Only)",
+        "desc": "The vampire makes two Grave Strike attacks and uses Bite."
+      },
+      {
+        "name": "Grave Strike (Vampire Form Only)",
+        "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 8 (1d8 + 4) Bludgeoning damage plus 7 (2d6) Necrotic damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of two hands.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Bite (Bat or Vampire Form Only)",
+        "desc": "Constitution Saving Throw: DC 17, one creature within 5 feet that is willing or that has the Grappled, Incapacitated, or Restrained condition. Failure: 6 (1d4 + 4) Piercing damage plus 13 (3d8) Necrotic damage. The target’s Hit Point maximum decreases by an amount equal to the Necrotic damage taken, and the vampire regains Hit Points equal to that amount. A Humanoid reduced to 0 Hit Points by this damage and then buried rises the following sunset as a Vampire Spawn under the vampire’s control.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Charm (Recharge 5–6)",
+        "desc": "The vampire casts Charm Person, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 17), and the duration is 24 hours. The Charmed target is a willing recipient of the vampire’s Bite, the damage of which doesn’t end the spell. When the spell ends, the target is unaware it was Charmed by the vampire."
+      },
+      {
+        "name": "Shape-Shift",
+        "desc": "If the vampire isn’t in sunlight or running water, it shape-shifts into a Tiny bat (Speed 5 ft., Fly Speed 30 ft.) or a Medium cloud of mist (Speed 5 ft., Fly Speed 20 ft. [hover]), or it returns to its vampire form. Anything it is wearing transforms with it. While in bat form, the vampire can’t speak. Its game statistics, other than its size and Speed, are unchanged. While in mist form, the vampire can’t take any actions, speak, or manipulate objects. It is weightless and can enter an enemy’s space and stop there. If air can pass through a space, the mist can do so, but it can’t pass through liquid. It has Resistance to all damage, except the damage it takes from sunlight."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Beguile",
+        "desc": "The vampire casts Command, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 17). The vampire can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Deathless Strike",
+        "desc": "The vampire moves up to half its Speed, and it makes one Grave Strike attack."
+      }
+    ]
+  },
+  "vrock": {
+    "name": "Vrock",
+    "slug": "vrock",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fiend",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 152,
+    "hit_dice": "16d10 + 64",
+    "speed": {
+      "walk": 40,
+      "fly": 60
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 15,
+    "dexterity_save": 5,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 8,
+    "intelligence_save": -1,
+    "wisdom": 13,
+    "wisdom_save": 4,
+    "charisma": 8,
+    "charisma_save": 2,
+    "damage_resistances": [
+      "Cold",
+      "Fire",
+      "Lightning"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Poisoned"
+    ],
+    "senses": "Darkvision 120 ft.; Passive Perception 11",
+    "languages": "Abyssal; telepathy 120 ft.",
+    "challenge_rating": "6",
+    "special_abilities": [
+      {
+        "name": "Demonic Restoration",
+        "desc": "If the vrock dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points somewhere in the Abyss."
+      },
+      {
+        "name": "Magic Resistance",
+        "desc": "The vrock has Advantage on saving throws against spells and other magical effects."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The vrock makes two Shred attacks."
+      },
+      {
+        "name": "Shred",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage plus 10 (3d6) Poison damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Spores (Recharge 6)",
+        "desc": "Constitution Saving Throw: DC 15, each creature in a 20-foot Emanation originating from the vrock. Failure: The target has the Poisoned condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. While Poisoned, the target takes 5 (1d10) Poison damage at the start of each of its turns. Emptying a flask of Holy Water on the target ends the effect early.",
+        "damage_dice": "1d10"
+      },
+      {
+        "name": "Stunning Screech (1/Day)",
+        "desc": "Constitution Saving Throw: DC 15, each creature in a 20-foot Emanation originating from the vrock (demons succeed automatically). Failure: 10 (3d6) Thunder damage, and the target has the Stunned condition until the end of the vrock’s next turn. Warriors",
+        "damage_dice": "3d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "warrior-infantry": {
+    "name": "Warrior Infantry",
+    "slug": "warrior-infantry",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 9,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 8,
+    "intelligence_save": -1,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 8,
+    "charisma_save": -1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "Common",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The warrior has Advantage on an attack roll against a creature if at least one of the warrior’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Spear",
+        "desc": "Melee or Ranged Attack Roll: +3, reach 5 ft. or range 20/60 ft. Hit: 4 (1d6 + 1) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "warrior-veteran": {
+    "name": "Warrior Veteran",
+    "slug": "warrior-veteran",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small humanoid",
+    "alignment": "neutral",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 65,
+    "hit_dice": "10d8 + 20",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 10,
+    "charisma_save": 0,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "Common plus one other language",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The warrior makes two Greatsword or Heavy Crossbow attacks."
+      },
+      {
+        "name": "Greatsword",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Heavy Crossbow",
+        "desc": "Ranged Attack Roll: +3, range 100/400 ft. Hit: 12 (2d10 + 1) Piercing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Parry",
+        "desc": "Trigger: The warrior is hit by a melee attack roll while holding a weapon. Response: The warrior adds 2 to its AC against that attack, possibly causing it to miss."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "water-elemental": {
+    "name": "Water Elemental",
+    "slug": "water-elemental",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 114,
+    "hit_dice": "12d10 + 48",
+    "speed": {
+      "walk": 30,
+      "swim": 90
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 8,
+    "charisma_save": -1,
+    "damage_resistances": [
+      "Acid",
+      "Fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Prone",
+      "Restrained",
+      "Unconscious"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "Primordial (Aquan)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Freeze",
+        "desc": "If the elemental takes Cold damage, its Speed decreases by 20 feet until the end of its next turn."
+      },
+      {
+        "name": "Water Form",
+        "desc": "The elemental can enter an enemy’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The elemental makes two Slam attacks."
+      },
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Whelm (Recharge 4–6)",
+        "desc": "Strength Saving Throw: DC 15, each creature in the elemental’s space. Failure: 22 (4d8 + 4) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14). Until the grapple ends, the target has the Restrained condition, is suffocating unless it can breathe water, and takes 9 (2d8) Bludgeoning damage at the start of each of the elemental’s turns. The elemental can grapple one Large creature or up to two Medium or smaller creatures at a time with Whelm. As an action, a creature within 5 feet of the elemental can pull a creature out of it by succeeding on a DC 14 Strength (Athletics) check. Success: Half damage only.",
+        "damage_dice": "4d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "werebear": {
+    "name": "Werebear",
+    "slug": "werebear",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small monstrosity",
+    "alignment": "neutral good",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 135,
+    "hit_dice": "18d8 + 54",
+    "speed": {
+      "walk": 40,
+      "climb": 30
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 12,
+    "charisma_save": 1,
+    "perception": 7,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 17",
+    "languages": "Common (can’t speak in bear form)",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The werebear makes two attacks, using"
+      },
+      {
+        "name": "Handaxe or Rend in any combination",
+        "desc": "It can replace one attack with a Bite attack."
+      },
+      {
+        "name": "Bite (Bear or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 17 (2d12 + 4) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 14. Failure:",
+        "damage_dice": "2d12",
+        "damage_bonus": 4
+      },
+      {
+        "name": "The target is cursed",
+        "desc": "If the cursed target drops to 0 Hit Points, it instead becomes a Werebear under the GM’s control and has 10 Hit Points. Success: The target is immune to this werebear’s curse for 24 hours."
+      },
+      {
+        "name": "Handaxe (Humanoid or Hybrid Form Only)",
+        "desc": "Melee or Ranged Attack Roll: +7, reach 5 ft or range 20/60 ft. Hit: 14 (3d6 + 4) Slashing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Rend (Bear or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The werebear shape-shifts into a Large bear-humanoid hybrid form or a Large bear, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "wereboar": {
+    "name": "Wereboar",
+    "slug": "wereboar",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 97,
+    "hit_dice": "15d8 + 30",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "Common (can’t speak in boar form)",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The wereboar makes two attacks, using"
+      },
+      {
+        "name": "Javelin or Tusk in any combination",
+        "desc": "It can replace one attack with a Gore attack."
+      },
+      {
+        "name": "Gore (Boar or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 12. Failure:",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "The target is cursed",
+        "desc": "If the cursed target drops to 0 Hit Points, it instead becomes a Wereboar under the GM’s control and has 10 Hit Points. Success: The target is immune to this wereboar’s curse for 24 hours."
+      },
+      {
+        "name": "Javelin (Humanoid or Hybrid Form Only)",
+        "desc": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 30/120 ft. Hit: 13 (3d6 + 3) Piercing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Tusk (Boar or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Medium or smaller creature and the wereboar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 7 (2d6) Piercing damage and has the Prone condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The wereboar shape-shifts into a Medium boar-humanoid hybrid or a Small boar, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "wererat": {
+    "name": "Wererat",
+    "slug": "wererat",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small monstrosity",
+    "alignment": "lawful evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 60,
+    "hit_dice": "11d8 + 11",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Common (can’t speak in rat form)",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The wererat makes two attacks, using"
+      },
+      {
+        "name": "Scratch or Hand Crossbow in any combination",
+        "desc": "It can replace one attack with a Bite attack."
+      },
+      {
+        "name": "Bite (Rat or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (2d4 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 11. Failure: The target is cursed. If the cursed target drops to 0 Hit Points, it instead becomes a Wererat under the GM’s control and has 10 Hit Points. Success: The target is immune to this wererat’s curse for 24 hours.",
+        "damage_dice": "2d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Scratch",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage. Hand Crossbow (Humanoid or Hybrid Form Only). Ranged Attack Roll: +5, range 30/120 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The wererat shape-shifts into a Medium rat-humanoid hybrid or a Small rat, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "weretiger": {
+    "name": "Weretiger",
+    "slug": "weretiger",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small monstrosity",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 120,
+    "hit_dice": "16d8 + 48",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 11,
+    "charisma_save": 0,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "Common (can’t speak in tiger form)",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The weretiger makes two attacks, using"
+      },
+      {
+        "name": "Scratch or Longbow in any combination",
+        "desc": "It can replace one attack with a Bite attack."
+      },
+      {
+        "name": "Bite (Tiger or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 13. Failure:",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "The target is cursed",
+        "desc": "If the cursed target drops to 0 Hit Points, it instead becomes a Weretiger under the GM’s control and has 10 Hit Points. Success: The target is immune to this weretiger’s curse for 24 hours."
+      },
+      {
+        "name": "Scratch",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Longbow (Humanoid or Hybrid Form Only)",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 11 (2d8 + 2) Piercing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Prowl (Tiger or Hybrid Form Only)",
+        "desc": "The weretiger moves up to its Speed without provoking Opportunity"
+      },
+      {
+        "name": "Attacks",
+        "desc": "At the end of this movement, the weretiger can take the Hide action."
+      },
+      {
+        "name": "Shape-Shift",
+        "desc": "The weretiger shape-shifts into a Large tiger-humanoid hybrid or a Large tiger, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "werewolf": {
+    "name": "Werewolf",
+    "slug": "werewolf",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small monstrosity",
+    "alignment": "chaotic evil",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 71,
+    "hit_dice": "11d8 + 22",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 10,
+    "charisma_save": 0,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Common (can’t speak in wolf form)",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The werewolf has Advantage on an attack roll against a creature if at least one of the werewolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The werewolf makes two attacks, using"
+      },
+      {
+        "name": "Scratch or Longbow in any combination",
+        "desc": "It can replace one attack with a Bite attack."
+      },
+      {
+        "name": "Bite (Wolf or Hybrid Form Only)",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 12. Failure:",
+        "damage_dice": "2d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "The target is cursed",
+        "desc": "If the cursed target drops to 0 Hit Points, it instead becomes a Werewolf under the GM’s control and has 10 Hit Points. Success: The target is immune to this werewolf’s curse for 24 hours."
+      },
+      {
+        "name": "Scratch",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Longbow (Humanoid or Hybrid Form Only)",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 11 (2d8 + 2) Piercing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Shape-Shift",
+        "desc": "The werewolf shape-shifts into a Large wolf-humanoid hybrid or a Medium wolf, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. White Dragons"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "white-dragon-wyrmling": {
+    "name": "White Dragon Wyrmling",
+    "slug": "white-dragon-wyrmling",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 16,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 32,
+    "hit_dice": "5d8 + 10",
+    "speed": {
+      "walk": 30,
+      "burrow": 15,
+      "fly": 60,
+      "swim": 30
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 10,
+    "dexterity_save": 2,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 10,
+    "wisdom_save": 2,
+    "charisma": 11,
+    "charisma_save": 0,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "Draconic",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Ice Walk",
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 2 (1d4) Cold damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 22 (5d8) Cold damage. Success: Half damage.",
+        "damage_dice": "5d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "young-white-dragon": {
+    "name": "Young White Dragon",
+    "slug": "young-white-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 123,
+    "hit_dice": "13d10 + 52",
+    "speed": {
+      "walk": 40,
+      "burrow": 20,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 3,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 6,
+    "intelligence_save": 2,
+    "wisdom": 11,
+    "wisdom_save": 3,
+    "charisma": 12,
+    "charisma_save": 1,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "6",
+    "special_abilities": [
+      {
+        "name": "Ice Walk",
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 9 (2d4 + 4) Slashing damage plus 2 (1d4) Cold damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 15, each creature in a 30-foot Cone. Failure: 40 (9d8) Cold damage. Success: Half damage.",
+        "damage_dice": "9d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "adult-white-dragon": {
+    "name": "Adult White Dragon",
+    "slug": "adult-white-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 18,
+    "armor_desc": "",
+    "initiative": 10,
+    "hit_points": 200,
+    "hit_dice": "16d12 + 96",
+    "speed": {
+      "walk": 40,
+      "burrow": 30,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 22,
+    "strength_save": 6,
+    "dexterity": 10,
+    "dexterity_save": 5,
+    "constitution": 22,
+    "constitution_save": 6,
+    "intelligence": 8,
+    "intelligence_save": -1,
+    "wisdom": 12,
+    "wisdom_save": 6,
+    "charisma": 12,
+    "charisma_save": 1,
+    "perception": 11,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "13",
+    "special_abilities": [
+      {
+        "name": "Ice Walk",
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+      },
+      {
+        "name": "Legendary Resistance (3/Day, or 4/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +11, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 4 (1d8) Cold damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 19, each creature in a 60-foot Cone. Failure: 54 (12d8) Cold damage. Success: Half damage.",
+        "damage_dice": "12d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Freezing Burst",
+        "desc": "Constitution Saving Throw: DC 14, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 7 (2d6) Cold damage, and the target’s Speed is 0 until the end of the target’s next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "2d6"
+      },
+      {
+        "name": "Frightful Presence",
+        "desc": "The dragon casts Fear, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 14). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "ancient-white-dragon": {
+    "name": "Ancient White Dragon",
+    "slug": "ancient-white-dragon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Gargantuan",
+    "type": "dragon",
+    "alignment": "chaotic evil",
+    "armor_class": 20,
+    "armor_desc": "",
+    "initiative": 12,
+    "hit_points": 333,
+    "hit_dice": "18d20 + 144",
+    "speed": {
+      "walk": 40,
+      "burrow": 40,
+      "fly": 80,
+      "swim": 40
+    },
+    "strength": 26,
+    "strength_save": 8,
+    "dexterity": 10,
+    "dexterity_save": 6,
+    "constitution": 26,
+    "constitution_save": 8,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 13,
+    "wisdom_save": 7,
+    "charisma": 18,
+    "charisma_save": 4,
+    "perception": 13,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft., Darkvision 120 ft.;",
+    "languages": "Common, Draconic",
+    "challenge_rating": "20",
+    "special_abilities": [
+      {
+        "name": "Ice Walk",
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement."
+      },
+      {
+        "name": "Legendary Resistance (4/Day, or 5/Day in Lair)",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The dragon makes three Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +14, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 7 (2d6) Cold damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 8
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Failure: 63 (14d8) Cold damage. Success: Half damage.",
+        "damage_dice": "14d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": [
+      {
+        "name": "Freezing Burst",
+        "desc": "Constitution Saving Throw: DC 20, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 14 (4d6) Cold damage, and the target’s Speed is 0 until the end of the target’s next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "damage_dice": "4d6"
+      },
+      {
+        "name": "Frightful Presence",
+        "desc": "The dragon casts Fear, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18). The dragon can’t take this action again until the start of its next turn."
+      },
+      {
+        "name": "Pounce",
+        "desc": "The dragon moves up to half its Speed, and it makes one Rend attack."
+      }
+    ]
+  },
+  "wight": {
+    "name": "Wight",
+    "slug": "wight",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "neutral evil",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 82,
+    "hit_dice": "11d8 + 33",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 15,
+    "charisma_save": 2,
+    "perception": 3,
+    "damage_resistances": [
+      "Necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "Common plus one other language",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Sunlight Sensitivity",
+        "desc": "While in sunlight, the wight has Disadvantage on ability checks and attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The wight makes two attacks, using Necrotic Sword or Necrotic Bow in any combination. It can replace one attack with a use of Life Drain."
+      },
+      {
+        "name": "Necrotic Sword",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 4 (1d8) Necrotic damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Necrotic Bow",
+        "desc": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage plus 4 (1d8) Necrotic damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Life Drain",
+        "desc": "Constitution Saving Throw: DC 13, one creature within 5 feet. Failure: 6 (1d8 + 2) Necrotic damage, and the target’s Hit Point maximum decreases by an amount equal to the damage taken. A Humanoid slain by this attack rises 24 hours later as a Zombie under the wight’s control, unless the Humanoid is restored to life or its body is destroyed. The wight can have no more than twelve zombies under its control at a time.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "will-o-wisp": {
+    "name": "Will-o’-Wisp",
+    "slug": "will-o-wisp",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "undead",
+    "alignment": "chaotic evil",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 9,
+    "hit_points": 27,
+    "hit_dice": "11d4",
+    "speed": {
+      "walk": 5,
+      "fly": 50,
+      "hover": true
+    },
+    "strength": 1,
+    "strength_save": -5,
+    "dexterity": 28,
+    "dexterity_save": 9,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 13,
+    "intelligence_save": 1,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 11,
+    "charisma_save": 0,
+    "damage_resistances": [
+      "Acid",
+      "Bludgeoning",
+      "Cold",
+      "Fire",
+      "Necrotic",
+      ""
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Lightning",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Prone",
+      "Restrained",
+      "Unconscious"
+    ],
+    "senses": "Darkvision 120 ft.; Passive Perception 12",
+    "languages": "Common plus one other language",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Ephemeral",
+        "desc": "The wisp can’t wear or carry anything."
+      },
+      {
+        "name": "Illumination",
+        "desc": "The wisp sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet."
+      },
+      {
+        "name": "Incorporeal Movement",
+        "desc": "The wisp can move through other creatures and objects as if they were Difficult"
+      },
+      {
+        "name": "Terrain",
+        "desc": "It takes 5 (1d10) Force damage if it ends its turn inside an object."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Shock",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 11 (2d8 + 2) Lightning damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Consume Life",
+        "desc": "Constitution Saving Throw: DC 10, one living creature the wisp can see within 5 feet that has 0 Hit Points. Failure: The target dies, and the wisp regains 10 (3d6) Hit Points."
+      },
+      {
+        "name": "Vanish",
+        "desc": "The wisp and its light have the Invisible condition until the wisp’s Concentration ends on this effect, which ends early immediately after the wisp makes an attack roll or uses Consume Life."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "winter-wolf": {
+    "name": "Winter Wolf",
+    "slug": "winter-wolf",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 75,
+    "hit_dice": "10d10 + 20",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Cold"
+    ],
+    "condition_immunities": [],
+    "senses": "Passive Perception 15",
+    "languages": "Common, Giant",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The wolf has Advantage on an attack roll against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature, it has the Prone condition."
+      },
+      {
+        "name": "Cold Breath (Recharge 5–6)",
+        "desc": "Constitution Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 18 (4d8) Cold damage. Success: Half damage.",
+        "damage_dice": "4d8"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "worg": {
+    "name": "Worg",
+    "slug": "worg",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "fey",
+    "alignment": "neutral evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 26,
+    "hit_dice": "4d10 + 4",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "Goblin, Worg",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage, and the next attack roll made against the target before the start of the worg’s next turn has Advantage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "wraith": {
+    "name": "Wraith",
+    "slug": "wraith",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "or small undead",
+    "alignment": "neutral evil",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 67,
+    "hit_dice": "9d8 + 27",
+    "speed": {
+      "walk": 5,
+      "fly": 60,
+      "hover": true
+    },
+    "strength": 6,
+    "strength_save": -2,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 12,
+    "intelligence_save": 1,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 15,
+    "charisma_save": 2,
+    "damage_resistances": [
+      "Acid",
+      "Bludgeoning",
+      "Cold",
+      "Fire",
+      "Piercing",
+      ""
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Necrotic",
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Charmed",
+      "Exhaustion",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Poisoned",
+      "Prone",
+      "Restrained",
+      "Unconscious"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 12",
+    "languages": "Common plus two other languages",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Incorporeal Movement",
+        "desc": "The wraith can move through other creatures and objects as if they were Difficult"
+      },
+      {
+        "name": "Terrain",
+        "desc": "It takes 5 (1d10) Force damage if it ends its turn inside an object."
+      },
+      {
+        "name": "Sunlight Sensitivity",
+        "desc": "While in sunlight, the wraith has Disadvantage on ability checks and attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Life Drain",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 21 (4d8 + 3) Necrotic damage. If the target is a creature, its Hit Point maximum decreases by an amount equal to the damage taken.",
+        "damage_dice": "4d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Create Specter",
+        "desc": "The wraith targets a Humanoid corpse within 10 feet of itself that has been dead for no longer than 1 minute. The target’s spirit rises as a Specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith’s control. The wraith can have no more than seven specters under its control at a time."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "wyvern": {
+    "name": "Wyvern",
+    "slug": "wyvern",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "dragon",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 127,
+    "hit_dice": "15d10 + 45",
+    "speed": {
+      "walk": 30,
+      "fly": 80
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 14",
+    "languages": "None",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The wyvern makes one Bite attack and one Sting attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 13 (2d8 + 4) Piercing damage.",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Sting",
+        "desc": "Melee Attack Roll: +7, reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage plus 24 (7d6) Poison damage, and the target has the Poisoned condition until the start of the wyvern’s next turn.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "xorn": {
+    "name": "Xorn",
+    "slug": "xorn",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "elemental",
+    "alignment": "neutral",
+    "armor_class": 19,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 84,
+    "hit_dice": "8d8 + 48",
+    "speed": {
+      "walk": 20,
+      "burrow": 20
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 22,
+    "constitution_save": 6,
+    "intelligence": 11,
+    "intelligence_save": 0,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 11,
+    "charisma_save": 0,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Paralyzed",
+      "Petrified",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft., Tremorsense 60 ft.;",
+    "languages": "Primordial (Terran)",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Earth Glide",
+        "desc": "The xorn can burrow through nonmagical, unworked earth and stone. While doing so, the xorn doesn’t disturb the material it moves through."
+      },
+      {
+        "name": "Treasure Sense",
+        "desc": "The xorn can pinpoint the location of precious metals and stones within 60 feet of itself."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The xorn makes one Bite attack and three Claw attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 17 (4d6 + 3) Piercing damage.",
+        "damage_dice": "4d6",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Charge",
+        "desc": "The xorn moves up to its Speed or Burrow Speed straight toward an enemy it can sense. Zombies"
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "zombie": {
+    "name": "Zombie",
+    "slug": "zombie",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "undead",
+    "alignment": "neutral evil",
+    "armor_class": 8,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 15,
+    "hit_dice": "2d8 + 6",
+    "speed": {
+      "walk": 20
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 6,
+    "dexterity_save": -2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 6,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 8",
+    "languages": "Understands Common plus one other language",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Undead Fortitude",
+        "desc": "If damage reduces the zombie to 0 Hit Points, it makes a Constitution saving throw (DC 5 plus the damage taken) unless the damage is Radiant or from a Critical Hit. On a successful save, the zombie drops to 1 Hit Point instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Bludgeoning damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "ogre-zombie": {
+    "name": "Ogre Zombie",
+    "slug": "ogre-zombie",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "undead",
+    "alignment": "neutral evil",
+    "armor_class": 8,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 85,
+    "hit_dice": "9d10 + 36",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 6,
+    "dexterity_save": -2,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 6,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Poison"
+    ],
+    "condition_immunities": [
+      "Exhaustion",
+      "Poisoned"
+    ],
+    "senses": "Darkvision 60 ft.; Passive Perception 8",
+    "languages": "Understands Common and Giant but can’t",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Undead Fortitude",
+        "desc": "If damage reduces the zombie to 0 Hit Points, it makes a Constitution saving throw (DC 5 plus the damage taken) unless the damage is Radiant or from a Critical Hit. On a successful save, the zombie drops to 1 Hit Point instead."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Slam",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage. Animals",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "allosaurus": {
+    "name": "Allosaurus",
+    "slug": "allosaurus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 51,
+    "hit_dice": "6d10 + 18",
+    "speed": {
+      "walk": 60
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Piercing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Claws",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Slashing damage. If the target is a Large or smaller creature and the allosaurus moved 30+ feet straight toward it immediately before the hit, the target has the Prone condition, and the allosaurus can make one Bite attack against it.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "ankylosaurus": {
+    "name": "Ankylosaurus",
+    "slug": "ankylosaurus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 68,
+    "hit_dice": "8d12 + 16",
+    "speed": {
+      "walk": 30
+    },
+    "strength": 19,
+    "strength_save": 6,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ankylosaurus makes two Tail attacks."
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+        "damage_dice": "1d10",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "ape": {
+    "name": "Ape",
+    "slug": "ape",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 19,
+    "hit_dice": "3d8 + 6",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ape makes two Fist attacks."
+      },
+      {
+        "name": "Fist",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Bludgeoning damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Rock (Recharge 6)",
+        "desc": "Ranged Attack Roll: +5, range 25/50 ft. Hit: 10 (2d6 + 3) Bludgeoning damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "archelon": {
+    "name": "Archelon",
+    "slug": "archelon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 17,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 90,
+    "hit_dice": "12d12 + 12",
+    "speed": {
+      "walk": 20,
+      "swim": 80
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 4,
+    "intelligence_save": -3,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The archelon can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The archelon makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 14 (3d6 + 4) Piercing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "baboon": {
+    "name": "Baboon",
+    "slug": "baboon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 3,
+    "hit_dice": "1d6",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 8,
+    "strength_save": -1,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 4,
+    "intelligence_save": -3,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The baboon has Advantage on an attack roll against a creature if at least one of the baboon’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 (1d4 − 1) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": -1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "badger": {
+    "name": "Badger",
+    "slug": "badger",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 5,
+    "hit_dice": "1d4 + 3",
+    "speed": {
+      "walk": 20,
+      "burrow": 5
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 3,
+    "damage_resistances": [
+      "Poison"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 30 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "bat": {
+    "name": "Bat",
+    "slug": "bat",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 1,
+    "hit_dice": "1d4 − 1",
+    "speed": {
+      "walk": 5,
+      "fly": 30
+    },
+    "strength": 2,
+    "strength_save": -4,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 8,
+    "constitution_save": -1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 4,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft.; Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "black-bear": {
+    "name": "Black Bear",
+    "slug": "black-bear",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d8 + 6",
+    "speed": {
+      "walk": 30,
+      "climb": 30,
+      "swim": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bear makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "blood-hawk": {
+    "name": "Blood Hawk",
+    "slug": "blood-hawk",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 7,
+    "hit_dice": "2d6",
+    "speed": {
+      "walk": 10,
+      "fly": 60
+    },
+    "strength": 6,
+    "strength_save": -2,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 16",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The hawk has Advantage on an attack roll against a creature if at least one of the hawk’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage, or 6 (1d8 + 2) Piercing damage if the target is Bloodied.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "boar": {
+    "name": "Boar",
+    "slug": "boar",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 13,
+    "hit_dice": "2d8 + 4",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 9,
+    "wisdom_save": -1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 9",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Bloodied Fury",
+        "desc": "While Bloodied, the boar has Advantage on attack rolls."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Piercing damage. If the target is a Medium or smaller creature and the boar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 3 (1d6) Piercing damage and has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "brown-bear": {
+    "name": "Brown Bear",
+    "slug": "brown-bear",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 22,
+    "hit_dice": "3d10 + 6",
+    "speed": {
+      "walk": 40,
+      "climb": 30
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bear makes one Bite attack and one Claw attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "camel": {
+    "name": "Camel",
+    "slug": "camel",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 17,
+    "hit_dice": "2d10 + 6",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 17,
+    "constitution_save": 5,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Bludgeoning damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "cat": {
+    "name": "Cat",
+    "slug": "cat",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 2,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": 40,
+      "climb": 40
+    },
+    "strength": 3,
+    "strength_save": -4,
+    "dexterity": 15,
+    "dexterity_save": 4,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Jumper",
+        "desc": "The cat’s jump distance is determined using its Dexterity rather than its Strength."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Scratch",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Slashing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "constrictor-snake": {
+    "name": "Constrictor Snake",
+    "slug": "constrictor-snake",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 13,
+    "hit_dice": "2d10 + 2",
+    "speed": {
+      "walk": 30,
+      "swim": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 12, one Medium or smaller creature the snake can see within 5 feet. Failure: 7 (3d4) Bludgeoning damage, and the target has the Grappled condition (escape DC 12).",
+        "damage_dice": "3d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "crab": {
+    "name": "Crab",
+    "slug": "crab",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 3,
+    "hit_dice": "1d4 + 1",
+    "speed": {
+      "walk": 20,
+      "swim": 20
+    },
+    "strength": 6,
+    "strength_save": -2,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 2,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft.; Passive Perception 9",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The crab can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Bludgeoning damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "crocodile": {
+    "name": "Crocodile",
+    "slug": "crocodile",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 13,
+    "hit_dice": "2d10 + 2",
+    "speed": {
+      "walk": 20,
+      "swim": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 13,
+    "constitution_save": 3,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The crocodile can hold its breath for 1 hour."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12). While Grappled, the target has the Restrained condition.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "deer": {
+    "name": "Deer",
+    "slug": "deer",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 4,
+    "hit_dice": "1d8",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Agile",
+        "desc": "The deer doesn’t provoke an Opportunity Attack when it moves out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Bludgeoning damage.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "dire-wolf": {
+    "name": "Dire Wolf",
+    "slug": "dire-wolf",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "3d10 + 6",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The wolf has Advantage on an attack roll against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Piercing damage. If the target is a Large or smaller creature, it has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "draft-horse": {
+    "name": "Draft Horse",
+    "slug": "draft-horse",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 15,
+    "hit_dice": "2d10 + 4",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Bludgeoning damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "eagle": {
+    "name": "Eagle",
+    "slug": "eagle",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 4,
+    "hit_dice": "1d6 + 1",
+    "speed": {
+      "walk": 10,
+      "fly": 60
+    },
+    "strength": 6,
+    "strength_save": -2,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 16",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Talons",
+        "desc": "Melee Attack Roll: +4, reach 5 feet. Hit: 4 (1d4 + 2) Slashing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "elephant": {
+    "name": "Elephant",
+    "slug": "elephant",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 76,
+    "hit_dice": "8d12 + 24",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 22,
+    "strength_save": 6,
+    "dexterity": 9,
+    "dexterity_save": -1,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The elephant makes two Gore attacks."
+      },
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 15 (2d8 + 6) Piercing damage. If the target is a Huge or smaller creature and the elephant moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+        "damage_dice": "2d8",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Trample",
+        "desc": "Dexterity Saving Throw: DC 16, one creature within 5 feet that has the Prone condition. Failure: 17 (2d10 + 6) Bludgeoning damage. Success: Half damage."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "elk": {
+    "name": "Elk",
+    "slug": "elk",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 11,
+    "hit_dice": "2d10",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature and the elk moved 20+ feet straight toward it immediately before the hit, the target takes an extra 3 (1d6) Bludgeoning damage and has the Prone condition.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "flying-snake": {
+    "name": "Flying Snake",
+    "slug": "flying-snake",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "monstrosity",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 5,
+    "hit_dice": "2d4",
+    "speed": {
+      "walk": 30,
+      "fly": 60,
+      "swim": 30
+    },
+    "strength": 4,
+    "strength_save": -3,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft.; Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The snake doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage plus 5 (2d4) Poison damage.",
+        "damage_dice": "2d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "frog": {
+    "name": "Frog",
+    "slug": "frog",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 1,
+    "hit_dice": "1d4 − 1",
+    "speed": {
+      "walk": 20,
+      "swim": 20
+    },
+    "strength": 1,
+    "strength_save": -5,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 8,
+    "constitution_save": -1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 3,
+    "charisma_save": -4,
+    "perception": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 30 ft.; Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The frog can breathe air and water."
+      },
+      {
+        "name": "Standing Leap",
+        "desc": "The frog’s Long Jump is up to 10 feet and its High Jump is up to 5 feet with or without a running start."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-ape": {
+    "name": "Giant Ape",
+    "slug": "giant-ape",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 5,
+    "hit_points": 168,
+    "hit_dice": "16d12 + 64",
+    "speed": {
+      "walk": 40,
+      "climb": 40
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 18,
+    "constitution_save": 4,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 14",
+    "languages": "None",
+    "challenge_rating": "7",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The ape makes two Fist attacks."
+      },
+      {
+        "name": "Fist",
+        "desc": "Melee Attack Roll: +9, reach 10 ft. Hit: 22 (3d10 + 6) Bludgeoning damage.",
+        "damage_dice": "3d10",
+        "damage_bonus": 6
+      },
+      {
+        "name": "Boulder Toss (Recharge 6)",
+        "desc": "The ape hurls a boulder at a point it can see within 90 feet. Dexterity Saving Throw: DC 17, each creature in a 5-foot-radius Sphere centered on that point. Failure: 24 (7d6) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition. Success: Half damage only.",
+        "damage_dice": "7d6"
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Leap",
+        "desc": "The ape jumps up to 30 feet by spending 10 feet of movement."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-badger": {
+    "name": "Giant Badger",
+    "slug": "giant-badger",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 15,
+    "hit_dice": "2d8 + 6",
+    "speed": {
+      "walk": 30,
+      "burrow": 10
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 3,
+    "damage_resistances": [
+      "Poison"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Piercing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-bat": {
+    "name": "Giant Bat",
+    "slug": "giant-bat",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 22,
+    "hit_dice": "4d10",
+    "speed": {
+      "walk": 10,
+      "fly": 60
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 120 ft.; Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-boar": {
+    "name": "Giant Boar",
+    "slug": "giant-boar",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 42,
+    "hit_dice": "5d10 + 15",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 17,
+    "strength_save": 5,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 7,
+    "wisdom_save": -2,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 8",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Bloodied Fury",
+        "desc": "The boar has Advantage on melee attack rolls while it is Bloodied."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Large or smaller creature and the boar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 7 (2d6) Piercing damage and has the Prone condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-centipede": {
+    "name": "Giant Centipede",
+    "slug": "giant-centipede",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 9,
+    "hit_dice": "2d6 + 2",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 5,
+    "strength_save": -3,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 7,
+    "wisdom_save": -2,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft.; Passive Perception 8",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage, and the target has the Poisoned condition until the start of the centipede’s next turn.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-constrictor-snake": {
+    "name": "Giant Constrictor Snake",
+    "slug": "giant-constrictor-snake",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 60,
+    "hit_dice": "8d12 + 8",
+    "speed": {
+      "walk": 30,
+      "swim": 30
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The snake makes one Bite attack and uses Constrict."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      },
+      {
+        "name": "Constrict",
+        "desc": "Strength Saving Throw: DC 14, one Large or smaller creature the snake can see within 10 feet. Failure: 13 (2d8 + 4) Bludgeoning damage, and the target has the Grappled condition (escape DC 14).",
+        "damage_dice": "2d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-crab": {
+    "name": "Giant Crab",
+    "slug": "giant-crab",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 13,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": 30,
+      "swim": 30
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 9,
+    "wisdom_save": -1,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft.; Passive Perception 9",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The crab can breathe air and water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 11) from one of two claws."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-crocodile": {
+    "name": "Giant Crocodile",
+    "slug": "giant-crocodile",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 85,
+    "hit_dice": "9d12 + 27",
+    "speed": {
+      "walk": 30,
+      "swim": 50
+    },
+    "strength": 21,
+    "strength_save": 5,
+    "dexterity": 9,
+    "dexterity_save": -1,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The crocodile can hold its breath for 1 hour."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The crocodile makes one Bite attack and one Tail attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +8, reach 5 ft. Hit: 21 (3d10 + 5) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 15). While Grappled, the target has the Restrained condition and can’t be targeted by the crocodile’s Tail.",
+        "damage_dice": "3d10",
+        "damage_bonus": 5
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +8, reach 10 ft. Hit: 18 (3d8 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "3d8",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-eagle": {
+    "name": "Giant Eagle",
+    "slug": "giant-eagle",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "neutral good",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 26,
+    "hit_dice": "4d10 + 4",
+    "speed": {
+      "walk": 10,
+      "fly": 80
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 8,
+    "intelligence_save": -1,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 10,
+    "charisma_save": 0,
+    "perception": 6,
+    "damage_resistances": [
+      "Necrotic",
+      "Radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 16",
+    "languages": "Celestial; understands Common and Primordial",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The eagle makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage plus 3 (1d6) Radiant damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-elk": {
+    "name": "Giant Elk",
+    "slug": "giant-elk",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "celestial",
+    "alignment": "neutral good",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 6,
+    "hit_points": 42,
+    "hit_dice": "5d12 + 10",
+    "speed": {
+      "walk": 60
+    },
+    "strength": 19,
+    "strength_save": 6,
+    "dexterity": 18,
+    "dexterity_save": 6,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 7,
+    "intelligence_save": -2,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 10,
+    "charisma_save": 0,
+    "perception": 4,
+    "damage_resistances": [
+      "Necrotic",
+      "Radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 90 ft.; Passive Perception 14",
+    "languages": "Celestial; understands Common, Elvish, and",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Bludgeoning damage plus 5 (2d4) Radiant damage. If the target is a Huge or smaller creature and the elk moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-fire-beetle": {
+    "name": "Giant Fire Beetle",
+    "slug": "giant-fire-beetle",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 4,
+    "hit_dice": "1d6 + 1",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 8,
+    "strength_save": -1,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 7,
+    "wisdom_save": -2,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [
+      "Fire"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft.; Passive Perception 8",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Illumination",
+        "desc": "The beetle sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 Fire damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-frog": {
+    "name": "Giant Frog",
+    "slug": "giant-frog",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 18,
+    "hit_dice": "4d8",
+    "speed": {
+      "walk": 30,
+      "swim": 30
+    },
+    "strength": 12,
+    "strength_save": 1,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 30 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The frog can breathe air and water."
+      },
+      {
+        "name": "Standing Leap",
+        "desc": "The frog’s Long Jump is up to 20 feet and its High Jump is up to 10 feet with or without a running start."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 11)."
+      },
+      {
+        "name": "Swallow",
+        "desc": "The frog swallows a Small or smaller target it is grappling. While swallowed, the target isn’t Grappled but has the Blinded and Restrained conditions, and it has Total Cover against attacks and other effects outside the frog. While swallowing the target, the frog can’t use Bite, and if the frog dies, the swallowed target is no longer Restrained and can escape from the corpse using 5 feet of movement, exiting with the Prone condition. At the end of the frog’s next turn, the swallowed target takes 5 (2d4) Acid damage. If that damage doesn’t kill it, the frog disgorges it, causing it to exit Prone.",
+        "damage_dice": "2d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-goat": {
+    "name": "Giant Goat",
+    "slug": "giant-goat",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d10 + 3",
+    "speed": {
+      "walk": 40,
+      "climb": 30
+    },
+    "strength": 17,
+    "strength_save": 5,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature and the goat moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-hyena": {
+    "name": "Giant Hyena",
+    "slug": "giant-hyena",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 45,
+    "hit_dice": "6d10 + 12",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Rampage (1/Day)",
+        "desc": "Immediately after dealing damage to a creature that was already Bloodied, the hyena can move up to half its Speed, and it makes one Bite attack."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-lizard": {
+    "name": "Giant Lizard",
+    "slug": "giant-lizard",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d10 + 3",
+    "speed": {
+      "walk": 40,
+      "climb": 40
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 12,
+    "dexterity_save": 3,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The lizard can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-octopus": {
+    "name": "Giant Octopus",
+    "slug": "giant-octopus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 45,
+    "hit_dice": "7d10 + 7",
+    "speed": {
+      "walk": 10,
+      "swim": 60
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 4,
+    "charisma_save": -3,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The octopus can breathe only underwater. It can hold its breath for 1 hour outside water."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Tentacles",
+        "desc": "Melee Attack Roll: +5, reach 10 ft. Hit: 10 (2d6 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 13) from all eight tentacles. While Grappled, the target has the Restrained condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Ink Cloud (1/Day)",
+        "desc": "Trigger: The octopus takes damage while underwater. Response: The octopus releases ink that fills a 10-foot Cube centered on itself, and the octopus moves up to its Swim Speed. The Cube is Heavily Obscured for 1 minute or until a strong current or similar effect disperses the ink."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "giant-owl": {
+    "name": "Giant Owl",
+    "slug": "giant-owl",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "celestial",
+    "alignment": "neutral",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 19,
+    "hit_dice": "3d10 + 3",
+    "speed": {
+      "walk": 5,
+      "fly": 60
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 10,
+    "intelligence_save": 0,
+    "wisdom": 14,
+    "wisdom_save": 4,
+    "charisma": 10,
+    "charisma_save": 0,
+    "perception": 6,
+    "damage_resistances": [
+      "Necrotic",
+      "Radiant"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 16",
+    "languages": "Celestial; understands Common, Elvish, and",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The owl doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Talons",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage.",
+        "damage_dice": "1d10",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Spellcasting",
+        "desc": "The owl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability:"
+      },
+      {
+        "name": "At Will",
+        "desc": "Detect Evil and Good, Detect Magic"
+      },
+      {
+        "name": "1/Day",
+        "desc": "Clairvoyance"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-rat": {
+    "name": "Giant Rat",
+    "slug": "giant-rat",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 7,
+    "hit_dice": "2d6",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 7,
+    "strength_save": -2,
+    "dexterity": 16,
+    "dexterity_save": 5,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 4,
+    "charisma_save": -3,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The rat has Advantage on an attack roll against a creature if at least one of the rat’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 feet. Hit: 5 (1d4 + 3) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-scorpion": {
+    "name": "Giant Scorpion",
+    "slug": "giant-scorpion",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 15,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 52,
+    "hit_dice": "7d10 + 14",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 9,
+    "wisdom_save": -1,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft.; Passive Perception 9",
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The scorpion makes two Claw attacks and one Sting attack."
+      },
+      {
+        "name": "Claw",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13) from one of two claws."
+      },
+      {
+        "name": "Sting",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 11 (2d10) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-seahorse": {
+    "name": "Giant Seahorse",
+    "slug": "giant-seahorse",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 16,
+    "hit_dice": "3d10",
+    "speed": {
+      "walk": 5,
+      "swim": 40
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The seahorse can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Bludgeoning damage, or 11 (2d8 + 2) Bludgeoning damage if the seahorse moved 20+ feet straight toward the target immediately before the hit.",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Bubble Dash",
+        "desc": "While underwater, the seahorse moves up to half its Swim Speed without provoking Opportunity Attacks."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-shark": {
+    "name": "Giant Shark",
+    "slug": "giant-shark",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 92,
+    "hit_dice": "8d12 + 40",
+    "speed": {
+      "walk": 5,
+      "swim": 60
+    },
+    "strength": 23,
+    "strength_save": 6,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 21,
+    "constitution_save": 5,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The shark can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The shark makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +9 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 22 (3d10 + 6) Piercing damage.",
+        "damage_dice": "3d10",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-spider": {
+    "name": "Giant Spider",
+    "slug": "giant-spider",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 26,
+    "hit_dice": "4d10 + 4",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 4,
+    "charisma_save": -3,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Web Walker",
+        "desc": "The spider ignores movement restrictions caused by webs, and it knows the location of any other creature in contact with the same web."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Web (Recharge 5–6)",
+        "desc": "Dexterity Saving Throw: DC 13, one creature the spider can see within 60 feet. Failure: The target has the Restrained condition until the web is destroyed (AC 10; HP 5; Vulnerability to Fire damage; Immunity to Poison and Psychic damage)."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-toad": {
+    "name": "Giant Toad",
+    "slug": "giant-toad",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 39,
+    "hit_dice": "6d10 + 6",
+    "speed": {
+      "walk": 30,
+      "swim": 30
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Amphibious",
+        "desc": "The toad can breathe air and water."
+      },
+      {
+        "name": "Standing Leap",
+        "desc": "The toad’s Long Jump is up to 20 feet and its High Jump is up to 10 feet with or without a running start."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 5 (2d4) Poison damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 12).",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Swallow",
+        "desc": "The toad swallows a Medium or smaller target it is grappling. While swallowed, the target isn’t Grappled but has the Blinded and Restrained conditions, and it has Total Cover against attacks and other effects outside the toad. In addition, the target takes 10 (3d6) Acid damage at the end of each of the toad’s turns. The toad can have only one target swallowed at a time, and it can’t use Bite while it has a swallowed target. If the toad dies, a swallowed creature is no longer Restrained and can escape from the corpse using 5 feet of movement, exiting with the Prone condition.",
+        "damage_dice": "3d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-venomous-snake": {
+    "name": "Giant Venomous Snake",
+    "slug": "giant-venomous-snake",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 40,
+      "swim": 40
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 18,
+    "dexterity_save": 4,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 6 (1d4 + 4) Piercing damage plus 4 (1d8) Poison damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-vulture": {
+    "name": "Giant Vulture",
+    "slug": "giant-vulture",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "monstrosity",
+    "alignment": "neutral evil",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 25,
+    "hit_dice": "3d10 + 9",
+    "speed": {
+      "walk": 10,
+      "fly": 60
+    },
+    "strength": 15,
+    "strength_save": 2,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 6,
+    "intelligence_save": -2,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 3,
+    "damage_resistances": [
+      "Necrotic"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "Understands Common but can’t speak",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The vulture has Advantage on an attack roll against a creature if at least one of the vulture’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Gouge",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Piercing damage, and the target has the Poisoned condition until the end of its next turn.",
+        "damage_dice": "2d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-wasp": {
+    "name": "Giant Wasp",
+    "slug": "giant-wasp",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "5d8",
+    "speed": {
+      "walk": 10,
+      "fly": 50
+    },
+    "strength": 10,
+    "strength_save": 0,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The wasp doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Sting",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 5 (2d4) Poison damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-weasel": {
+    "name": "Giant Weasel",
+    "slug": "giant-weasel",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 9,
+    "hit_dice": "2d8",
+    "speed": {
+      "walk": 40,
+      "climb": 30
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 17,
+    "dexterity_save": 3,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 4,
+    "intelligence_save": -3,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "giant-wolf-spider": {
+    "name": "Giant Wolf Spider",
+    "slug": "giant-wolf-spider",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 40,
+      "climb": 40
+    },
+    "strength": 12,
+    "strength_save": 1,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 4,
+    "charisma_save": -3,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft., Darkvision 60 ft.;",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage plus 5 (2d4) Poison damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "goat": {
+    "name": "Goat",
+    "slug": "goat",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 4,
+    "hit_dice": "1d8",
+    "speed": {
+      "walk": 40,
+      "climb": 30
+    },
+    "strength": 11,
+    "strength_save": 2,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Ram",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Bludgeoning damage, or 2 (1d4) Bludgeoning damage if the goat moved 20+ feet straight toward the target immediately before the hit.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hawk": {
+    "name": "Hawk",
+    "slug": "hawk",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 1,
+    "hit_dice": "1d4 − 1",
+    "speed": {
+      "walk": 10,
+      "fly": 60
+    },
+    "strength": 5,
+    "strength_save": -3,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 8,
+    "constitution_save": -1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 6,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 16",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Talons",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 1 Slashing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hippopotamus": {
+    "name": "Hippopotamus",
+    "slug": "hippopotamus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": -2,
+    "hit_points": 82,
+    "hit_dice": "11d10 + 22",
+    "speed": {
+      "walk": 30,
+      "swim": 30
+    },
+    "strength": 21,
+    "strength_save": 7,
+    "dexterity": 7,
+    "dexterity_save": -2,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 4,
+    "charisma_save": -3,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "4",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The hippopotamus can hold its breath for 10 minutes."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The hippopotamus makes two Bite attacks."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 16 (2d10 + 5) Piercing damage.",
+        "damage_dice": "2d10",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hunter-shark": {
+    "name": "Hunter Shark",
+    "slug": "hunter-shark",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 45,
+    "hit_dice": "6d10 + 12",
+    "speed": {
+      "walk": 5,
+      "swim": 40
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 4,
+    "charisma_save": -3,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The shark can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 14 (3d6 + 4) Piercing damage.",
+        "damage_dice": "3d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "hyena": {
+    "name": "Hyena",
+    "slug": "hyena",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 5,
+    "hit_dice": "1d8 + 1",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 11,
+    "strength_save": 0,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The hyena has Advantage on an attack roll against a creature if at least one of the hyena’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 3 (1d6) Piercing damage.",
+        "damage_dice": "1d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "jackal": {
+    "name": "Jackal",
+    "slug": "jackal",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Small",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 3,
+    "hit_dice": "1d6",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 8,
+    "strength_save": -1,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 90 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 (1d4 – 1) Piercing damage.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "killer-whale": {
+    "name": "Killer Whale",
+    "slug": "killer-whale",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 90,
+    "hit_dice": "12d12 + 12",
+    "speed": {
+      "walk": 5,
+      "swim": 60
+    },
+    "strength": 19,
+    "strength_save": 4,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 120 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "3",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The whale can hold its breath for 30 minutes."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 21 (5d6 + 4) Piercing damage.",
+        "damage_dice": "5d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "lion": {
+    "name": "Lion",
+    "slug": "lion",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "4d10",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The lion has Advantage on an attack roll against a creature if at least one of the lion’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      },
+      {
+        "name": "Running Leap",
+        "desc": "With a 10-foot running start, the lion can Long Jump up to 25 feet."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The lion makes two Rend attacks. It can replace one attack with a use of Roar."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      },
+      {
+        "name": "Roar",
+        "desc": "Wisdom Saving Throw: DC 11, one creature within 15 feet. Failure: The target has the Frightened condition until the start of the lion’s next turn."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "lizard": {
+    "name": "Lizard",
+    "slug": "lizard",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 2,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": 20,
+      "climb": 20
+    },
+    "strength": 2,
+    "strength_save": -4,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 30 ft.; Passive Perception 9",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The lizard can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "mammoth": {
+    "name": "Mammoth",
+    "slug": "mammoth",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 126,
+    "hit_dice": "11d12 + 55",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 24,
+    "strength_save": 10,
+    "dexterity": 9,
+    "dexterity_save": -1,
+    "constitution": 21,
+    "constitution_save": 8,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "6",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The mammoth makes two Gore attacks."
+      },
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 18 (2d10 + 7) Piercing damage. If the target is a Huge or smaller creature and the mammoth moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition.",
+        "damage_dice": "2d10",
+        "damage_bonus": 7
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Trample",
+        "desc": "Dexterity Saving Throw: DC 18, one creature within 5 feet that has the Prone condition. Failure: 29 (4d10 + 7) Bludgeoning damage. Success: Half damage."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "mastiff": {
+    "name": "Mastiff",
+    "slug": "mastiff",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 5,
+    "hit_dice": "1d8 + 1",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 3,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "mule": {
+    "name": "Mule",
+    "slug": "mule",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 14,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [
+      {
+        "name": "Compression",
+        "desc": "The octopus can move through a space as narrow as 1 inch without expending extra movement to do so."
+      },
+      {
+        "name": "Water Breathing",
+        "desc": "The octopus can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Tentacles",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Bludgeoning damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": [
+      {
+        "name": "Ink Cloud (1/Day)",
+        "desc": "Trigger: A creature ends its turn within 5 feet of the octopus while underwater. Response: The octopus releases ink that fills a 5-foot Cube centered on itself, and the octopus moves up to its Swim Speed. The Cube is Heavily Obscured for 1 minute or until a strong current or similar effect disperses the ink."
+      }
+    ],
+    "legendary_actions": []
+  },
+  "owl": {
+    "name": "Owl",
+    "slug": "owl",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 1,
+    "hit_dice": "1d4 − 1",
+    "speed": {
+      "walk": 5,
+      "fly": 60
+    },
+    "strength": 3,
+    "strength_save": -4,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 8,
+    "constitution_save": -1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 120 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The owl doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Talons",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 1 Slashing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "panther": {
+    "name": "Panther",
+    "slug": "panther",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 13,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": 50,
+      "climb": 40
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 14,
+    "wisdom_save": 2,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 14",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage.",
+        "damage_dice": "1d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The panther takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "piranha": {
+    "name": "Piranha",
+    "slug": "piranha",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 1,
+    "hit_dice": "1d4 − 1",
+    "speed": {
+      "walk": 5,
+      "swim": 40
+    },
+    "strength": 2,
+    "strength_save": -4,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 9,
+    "constitution_save": -1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 7,
+    "wisdom_save": -2,
+    "charisma": 2,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 8",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The piranha can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "plesiosaurus": {
+    "name": "Plesiosaurus",
+    "slug": "plesiosaurus",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 68,
+    "hit_dice": "8d10 + 24",
+    "speed": {
+      "walk": 20,
+      "swim": 40
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Hold Breath",
+        "desc": "The plesiosaurus can hold its breath for 1 hour."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "polar-bear": {
+    "name": "Polar Bear",
+    "slug": "polar-bear",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 42,
+    "hit_dice": "5d10 + 15",
+    "speed": {
+      "walk": 40,
+      "swim": 40
+    },
+    "strength": 20,
+    "strength_save": 5,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 16,
+    "constitution_save": 3,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 7,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [
+      "Cold"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The bear makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 9 (1d8 + 5) Slashing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "pony": {
+    "name": "Pony",
+    "slug": "pony",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 15,
+    "strength_save": 4,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Bludgeoning damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "pteranodon": {
+    "name": "Pteranodon",
+    "slug": "pteranodon",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 13,
+    "hit_dice": "3d8",
+    "speed": {
+      "walk": 10,
+      "fly": 60
+    },
+    "strength": 12,
+    "strength_save": 1,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 9,
+    "wisdom_save": -1,
+    "charisma": 5,
+    "charisma_save": -3,
+    "perception": 1,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Flyby",
+        "desc": "The pteranodon doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "rat": {
+    "name": "Rat",
+    "slug": "rat",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 1,
+    "hit_dice": "1d4 − 1",
+    "speed": {
+      "walk": 20,
+      "climb": 20
+    },
+    "strength": 2,
+    "strength_save": -4,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 9,
+    "constitution_save": -1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 4,
+    "charisma_save": -3,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 30 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Agile",
+        "desc": "The rat doesn’t provoke an Opportunity Attack when it moves out of an enemy’s reach."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "raven": {
+    "name": "Raven",
+    "slug": "raven",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 2,
+    "hit_dice": "1d4",
+    "speed": {
+      "walk": 10,
+      "fly": 50
+    },
+    "strength": 2,
+    "strength_save": -4,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 13,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Mimicry",
+        "desc": "The raven can mimic simple sounds it has heard, such as a whisper or chitter. A hearer can discern the sounds are imitations with a successful DC 10 Wisdom (Insight) check."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "reef-shark": {
+    "name": "Reef Shark",
+    "slug": "reef-shark",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 22,
+    "hit_dice": "4d8 + 4",
+    "speed": {
+      "walk": 5,
+      "swim": 30
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 4,
+    "charisma_save": -3,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft.; Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The shark has Advantage on an attack roll against a creature if at least one of the shark’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      },
+      {
+        "name": "Water Breathing",
+        "desc": "The shark can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Piercing damage.",
+        "damage_dice": "2d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "rhinoceros": {
+    "name": "Rhinoceros",
+    "slug": "rhinoceros",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 45,
+    "hit_dice": "6d10 + 12",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 21,
+    "strength_save": 5,
+    "dexterity": 8,
+    "dexterity_save": -1,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +7, reach 5 ft. Hit: 14 (2d8 + 5) Piercing damage. If target is a Large or smaller creature and the rhinoceros moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition.",
+        "damage_dice": "2d8",
+        "damage_bonus": 5
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "riding-horse": {
+    "name": "Riding Horse",
+    "slug": "riding-horse",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 13,
+    "hit_dice": "2d10 + 2",
+    "speed": {
+      "walk": 60
+    },
+    "strength": 16,
+    "strength_save": 3,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "saber-toothed-tiger": {
+    "name": "Saber-Toothed Tiger",
+    "slug": "saber-toothed-tiger",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 52,
+    "hit_dice": "7d10 + 14",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 18,
+    "strength_save": 6,
+    "dexterity": 17,
+    "dexterity_save": 5,
+    "constitution": 15,
+    "constitution_save": 2,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Running Leap",
+        "desc": "With a 10-foot running start, the tiger can Long Jump up to 25 feet."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The tiger makes two Rend attacks."
+      },
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Slashing damage.",
+        "damage_dice": "2d6",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The tiger takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "scorpion": {
+    "name": "Scorpion",
+    "slug": "scorpion",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 1,
+    "hit_dice": "1d4 − 1",
+    "speed": {
+      "walk": 10
+    },
+    "strength": 2,
+    "strength_save": -4,
+    "dexterity": 11,
+    "dexterity_save": 0,
+    "constitution": 8,
+    "constitution_save": -1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 8,
+    "wisdom_save": -1,
+    "charisma": 2,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft.; Passive Perception 9",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Sting",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage plus 3 (1d6) Poison damage.",
+        "damage_dice": "1d6"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "seahorse": {
+    "name": "Seahorse",
+    "slug": "seahorse",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 1,
+    "hit_dice": "1d4 − 1",
+    "speed": {
+      "walk": 5,
+      "swim": 20
+    },
+    "strength": 1,
+    "strength_save": -5,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 8,
+    "constitution_save": -1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 2,
+    "charisma_save": -4,
+    "perception": 2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 12",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Water Breathing",
+        "desc": "The seahorse can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bubble Dash",
+        "desc": "While underwater, the seahorse moves up to its Swim Speed without provoking Opportunity Attacks."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "spider": {
+    "name": "Spider",
+    "slug": "spider",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 1,
+    "hit_dice": "1d4 − 1",
+    "speed": {
+      "walk": 20,
+      "climb": 20
+    },
+    "strength": 2,
+    "strength_save": -4,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 8,
+    "constitution_save": -1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 2,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 30 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Web Walker",
+        "desc": "The spider ignores movement restrictions caused by webs, and the spider knows the location of any other creature in contact with the same web."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage plus 2 (1d4) Poison damage.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "swarm-of-bats": {
+    "name": "Swarm of Bats",
+    "slug": "swarm-of-bats",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 11,
+    "hit_dice": "2d10",
+    "speed": {
+      "walk": 5,
+      "fly": 30
+    },
+    "strength": 5,
+    "strength_save": -3,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 10,
+    "constitution_save": 0,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 4,
+    "charisma_save": -3,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed",
+      "Frightened",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Prone",
+      "Restrained",
+      "Stunned"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 60 ft.; Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny bat. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bites",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (2d4) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied.",
+        "damage_dice": "2d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "swarm-of-insects": {
+    "name": "Swarm of Insects",
+    "slug": "swarm-of-insects",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d8 + 6",
+    "speed": {
+      "walk": 20
+    },
+    "strength": 3,
+    "strength_save": -4,
+    "dexterity": 13,
+    "dexterity_save": 1,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 7,
+    "wisdom_save": -2,
+    "charisma": 1,
+    "charisma_save": -5,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed",
+      "Frightened",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Prone",
+      "Restrained",
+      "Stunned"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 30 ft.; Passive Perception 8",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [
+      {
+        "name": "Spider Climb",
+        "desc": "If the swarm has a Climb Speed, the swarm can climb difficult surfaces, including along ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bites",
+        "desc": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Poison damage, or 3 (1d4 + 1) Poison damage if the swarm is Bloodied.",
+        "damage_dice": "2d4",
+        "damage_bonus": 1
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "swarm-of-piranhas": {
+    "name": "Swarm of Piranhas",
+    "slug": "swarm-of-piranhas",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 28,
+    "hit_dice": "8d8 − 8",
+    "speed": {
+      "walk": 5,
+      "swim": 40
+    },
+    "strength": 13,
+    "strength_save": 1,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 9,
+    "constitution_save": -1,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 7,
+    "wisdom_save": -2,
+    "charisma": 2,
+    "charisma_save": -4,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed",
+      "Frightened",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Prone",
+      "Restrained",
+      "Stunned"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 8",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny piranha. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      },
+      {
+        "name": "Water Breathing",
+        "desc": "The swarm can breathe only underwater."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bites",
+        "desc": "Melee Attack Roll: +5 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 8 (2d4 + 3) Piercing damage, or 5 (1d4 + 3) Piercing damage if the swarm is Bloodied.",
+        "damage_dice": "2d4",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "swarm-of-rats": {
+    "name": "Swarm of Rats",
+    "slug": "swarm-of-rats",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 14,
+    "hit_dice": "4d8 − 4",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 9,
+    "strength_save": -1,
+    "dexterity": 11,
+    "dexterity_save": 2,
+    "constitution": 9,
+    "constitution_save": -1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed",
+      "Frightened",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Prone",
+      "Restrained",
+      "Stunned"
+    ],
+    "condition_immunities": [],
+    "senses": "Darkvision 30 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny rat. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bites",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 5 (2d4) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied.",
+        "damage_dice": "2d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "swarm-of-ravens": {
+    "name": "Swarm of Ravens",
+    "slug": "swarm-of-ravens",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 10,
+      "fly": 50
+    },
+    "strength": 6,
+    "strength_save": -2,
+    "dexterity": 14,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 5,
+    "intelligence_save": -3,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed",
+      "Frightened",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Prone",
+      "Restrained",
+      "Stunned"
+    ],
+    "condition_immunities": [],
+    "senses": "Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny raven. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Beaks",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied.",
+        "damage_dice": "1d6",
+        "damage_bonus": 2
+      },
+      {
+        "name": "Cacophony (Recharge 6)",
+        "desc": "Wisdom Saving Throw: DC 10, one creature in the swarm’s space. Failure: The target has the Deafened condition until the start of the swarm’s next turn. While Deafened, the target also has Disadvantage on ability checks and attack rolls."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "swarm-of-venomous-snakes": {
+    "name": "Swarm of Venomous Snakes",
+    "slug": "swarm-of-venomous-snakes",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "swarm of tiny beasts",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": 4,
+    "hit_points": 36,
+    "hit_dice": "8d8",
+    "speed": {
+      "walk": 30,
+      "swim": 30
+    },
+    "strength": 8,
+    "strength_save": -1,
+    "dexterity": 18,
+    "dexterity_save": 4,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [
+      "Bludgeoning",
+      "Piercing",
+      "Slashing"
+    ],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [
+      "Charmed",
+      "Frightened",
+      "Grappled",
+      "Paralyzed",
+      "Petrified",
+      "Prone",
+      "Restrained",
+      "Stunned"
+    ],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "2",
+    "special_abilities": [
+      {
+        "name": "Swarm",
+        "desc": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny snake. The swarm can’t regain Hit Points or gain Temporary Hit Points."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bites",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Piercing damage—or 6 (1d4 + 4) Piercing damage if the swarm is Bloodied—plus 10 (3d6) Poison damage.",
+        "damage_dice": "1d8",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "tiger": {
+    "name": "Tiger",
+    "slug": "tiger",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 30,
+    "hit_dice": "4d10 + 8",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 17,
+    "strength_save": 3,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 14,
+    "constitution_save": 2,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 8,
+    "charisma_save": -1,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "1",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Rend",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+        "damage_dice": "2d6",
+        "damage_bonus": 3
+      }
+    ],
+    "bonus_actions": [
+      {
+        "name": "Nimble Escape",
+        "desc": "The tiger takes the Disengage or Hide action."
+      }
+    ],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "triceratops": {
+    "name": "Triceratops",
+    "slug": "triceratops",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 14,
+    "armor_desc": "",
+    "initiative": -1,
+    "hit_points": 114,
+    "hit_dice": "12d12 + 36",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 22,
+    "strength_save": 6,
+    "dexterity": 9,
+    "dexterity_save": -1,
+    "constitution": 17,
+    "constitution_save": 3,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 11,
+    "wisdom_save": 0,
+    "charisma": 5,
+    "charisma_save": -3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "5",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The triceratops makes two Gore attacks."
+      },
+      {
+        "name": "Gore",
+        "desc": "Melee Attack Roll: +9, reach 5 ft. Hit: 19 (2d12 + 6) Piercing damage. If the target is Huge or smaller and the triceratops moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition.",
+        "damage_dice": "2d12",
+        "damage_bonus": 6
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "tyrannosaurus-rex": {
+    "name": "Tyrannosaurus Rex",
+    "slug": "tyrannosaurus-rex",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Huge",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 136,
+    "hit_dice": "13d12 + 52",
+    "speed": {
+      "walk": 50
+    },
+    "strength": 25,
+    "strength_save": 10,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 19,
+    "constitution_save": 4,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 4,
+    "charisma": 9,
+    "charisma_save": -1,
+    "perception": 4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 14",
+    "languages": "None",
+    "challenge_rating": "8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Multiattack",
+        "desc": "The tyrannosaurus makes one Bite attack and one Tail attack."
+      },
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +10, reach 10 ft. Hit: 33 (4d12 + 7) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 17). While Grappled, the target has the Restrained condition and can’t be targeted by the tyrannosaurus’s Tail.",
+        "damage_dice": "4d12",
+        "damage_bonus": 7
+      },
+      {
+        "name": "Tail",
+        "desc": "Melee Attack Roll: +10, reach 15 ft. Hit: 25 (4d8 + 7) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition.",
+        "damage_dice": "4d8",
+        "damage_bonus": 7
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "venomous-snake": {
+    "name": "Venomous Snake",
+    "slug": "venomous-snake",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 5,
+    "hit_dice": "2d4",
+    "speed": {
+      "walk": 30,
+      "swim": 30
+    },
+    "strength": 2,
+    "strength_save": -4,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 11,
+    "constitution_save": 0,
+    "intelligence": 1,
+    "intelligence_save": -5,
+    "wisdom": 10,
+    "wisdom_save": 0,
+    "charisma": 3,
+    "charisma_save": -4,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Blindsight 10 ft.; Passive Perception 10",
+    "languages": "None",
+    "challenge_rating": "1/8",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage plus 3 (1d6) Poison damage.",
+        "damage_dice": "1d4",
+        "damage_bonus": 2
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "vulture": {
+    "name": "Vulture",
+    "slug": "vulture",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 10,
+    "armor_desc": "",
+    "initiative": 0,
+    "hit_points": 5,
+    "hit_dice": "1d8 + 1",
+    "speed": {
+      "walk": 10,
+      "fly": 50
+    },
+    "strength": 7,
+    "strength_save": -2,
+    "dexterity": 10,
+    "dexterity_save": 0,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 4,
+    "charisma_save": -3,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The vulture has Advantage on an attack roll against a creature if at least one of the vulture’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Beak",
+        "desc": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Piercing damage.",
+        "damage_dice": "1d4"
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "warhorse": {
+    "name": "Warhorse",
+    "slug": "warhorse",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Large",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 11,
+    "armor_desc": "",
+    "initiative": 1,
+    "hit_points": 19,
+    "hit_dice": "3d10 + 3",
+    "speed": {
+      "walk": 60
+    },
+    "strength": 18,
+    "strength_save": 4,
+    "dexterity": 12,
+    "dexterity_save": 1,
+    "constitution": 13,
+    "constitution_save": 1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 3,
+    "charisma": 7,
+    "charisma_save": -2,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Passive Perception 11",
+    "languages": "None",
+    "challenge_rating": "1/2",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Hooves",
+        "desc": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Bludgeoning damage. If the target is a Large or smaller creature and the horse moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition.",
+        "damage_dice": "2d4",
+        "damage_bonus": 4
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "weasel": {
+    "name": "Weasel",
+    "slug": "weasel",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Tiny",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 13,
+    "armor_desc": "",
+    "initiative": 3,
+    "hit_points": 1,
+    "hit_dice": "1d4 − 1",
+    "speed": {
+      "walk": 30,
+      "climb": 30
+    },
+    "strength": 3,
+    "strength_save": -4,
+    "dexterity": 16,
+    "dexterity_save": 3,
+    "constitution": 8,
+    "constitution_save": -1,
+    "intelligence": 2,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 3,
+    "charisma_save": -4,
+    "perception": 3,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 13",
+    "languages": "None",
+    "challenge_rating": "0",
+    "special_abilities": [],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +5, reach 5 ft. Hit: 1 Piercing damage."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  },
+  "wolf": {
+    "name": "Wolf",
+    "slug": "wolf",
+    "group": null,
+    "document_slug": "systems-reference-document",
+    "size": "Medium",
+    "type": "beast",
+    "alignment": "unaligned",
+    "armor_class": 12,
+    "armor_desc": "",
+    "initiative": 2,
+    "hit_points": 11,
+    "hit_dice": "2d8 + 2",
+    "speed": {
+      "walk": 40
+    },
+    "strength": 14,
+    "strength_save": 2,
+    "dexterity": 15,
+    "dexterity_save": 2,
+    "constitution": 12,
+    "constitution_save": 1,
+    "intelligence": 3,
+    "intelligence_save": -4,
+    "wisdom": 12,
+    "wisdom_save": 1,
+    "charisma": 6,
+    "charisma_save": -2,
+    "perception": 5,
+    "damage_resistances": [],
+    "damage_vulnerabilities": [],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": "Darkvision 60 ft.; Passive Perception 15",
+    "languages": "None",
+    "challenge_rating": "1/4",
+    "special_abilities": [
+      {
+        "name": "Pack Tactics",
+        "desc": "The wolf has Advantage on attack rolls against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition."
+      }
+    ],
+    "bonus_actions": [],
+    "reactions": "",
+    "legendary_actions": []
+  }
+}

--- a/src/2024/en/processMonsterData.js
+++ b/src/2024/en/processMonsterData.js
@@ -3,12 +3,14 @@ import { resourceLimits } from 'worker_threads';
 
 const monsters = JSON.parse(fs.readFileSync('./monsters.json', 'utf-8'));
 
+const monstersOld = JSON.parse(fs.readFileSync('../../2014/en/5e-SRD-Monsters.json', 'utf-8'));
+
 const monstersNew = Object.keys(monsters).filter((monster)=>{return monster != '_info'}).map((monster)=>{
 	const result = { ...monsters[monster] };
 
 	result.index = result.slug;
 	result.url = `/api/2024/monsters/${result.slug}`;
-	result.image = `/api/images/monsters/${result.slug}.png`
+	result.image = monstersOld.filter((monster)=>{ return monster.index == result.slug; })[0]?.image || `/api/images/monsters/${result.slug}-NYI.png`;
 	delete result.slug;
 
 	delete result.document_slug;

--- a/src/2024/en/processMonsterData.js
+++ b/src/2024/en/processMonsterData.js
@@ -1,0 +1,87 @@
+import fs from 'fs'
+import { resourceLimits } from 'worker_threads';
+
+const monsters = JSON.parse(fs.readFileSync('./monsters.json', 'utf-8'));
+
+const monstersNew = Object.keys(monsters).filter((monster)=>{return monster != '_info'}).map((monster)=>{
+	const result = { ...monsters[monster] };
+
+	result.index = result.slug;
+	result.url = `/api/2024/monsters/${result.slug}`;
+	result.image = `/api/images/monsters/${result.slug}.png`
+	delete result.slug;
+
+	delete result.document_slug;
+	delete result.group;
+
+	result.hit_points_roll = result.hit_dice;
+	result.hit_dice = result.hit_dice.split(' ')[0];
+
+	Object.keys(result.speed).forEach((type)=>{
+		result.speed[type] = type != 'hover' ? `${result.speed[type]} ft.` : true;
+	})
+
+	const stats = ['strength', 'dexterity', 'constitution', 'intelligence', 'wisdom', 'charisma'];
+
+	result.proficiencies = [];
+
+	stats.forEach((stat)=>{
+		if(result[`${stat}_save`] != Math.floor((result[stat] - 10) / 2)){
+			result.proficiencies.push(
+				{
+					"value": result[`${stat}_save`],
+					"proficiency": {
+						"index": `saving-throw-${stat.slice(0, 3)}`,
+						"name": `Saving Throw: ${stat.slice(0, 3).toUpperCase()}`,
+						"url": `/api/2024/proficiencies/saving-throw-${stat.slice(0, 3)}`
+					}
+				}
+			);
+		}
+		delete result[`${stat}_save`];
+	});
+
+	const senses = result.senses.split(';');
+	
+	const senseMap = {
+		'darkvision': {
+			"name": "Darkvision",
+			"value": (s)=>{ return s.slice(11); }
+		},
+		'blindsight': {
+			"name": "Blindsight",
+			"value": (s)=>{ return s.slice(11); }
+		},
+		'tremorsense': {
+			"name": "Tremorsense",
+			"value": (s)=>{ return s.slice(13); }
+		},
+		'truesight': {
+			"name": "Truesight",
+			"value": (s)=>{ return s.slice(10); }
+		},
+		'passive_perception': {
+			"name": "Passive Perception",
+			"value": (s)=>{ return Number(s.slice(19)); }
+		}
+	};
+
+	result.old_senses = result.senses;
+	result.senses = {};
+	
+	senses.forEach((sense)=>{
+		Object.keys(senseMap).forEach((sense_name)=>{
+			if(sense.trim().startsWith(senseMap[sense_name].name)){ result.senses[sense_name] = senseMap[sense_name].value(sense); };
+		});
+	});
+
+	const lowerCaseArrays = [ 'damage_resistances', 'damage_vulnerabilities', 'damage_immunities', 'condition_immunities'];
+
+	lowerCaseArrays.forEach((array_name)=>{
+		result[array_name] = result[array_name].map((value)=>{ return value.toLowerCase(); });
+	});
+
+	return result;
+})
+
+fs.writeFileSync('./5e-SRD-Monsters-New.json', JSON.stringify(monstersNew, null, 2));

--- a/src/2024/en/processMonsterData.mjs
+++ b/src/2024/en/processMonsterData.mjs
@@ -28,7 +28,9 @@ const monstersNew = Object.keys(monsters).filter((monster)=>{return monster != '
 	result.proficiencies = [];
 
 	stats.forEach((stat)=>{
-		if(result[`${stat}_save`] != Math.floor((result[stat] - 10) / 2)){
+		const stat_mod = Math.floor((result[stat] - 10) / 2);
+		if(result[`${stat}_save`] != stat_mod){
+			result.proficiency_bonus = result[`${stat}_save`] - stat_mod;
 			result.proficiencies.push(
 				{
 					"value": result[`${stat}_save`],
@@ -40,6 +42,7 @@ const monstersNew = Object.keys(monsters).filter((monster)=>{return monster != '
 				}
 			);
 		}
+		if(!result.proficiency_bonus) result.proficiency_bonus = 0;
 		delete result[`${stat}_save`];
 	});
 
@@ -87,3 +90,5 @@ const monstersNew = Object.keys(monsters).filter((monster)=>{return monster != '
 })
 
 fs.writeFileSync('./5e-SRD-Monsters-New.json', JSON.stringify(monstersNew, null, 2));
+
+console.log('Monster data entries:', monstersNew.length);


### PR DESCRIPTION
## What does this do?

Adds the 2024 Monster data

## How was it tested?

It's not (yet).

## Is there a Github issue this is resolving?

NA

## Did you update the docs in the API? Please link an associated PR if applicable.

No

## Here's a fun image for your troubles

<img width="1285" height="822" alt="image" src="https://github.com/user-attachments/assets/0728a4a9-7cca-4eae-91a4-c586809d0c44" />

I created the Barovian Travel Planner, a tool to calculate the distances and travel times between various locations in *Curse of Strahd*'s tiny country of Barovia. Many DMs choose to increase the map scale, but for my campaign, I've stuck to the classic quarter mile per hex.

---

### Sept 13, 2026

Currently this PR includes monster data from [this gist](https://gist.github.com/krisimmig/f4b7d2a30cadd2d94107f5533ba9c85c), as the text extraction that I have used previously did not handle the monsters well.
The PR currently includes the function that I have created to reshape the gist data to the API format.

#### Known Issues

Gist data does not include the fields `skills`, `gear`, or `proficiency_bonus`. Proficiency Bonus can be calculated in a future update, but Skills and Gear will need to acquired from another source.